### PR TITLE
feat: implement user profile page with edit functionality

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@mantine/form": "^7.16.0",
         "@mantine/hooks": "^7.16.0",
         "@mantine/modals": "^7.16.0",
+        "@mantine/notifications": "^7.16.0",
         "@reduxjs/toolkit": "^2.5.0",
         "@tabler/icons-react": "^3.28.1",
         "@tanstack/react-query": "^5.64.1",
@@ -1582,6 +1583,31 @@
         "@mantine/hooks": "7.16.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/notifications": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-7.16.0.tgz",
+      "integrity": "sha512-ofwpMLoe/QaXTEqrLNA2vEq4KblacKHLg1xJn7a40irt6uQ6GSlFoLveKjOupiG0xUa+gIbevA1uv3tHJuJ6uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mantine/store": "7.16.0",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "7.16.0",
+        "@mantine/hooks": "7.16.0",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-7.16.0.tgz",
+      "integrity": "sha512-IeeKk8w+a5Z5sctMUYrLBVVA9173B2oKPP4Rh656eoXH+vz/KCpL/ITnFWrt0Cv9Fyv/V+zm1UyAnUWRdQ6uXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -4939,6 +4965,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7674,7 +7710,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8310,7 +8345,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8644,6 +8678,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readdirp": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@mantine/form": "^7.16.0",
     "@mantine/hooks": "^7.16.0",
     "@mantine/modals": "^7.16.0",
+    "@mantine/notifications": "^7.16.0",
     "@reduxjs/toolkit": "^2.5.0",
     "@tabler/icons-react": "^3.28.1",
     "@tanstack/react-query": "^5.64.1",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { MantineProvider } from '@mantine/core';
 import { ModalsProvider } from '@mantine/modals';
+import { Notifications } from '@mantine/notifications';
 import { Provider as ReduxProvider } from 'react-redux';
 import { RouterProvider } from 'react-router-dom';
 import { store } from './app/store';
@@ -9,11 +10,13 @@ import { router } from './app/router/routes';
 
 import '@mantine/core/styles.css';
 import '@mantine/carousel/styles.css';
+import '@mantine/notifications/styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ReduxProvider store={store}>
       <MantineProvider>
+        <Notifications position="bottom-left" />
         <ModalsProvider>
           <RouterProvider router={router} />
         </ModalsProvider>

