### PR TITLE
feat: add drag-and-drop speaker reordering and fix role enums

### DIFF
--- a/frontend/src/pages/Agenda/SessionCard/index.jsx
+++ b/frontend/src/pages/Agenda/SessionCard/index.jsx
@@ -4,8 +4,7 @@ import styles from './styles/index.module.css';
 import PropTypes from 'prop-types';
 import { IconBrandLinkedin, IconWorld } from '@tabler/icons-react';
 import { format } from 'date-fns';
-
-const ROLE_ORDER = ['HOST', 'KEYNOTE', 'SPEAKER', 'MODERATOR', 'PANELIST'];
+import { SPEAKER_SPEAKER_ROLE_ORDER } from '@/shared/constants/speakerRoles';
 
 export const SessionCard = ({
   title,
@@ -34,7 +33,7 @@ export const SessionCard = ({
     social_links: speaker.social_links,
   }));
 
-  const speakersByRole = ROLE_ORDER.reduce((acc, role) => {
+  const speakersByRole = SPEAKER_ROLE_ORDER.reduce((acc, role) => {
     const roleSpeakers = speakers.filter((s) => s.role === role);
     if (roleSpeakers.length > 0) {
       acc[role] = roleSpeakers;
@@ -201,7 +200,7 @@ SessionCard.propTypes = {
       speaker_name: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
       company_name: PropTypes.string,
-      role: PropTypes.oneOf(ROLE_ORDER),
+      role: PropTypes.oneOf(SPEAKER_ROLE_ORDER),
       image_url: PropTypes.string,
       social_links: PropTypes.shape({
         linkedin: PropTypes.string,

--- a/frontend/src/pages/Session/SessionSpeakers/index.jsx
+++ b/frontend/src/pages/Session/SessionSpeakers/index.jsx
@@ -1,10 +1,11 @@
 // pages/Session/SessionSpeakers/index.jsx
 import { Card, Group, Button, Text } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { 
   useGetSessionSpeakersQuery,
-  useRemoveSessionSpeakerMutation 
+  useRemoveSessionSpeakerMutation,
+  useReorderSessionSpeakerMutation 
 } from '@/app/features/sessions/api';
 import { AddSpeakerModal } from '@/shared/components/modals/session/AddSpeakerModal';
 import { SpeakerCard } from './SpeakerCard';
@@ -12,10 +13,15 @@ import styles from './styles/index.module.css';
 
 export const SessionSpeakers = ({ sessionId, canEdit }) => {
   const [showAddModal, setShowAddModal] = useState(false);
+  const [draggedSpeaker, setDraggedSpeaker] = useState(null);
+  const [dragOverIndex, setDragOverIndex] = useState(null);
+  const draggedOverRef = useRef(null);
+  
   const { data: speakersData, isLoading } = useGetSessionSpeakersQuery({
     sessionId,
   });
   const [removeSpeaker] = useRemoveSessionSpeakerMutation();
+  const [reorderSpeaker] = useReorderSessionSpeakerMutation();
 
   // The API returns paginated data with session_speakers array
   const speakers = Array.isArray(speakersData?.session_speakers)
@@ -27,6 +33,67 @@ export const SessionSpeakers = ({ sessionId, canEdit }) => {
       await removeSpeaker({ sessionId, userId }).unwrap();
     } catch (error) {
       console.error('Failed to remove speaker:', error);
+    }
+  };
+
+  const handleDragStart = (e, speaker, index) => {
+    if (!canEdit) return;
+    setDraggedSpeaker({ speaker, index });
+    e.dataTransfer.effectAllowed = 'move';
+    // Add a slight delay to allow the drag image to be captured
+    setTimeout(() => {
+      e.target.style.opacity = '0.5';
+    }, 0);
+  };
+
+  const handleDragEnd = (e) => {
+    e.target.style.opacity = '1';
+    setDraggedSpeaker(null);
+    setDragOverIndex(null);
+  };
+
+  const handleDragOver = (e, index) => {
+    e.preventDefault();
+    if (!canEdit || !draggedSpeaker) return;
+    
+    e.dataTransfer.dropEffect = 'move';
+    
+    // Only update if we're over a different index
+    if (dragOverIndex !== index) {
+      setDragOverIndex(index);
+      draggedOverRef.current = index;
+    }
+  };
+
+  const handleDragLeave = (e) => {
+    // Only clear if we're leaving the container entirely
+    if (e.currentTarget === e.target) {
+      setDragOverIndex(null);
+    }
+  };
+
+  const handleDrop = async (e, targetIndex) => {
+    e.preventDefault();
+    setDragOverIndex(null);
+    
+    if (!canEdit || !draggedSpeaker || draggedSpeaker.index === targetIndex) {
+      return;
+    }
+
+    const { speaker, index: sourceIndex } = draggedSpeaker;
+    
+    // Calculate the new order position (1-based)
+    const newOrder = targetIndex + 1;
+    
+    try {
+      // The API will return all speakers in their new order
+      await reorderSpeaker({
+        sessionId,
+        userId: speaker.user_id,
+        order: newOrder
+      }).unwrap();
+    } catch (error) {
+      console.error('Failed to reorder speaker:', error);
     }
   };
 
@@ -57,13 +124,36 @@ export const SessionSpeakers = ({ sessionId, canEdit }) => {
             No speakers assigned yet
           </Text>
         ) : (
-          speakers.map((speaker) => (
-            <SpeakerCard 
-              key={speaker.user_id} 
-              speaker={speaker} 
-              canEdit={canEdit}
-              onRemove={handleRemoveSpeaker}
-            />
+          speakers.map((speaker, index) => (
+            <div
+              key={speaker.user_id}
+              draggable={canEdit}
+              onDragStart={(e) => handleDragStart(e, speaker, index)}
+              onDragEnd={handleDragEnd}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDragLeave={handleDragLeave}
+              onDrop={(e) => handleDrop(e, index)}
+              className={`${styles.speakerWrapper} ${
+                dragOverIndex === index && draggedSpeaker?.index !== index
+                  ? styles.dragOver
+                  : ''
+              }`}
+              style={{
+                cursor: canEdit ? 'move' : 'default',
+                transition: 'transform 0.2s ease',
+                transform: dragOverIndex === index && draggedSpeaker?.index !== index
+                  ? draggedSpeaker.index < index
+                    ? 'translateY(-10px)'
+                    : 'translateY(10px)'
+                  : 'translateY(0)'
+              }}
+            >
+              <SpeakerCard 
+                speaker={speaker} 
+                canEdit={canEdit}
+                onRemove={handleRemoveSpeaker}
+              />
+            </div>
           ))
         )}
       </div>

--- a/frontend/src/pages/Session/SessionSpeakers/styles/index.module.css
+++ b/frontend/src/pages/Session/SessionSpeakers/styles/index.module.css
@@ -22,3 +22,44 @@
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: var(--mantine-spacing-sm);
 }
+
+.speakerWrapper {
+  position: relative;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.speakerWrapper[draggable="true"] {
+  cursor: move;
+}
+
+.speakerWrapper[draggable="true"]:hover {
+  transform: scale(1.02);
+}
+
+.dragOver {
+  position: relative;
+}
+
+.dragOver::before {
+  content: '';
+  position: absolute;
+  top: -4px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--mantine-color-blue-5);
+  border-radius: 2px;
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
+}

--- a/frontend/src/shared/components/modals/session/AddSpeakerModal/index.jsx
+++ b/frontend/src/shared/components/modals/session/AddSpeakerModal/index.jsx
@@ -8,6 +8,7 @@ import {
 } from '@/app/features/sessions/api';
 import { useGetEventUsersQuery } from '@/app/features/events/api';
 import { useMemo } from 'react';
+import { SPEAKER_ROLES, SPEAKER_ROLE_OPTIONS } from '@/shared/constants/speakerRoles';
 import styles from './styles/index.module.css';
 
 export const AddSpeakerModal = ({ sessionId, opened, onClose }) => {
@@ -25,7 +26,7 @@ export const AddSpeakerModal = ({ sessionId, opened, onClose }) => {
   const form = useForm({
     initialValues: {
       user_id: '',
-      role: 'SPEAKER',
+      role: SPEAKER_ROLES.SPEAKER,
     },
   });
 
@@ -95,13 +96,7 @@ export const AddSpeakerModal = ({ sessionId, opened, onClose }) => {
 
               <Select
                 label="Speaker Role"
-                data={[
-                  { value: 'SPEAKER', label: 'Speaker' },
-                  { value: 'PRIMARY', label: 'Primary Speaker' },
-                  { value: 'CO_SPEAKER', label: 'Co-Speaker' },
-                  { value: 'MODERATOR', label: 'Moderator' },
-                  { value: 'PANELIST', label: 'Panelist' },
-                ]}
+                data={SPEAKER_ROLE_OPTIONS}
                 {...form.getInputProps('role')}
                 disabled={isLoading}
               />

--- a/frontend/src/shared/constants/speakerRoles.js
+++ b/frontend/src/shared/constants/speakerRoles.js
@@ -1,0 +1,32 @@
+// Speaker role constants matching backend enums
+export const SPEAKER_ROLES = {
+  HOST: 'HOST',
+  SPEAKER: 'SPEAKER',
+  PANELIST: 'PANELIST',
+  MODERATOR: 'MODERATOR',
+  KEYNOTE: 'KEYNOTE',
+};
+
+// Role display options for select components
+export const SPEAKER_ROLE_OPTIONS = [
+  { value: SPEAKER_ROLES.SPEAKER, label: 'Speaker' },
+  { value: SPEAKER_ROLES.HOST, label: 'Host' },
+  { value: SPEAKER_ROLES.KEYNOTE, label: 'Keynote Speaker' },
+  { value: SPEAKER_ROLES.MODERATOR, label: 'Moderator' },
+  { value: SPEAKER_ROLES.PANELIST, label: 'Panelist' },
+];
+
+// Role display order for UI
+export const SPEAKER_ROLE_ORDER = [
+  SPEAKER_ROLES.HOST,
+  SPEAKER_ROLES.KEYNOTE,
+  SPEAKER_ROLES.SPEAKER,
+  SPEAKER_ROLES.MODERATOR,
+  SPEAKER_ROLES.PANELIST,
+];
+
+// Format role for display
+export const formatSpeakerRole = (role) => {
+  if (!role) return '';
+  return role.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+};


### PR DESCRIPTION
- Implement drag-and-drop functionality for reordering session speakers
- Only enabled for users with ADMIN/ORGANIZER roles
- Add visual feedback during drag operations (opacity, scale, drop indicator)
- Create centralized speaker role constants matching backend enums
- Remove invalid PRIMARY/CO_SPEAKER roles from frontend
- Add correct HOST/KEYNOTE roles to match backend
- Update AddSpeakerModal and SessionCard to use centralized constants