### PR TITLE
feat: update networking page UI with modern person cards

### DIFF
--- a/frontend/src/shared/components/PersonCard/index.jsx
+++ b/frontend/src/shared/components/PersonCard/index.jsx
@@ -1,14 +1,17 @@
-import { Card, Text, Avatar, Group, Badge, ActionIcon, Stack } from '@mantine/core';
-import { IconBrandLinkedin, IconWorld, IconMail, IconMessageCircle } from '@tabler/icons-react';
+import { Card, Text, Avatar, Group, Badge, Button, ActionIcon, Stack } from '@mantine/core';
+import { IconBrandLinkedin, IconWorld, IconMail, IconMessageCircle, IconUserPlus } from '@tabler/icons-react';
+import { useSelector } from 'react-redux';
 import styles from './styles/index.module.css';
 
 export function PersonCard({ 
   person, 
   variant = 'attendee', // 'speaker' | 'attendee'
+  role, // User's actual role: ADMIN, ORGANIZER, SPEAKER, ATTENDEE
   onConnect,
   onMessage,
   showActions = true 
 }) {
+  const currentUser = useSelector((state) => state.auth.user);
   const { 
     firstName, 
     lastName, 
@@ -23,7 +26,7 @@ export function PersonCard({
     privacySettings = {}
   } = person;
 
-  const fullName = `${firstName} ${lastName}`;
+  const fullName = `${firstName || ''} ${lastName || ''}`.trim();
   const initial = firstName?.[0]?.toUpperCase() || '?';
   
   // Privacy controls - what info to show
@@ -42,13 +45,13 @@ export function PersonCard({
         >
           {!avatarUrl && initial}
         </Avatar>
-        
-        {variant === 'speaker' && (
-          <Badge color="blue" variant="light" className={styles.badge}>
-            Speaker
-          </Badge>
-        )}
       </div>
+      
+      {role && (
+        <div className={`${styles.roleBadge} ${styles[role?.toLowerCase() || '']}`}>
+          {role?.charAt(0) + role?.slice(1).toLowerCase()}
+        </div>
+      )}
 
       <Stack gap="xs" className={styles.content}>
         <Text size="lg" weight={600} className={styles.name}>
@@ -73,71 +76,91 @@ export function PersonCard({
           </Text>
         )}
 
-        {showSocials && (linkedin || website || (showEmail && email)) && (
-          <Group gap="xs" className={styles.socials}>
-            {linkedin && (
-              <ActionIcon 
-                size="sm" 
-                variant="subtle" 
-                component="a" 
-                href={linkedin} 
-                target="_blank"
-                aria-label="LinkedIn"
-              >
-                <IconBrandLinkedin size={16} />
-              </ActionIcon>
-            )}
-            {website && (
-              <ActionIcon 
-                size="sm" 
-                variant="subtle" 
-                component="a" 
-                href={website} 
-                target="_blank"
-                aria-label="Website"
-              >
-                <IconWorld size={16} />
-              </ActionIcon>
-            )}
-            {showEmail && email && (
-              <ActionIcon 
-                size="sm" 
-                variant="subtle" 
-                component="a" 
-                href={`mailto:${email}`}
-                aria-label="Email"
-              >
-                <IconMail size={16} />
-              </ActionIcon>
-            )}
-          </Group>
-        )}
-
-        {variant === 'attendee' && showActions && (
-          <Group gap="xs" className={styles.actions}>
-            {connectionStatus === 'connected' ? (
-              <ActionIcon 
-                variant="filled" 
-                color="blue" 
-                size="md"
-                onClick={() => onMessage?.(person)}
-                aria-label="Send message"
-              >
-                <IconMessageCircle size={16} />
-              </ActionIcon>
-            ) : (
-              <Badge 
-                variant="light" 
-                color={connectionStatus === 'pending' ? 'yellow' : 'blue'}
-                className={styles.connectBadge}
-                onClick={() => !connectionStatus && onConnect?.(person)}
-                style={{ cursor: connectionStatus ? 'default' : 'pointer' }}
-              >
-                {connectionStatus === 'pending' ? 'Pending' : 'Connect'}
-              </Badge>
-            )}
-          </Group>
-        )}
+        <Group gap="xs" className={styles.socials}>
+          {showSocials && (
+            <>
+              {linkedin && (
+                <ActionIcon 
+                  size="sm" 
+                  variant="subtle" 
+                  component="a" 
+                  href={linkedin} 
+                  target="_blank"
+                  aria-label="LinkedIn"
+                >
+                  <IconBrandLinkedin size={16} />
+                </ActionIcon>
+              )}
+              {website && (
+                <ActionIcon 
+                  size="sm" 
+                  variant="subtle" 
+                  component="a" 
+                  href={website} 
+                  target="_blank"
+                  aria-label="Website"
+                >
+                  <IconWorld size={16} />
+                </ActionIcon>
+              )}
+              {showEmail && email && (
+                <ActionIcon 
+                  size="sm" 
+                  variant="subtle" 
+                  component="a" 
+                  href={`mailto:${email}`}
+                  aria-label="Email"
+                >
+                  <IconMail size={16} />
+                </ActionIcon>
+              )}
+            </>
+          )}
+          
+          {showActions && currentUser?.id !== person.id && (
+            <div className={styles.actionButtonWrapper}>
+              {connectionStatus === 'connected' ? (
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="blue"
+                  leftIcon={<IconMessageCircle size={14} />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMessage?.(person);
+                  }}
+                  className={styles.actionButton}
+                >
+                  Message
+                </Button>
+              ) : connectionStatus === 'pending' ? (
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="yellow"
+                  disabled
+                  className={styles.actionButton}
+                >
+                  Pending
+                </Button>
+              ) : (
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="blue"
+                  leftIcon={<IconUserPlus size={14} />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onConnect?.(person);
+                  }}
+                  className={styles.actionButton}
+                >
+                  Connect
+                </Button>
+              )}
+            </div>
+          )}
+        </Group>
       </Stack>
     </Card>
   );

--- a/frontend/src/shared/components/PersonCard/styles/index.module.css
+++ b/frontend/src/shared/components/PersonCard/styles/index.module.css
@@ -4,6 +4,8 @@
   flex-direction: column;
   transition: all 0.2s ease;
   cursor: pointer;
+  position: relative;
+  overflow: visible;
 }
 
 .card:hover {
@@ -24,6 +26,38 @@
 
 .badge {
   margin-top: 4px;
+}
+
+/* Modern squared role badges */
+.roleBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+/* Role colors matching session types */
+.admin,
+.organizer {
+  background-color: var(--mantine-color-grape-1);
+  color: var(--mantine-color-grape-7);
+}
+
+.speaker {
+  background-color: var(--mantine-color-blue-1);
+  color: var(--mantine-color-blue-7);
+}
+
+.attendee {
+  background-color: var(--mantine-color-gray-1);
+  color: var(--mantine-color-gray-7);
 }
 
 .content {
@@ -48,8 +82,14 @@
 }
 
 .socials {
+  margin-top: auto; /* Push to bottom */
   padding-top: var(--mantine-spacing-xs);
   border-top: 1px solid #e9ecef;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 32px; /* Fixed height to match button height + alignment */
 }
 
 .actions {
@@ -65,4 +105,26 @@
 
 .connectBadge:hover {
   transform: scale(1.02);
+}
+
+/* Action button wrapper */
+.actionButtonWrapper {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+.actionButton {
+  padding: 4px 12px;
+  height: 28px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  margin: 0; /* Ensure no margin */
+}
+
+.actionButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
- Redesign connect button as small pill, positioned right with social icons
- Update role badges to modern squared style (4px radius) matching session page
- Show actual roles (Admin/Organizer/Speaker/Attendee) with proper colors
- Hide connect button when viewing own card
- Fix "Organizers" filter to include both ADMIN and ORGANIZER roles
- Fix alignment issues ensuring consistent border positioning
- Add safety checks for string methods to prevent race condition crashes
- Improve layout with flex positioning for better button alignment