--- a/frontend/src/pages/Profile/index.jsx
+++ b/frontend/src/pages/Profile/index.jsx
@@ -1,1 +1,398 @@
-export { default } from '@/pages/Roadmap';
+import { useState, useEffect } from 'react';
+import {
+  Container,
+  Stack,
+  Title,
+  Paper,
+  Group,
+  Button,
+  Text,
+  Avatar,
+  TextInput,
+  Textarea,
+  LoadingOverlay,
+  Alert,
+} from '@mantine/core';
+import { IconEdit, IconCheck, IconX } from '@tabler/icons-react';
+import { useSelector } from 'react-redux';
+import { useGetUserQuery, useUpdateUserMutation } from '@/app/features/users/api';
+import { useForm, zodResolver } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { profileSchema } from './schemas/profileSchema';
+import styles from './styles/index.module.css';
+
+export const ProfilePage = () => {
+  const currentUser = useSelector((state) => state.auth.user);
+  const [isEditing, setIsEditing] = useState(false);
+  
+  const { data: userProfile, isLoading, error } = useGetUserQuery(currentUser?.id, {
+    skip: !currentUser?.id,
+  });
+  
+  const [updateUser, { isLoading: isUpdating }] = useUpdateUserMutation();
+  
+  const form = useForm({
+    initialValues: {
+      first_name: '',
+      last_name: '',
+      company_name: '',
+      title: '',
+      bio: '',
+      social_links: {
+        linkedin: '',
+        twitter: '',
+        website: '',
+      },
+    },
+    validate: zodResolver(profileSchema),
+  });
+  
+  // Update form when user data loads
+  useEffect(() => {
+    if (userProfile) {
+      form.setValues({
+        first_name: userProfile.first_name || '',
+        last_name: userProfile.last_name || '',
+        company_name: userProfile.company_name || '',
+        title: userProfile.title || '',
+        bio: userProfile.bio || '',
+        social_links: {
+          linkedin: userProfile.social_links?.linkedin || '',
+          twitter: userProfile.social_links?.twitter || '',
+          website: userProfile.social_links?.website || '',
+        },
+      });
+    }
+  }, [userProfile]);
+  
+  const handleSave = async (values) => {
+    try {
+      await updateUser({
+        id: currentUser.id,
+        ...values,
+      }).unwrap();
+      notifications.show({
+        title: 'Success',
+        message: 'Profile updated successfully',
+        color: 'green',
+      });
+      setIsEditing(false);
+    } catch (error) {
+      notifications.show({
+        title: 'Error',
+        message: error.data?.message || 'Failed to update profile',
+        color: 'red',
+      });
+    }
+  };
+  
+  const handleCancel = () => {
+    // Reset form to current user values
+    if (userProfile) {
+      form.setValues({
+        first_name: userProfile.first_name || '',
+        last_name: userProfile.last_name || '',
+        company_name: userProfile.company_name || '',
+        title: userProfile.title || '',
+        bio: userProfile.bio || '',
+        social_links: {
+          linkedin: userProfile.social_links?.linkedin || '',
+          twitter: userProfile.social_links?.twitter || '',
+          website: userProfile.social_links?.website || '',
+        },
+      });
+    }
+    setIsEditing(false);
+  };
+  
+  if (isLoading) {
+    return <LoadingOverlay visible />;
+  }
+  
+  if (error) {
+    return (
+      <Container size="xl" className={styles.container}>
+        <Alert color="red" title="Error">
+          Failed to load profile
+        </Alert>
+      </Container>
+    );
+  }
+  
+  return (
+    <Container size="xl" className={styles.container}>
+      <Stack spacing="xl">
+        {/* Header */}
+        <Group position="apart">
+          <Title order={1} className={styles.title}>
+            My Profile
+          </Title>
+          {!isEditing && (
+            <Button
+              leftIcon={<IconEdit size={16} />}
+              onClick={() => {
+                // Populate form with current values when entering edit mode
+                if (userProfile) {
+                  form.setValues({
+                    first_name: userProfile.first_name || '',
+                    last_name: userProfile.last_name || '',
+                    company_name: userProfile.company_name || '',
+                    title: userProfile.title || '',
+                    bio: userProfile.bio || '',
+                    social_links: {
+                      linkedin: userProfile.social_links?.linkedin || '',
+                      twitter: userProfile.social_links?.twitter || '',
+                      website: userProfile.social_links?.website || '',
+                    },
+                  });
+                }
+                setIsEditing(true);
+              }}
+              variant="subtle"
+            >
+              Edit Profile
+            </Button>
+          )}
+        </Group>
+        
+        {/* Profile Content */}
+        <Paper shadow="sm" p="xl" className={styles.profileCard}>
+          <form onSubmit={form.onSubmit(handleSave)}>
+            <Stack spacing="lg">
+              {/* Avatar and Basic Info */}
+              <Group spacing="xl" align="flex-start">
+                <Avatar
+                  src={userProfile?.image_url}
+                  size={120}
+                  radius="md"
+                  className={styles.avatar}
+                />
+                
+                <Stack spacing="sm" style={{ flex: 1 }}>
+                  {isEditing ? (
+                    <>
+                      <Group grow>
+                        <TextInput
+                          label="First Name"
+                          {...form.getInputProps('first_name')}
+                          required
+                        />
+                        <TextInput
+                          label="Last Name"
+                          {...form.getInputProps('last_name')}
+                          required
+                        />
+                      </Group>
+                      <TextInput
+                        label="Email"
+                        value={userProfile?.email}
+                        disabled
+                        description="Email cannot be changed"
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <Title order={2} className={styles.name}>
+                        {userProfile?.full_name}
+                      </Title>
+                      <Text color="dimmed" size="sm">
+                        {userProfile?.email}
+                      </Text>
+                    </>
+                  )}
+                </Stack>
+              </Group>
+              
+              {/* Professional Info */}
+              <Stack spacing="md">
+                <Title order={4} className={styles.sectionTitle}>
+                  Professional Information
+                </Title>
+                
+                {isEditing ? (
+                  <>
+                    <TextInput
+                      label="Job Title"
+                      placeholder="e.g., Software Engineer"
+                      {...form.getInputProps('title')}
+                    />
+                    <TextInput
+                      label="Company"
+                      placeholder="e.g., Acme Corp"
+                      {...form.getInputProps('company_name')}
+                    />
+                  </>
+                ) : (
+                  <div className={styles.infoGroup}>
+                    {userProfile?.title && (
+                      <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>Title</span>
+                        <span className={styles.infoValue}>{userProfile.title}</span>
+                      </div>
+                    )}
+                    {userProfile?.company_name && (
+                      <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>Company</span>
+                        <span className={styles.infoValue}>{userProfile.company_name}</span>
+                      </div>
+                    )}
+                    {!userProfile?.title && !userProfile?.company_name && (
+                      <Text color="dimmed" size="sm">
+                        No professional information added
+                      </Text>
+                    )}
+                  </div>
+                )}
+              </Stack>
+              
+              {/* Bio */}
+              <Stack spacing="md">
+                <Title order={4} className={styles.sectionTitle}>
+                  About Me
+                </Title>
+                
+                {isEditing ? (
+                  <Textarea
+                    placeholder="Tell us about yourself..."
+                    minRows={4}
+                    {...form.getInputProps('bio')}
+                  />
+                ) : (
+                  <Text className={styles.bio}>
+                    {userProfile?.bio || (
+                      <Text component="span" color="dimmed" size="sm">
+                        No bio added
+                      </Text>
+                    )}
+                  </Text>
+                )}
+              </Stack>
+              
+              {/* Social Links */}
+              <Stack spacing="md">
+                <Title order={4} className={styles.sectionTitle}>
+                  Social Links
+                </Title>
+                
+                {isEditing ? (
+                  <Stack spacing="sm">
+                    <TextInput
+                      label="LinkedIn"
+                      placeholder="https://linkedin.com/in/username"
+                      {...form.getInputProps('social_links.linkedin')}
+                    />
+                    <TextInput
+                      label="Twitter"
+                      placeholder="https://twitter.com/username"
+                      {...form.getInputProps('social_links.twitter')}
+                    />
+                    <TextInput
+                      label="Website"
+                      placeholder="https://example.com"
+                      {...form.getInputProps('social_links.website')}
+                    />
+                  </Stack>
+                ) : (
+                  <div className={styles.infoGroup}>
+                    {userProfile?.social_links?.linkedin && (
+                      <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>LinkedIn</span>
+                        <a
+                          href={userProfile.social_links.linkedin}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.link}
+                        >
+                          {userProfile.social_links.linkedin}
+                        </a>
+                      </div>
+                    )}
+                    {userProfile?.social_links?.twitter && (
+                      <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>Twitter</span>
+                        <a
+                          href={userProfile.social_links.twitter}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.link}
+                        >
+                          {userProfile.social_links.twitter}
+                        </a>
+                      </div>
+                    )}
+                    {userProfile?.social_links?.website && (
+                      <div className={styles.infoItem}>
+                        <span className={styles.infoLabel}>Website</span>
+                        <a
+                          href={userProfile.social_links.website}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={styles.link}
+                        >
+                          {userProfile.social_links.website}
+                        </a>
+                      </div>
+                    )}
+                    {!userProfile?.social_links?.linkedin &&
+                      !userProfile?.social_links?.twitter &&
+                      !userProfile?.social_links?.website && (
+                        <Text color="dimmed" size="sm">
+                          No social links added
+                        </Text>
+                      )}
+                  </div>
+                )}
+              </Stack>
+              
+              {/* Action Buttons */}
+              {isEditing && (
+                <Group position="right" mt="xl">
+                  <Button
+                    variant="subtle"
+                    color="gray"
+                    onClick={handleCancel}
+                    leftIcon={<IconX size={16} />}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    loading={isUpdating}
+                    leftIcon={<IconCheck size={16} />}
+                  >
+                    Save Changes
+                  </Button>
+                </Group>
+              )}
+            </Stack>
+          </form>
+        </Paper>
+        
+        {/* Account Information */}
+        <Paper shadow="sm" p="xl" className={styles.accountCard}>
+          <Stack spacing="md">
+            <Title order={4} className={styles.sectionTitle}>
+              Account Information
+            </Title>
+            <div className={styles.infoGroup}>
+              <div className={styles.infoItem}>
+                <span className={styles.infoLabel}>Member Since</span>
+                <span className={styles.infoValue}>
+                  {new Date(userProfile?.created_at).toLocaleDateString()}
+                </span>
+              </div>
+              <div className={styles.infoItem}>
+                <span className={styles.infoLabel}>Account Status</span>
+                <Text component="span" color={userProfile?.is_active ? 'green' : 'red'} weight={500}>
+                  {userProfile?.is_active ? 'Active' : 'Inactive'}
+                </Text>
+              </div>
+            </div>
+          </Stack>
+        </Paper>
+      </Stack>
+    </Container>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/Profile/schemas/profileSchema.js
+++ b/frontend/src/pages/Profile/schemas/profileSchema.js
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const profileSchema = z.object({
+  first_name: z.string().min(1, 'First name is required'),
+  last_name: z.string().min(1, 'Last name is required'),
+  company_name: z.string().optional(),
+  title: z.string().optional(),
+  bio: z.string().max(500, 'Bio must be less than 500 characters').optional(),
+  social_links: z.object({
+    linkedin: z.string().url('Must be a valid URL').or(z.literal('')).optional(),
+    twitter: z.string().url('Must be a valid URL').or(z.literal('')).optional(),
+    website: z.string().url('Must be a valid URL').or(z.literal('')).optional(),
+  }),
+});

--- a/frontend/src/pages/Profile/styles/index.module.css
+++ b/frontend/src/pages/Profile/styles/index.module.css
@@ -1,1 +1,109 @@
-/* Profile styles - placeholder for future implementation */
+.container {
+  padding: var(--mantine-spacing-md);
+  min-height: calc(100vh - var(--mantine-header-height, 0px));
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--mantine-color-gray-9);
+}
+
+.profileCard,
+.accountCard {
+  background: white;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.avatar {
+  border: 3px solid var(--mantine-color-gray-2);
+}
+
+.name {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--mantine-color-gray-9);
+  margin: 0;
+}
+
+.sectionTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--mantine-color-gray-8);
+  margin-bottom: 0;
+}
+
+.infoGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.infoItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--mantine-color-gray-2);
+}
+
+.infoItem:last-child {
+  border-bottom: none;
+}
+
+.infoLabel {
+  font-weight: 600;
+  color: var(--mantine-color-gray-7);
+  min-width: 100px;
+  font-size: 0.875rem;
+}
+
+.infoValue {
+  color: var(--mantine-color-gray-9);
+  font-size: 1rem;
+}
+
+.bio {
+  line-height: 1.6;
+  color: var(--mantine-color-gray-7);
+  white-space: pre-wrap;
+}
+
+.link {
+  color: var(--mantine-color-blue-6);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.link:hover {
+  color: var(--mantine-color-blue-8);
+  text-decoration: underline;
+}
+
+/* Match the squared pill style from session page */
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .container {
+    padding: var(--mantine-spacing-sm);
+  }
+  
+  .title {
+    font-size: 1.5rem;
+  }
+  
+  .profileCard,
+  .accountCard {
+    padding: var(--mantine-spacing-md);
+  }
+}


### PR DESCRIPTION
- Add complete profile view/edit interface
- Implement inline editing with Mantine form and Zod validation
- Add @mantine/notifications for success/error toasts (bottom-left position)
- Style profile sections with clear label/value layout
- Support all user fields: name, title, company, bio, social links
- Show account info: member since date and status
- Follow established patterns with schema in dedicated file
- Match aesthetic from session/agenda pages