### PR TITLE
feat: enhance seeders and fix sponsor display issues

### DIFF
--- a/backend/atria/api/api/schemas/event_user.py
+++ b/backend/atria/api/api/schemas/event_user.py
@@ -22,6 +22,8 @@ class EventUserSchema(ma.SQLAlchemyAutoSchema):
     sort_name = ma.String(dump_only=True)
     image_url = ma.String(dump_only=True)
     social_links = ma.Dict(dump_only=True)
+    company_name = ma.String(dump_only=True)
+    title = ma.String(dump_only=True)
 
 
 class EventUserDetailSchema(EventUserSchema):

--- a/backend/atria/api/models/event_user.py
+++ b/backend/atria/api/models/event_user.py
@@ -93,6 +93,16 @@ class EventUser(db.Model):
     def social_links(self):
         """Get user's social links"""
         return self.user.social_links
+    
+    @property
+    def company_name(self):
+        """Get user's company name"""
+        return self.user.company_name
+    
+    @property
+    def title(self):
+        """Get user's title"""
+        return self.user.title
 
     def update_speaker_info(self, speaker_bio=None, speaker_title=None):
         """Update speaker bio and title"""

--- a/backend/atria/seeders/seed_data.py
+++ b/backend/atria/seeders/seed_data.py
@@ -63,6 +63,59 @@ def seed_users():
             },
             "is_active": True,
         },
+        # Additional Attendees
+        {
+            "id": 5,
+            "email": "alex.patel@example.com",
+            "password_hash": pwd_context.hash("password123"),
+            "first_name": "Alex",
+            "last_name": "Patel",
+            "company_name": "Startup Inc",
+            "title": "Full Stack Developer",
+            "bio": "Building scalable web applications",
+            "image_url": "https://api.dicebear.com/7.x/avataaars/svg?seed=Alex",
+            "social_links": {"linkedin": "https://linkedin.com/in/alexpatel"},
+            "is_active": True,
+        },
+        {
+            "id": 6,
+            "email": "jamie.wong@example.com",
+            "password_hash": pwd_context.hash("password123"),
+            "first_name": "Jamie",
+            "last_name": "Wong",
+            "company_name": "Tech Solutions",
+            "title": "DevOps Engineer",
+            "bio": "Container orchestration enthusiast",
+            "image_url": "https://api.dicebear.com/7.x/avataaars/svg?seed=Jamie",
+            "social_links": {"linkedin": "https://linkedin.com/in/jamiewong"},
+            "is_active": True,
+        },
+        {
+            "id": 7,
+            "email": "taylor.kim@example.com",
+            "password_hash": pwd_context.hash("password123"),
+            "first_name": "Taylor",
+            "last_name": "Kim",
+            "company_name": "DataCorp",
+            "title": "Data Engineer",
+            "bio": "Real-time data processing and analytics",
+            "image_url": "https://api.dicebear.com/7.x/avataaars/svg?seed=Taylor",
+            "social_links": {"linkedin": "https://linkedin.com/in/taylorkim"},
+            "is_active": True,
+        },
+        {
+            "id": 8,
+            "email": "chris.martinez@example.com",
+            "password_hash": pwd_context.hash("password123"),
+            "first_name": "Chris",
+            "last_name": "Martinez",
+            "company_name": "Atria",
+            "title": "Event Operations Manager",
+            "bio": "Managing event logistics and operations",
+            "image_url": "https://api.dicebear.com/7.x/avataaars/svg?seed=Chris",
+            "social_links": {"linkedin": "https://linkedin.com/in/chrismartinez"},
+            "is_active": True,
+        },
     ]
 
 
@@ -89,8 +142,8 @@ def seed_events():
             "description": "Three-day technology conference featuring industry leaders",
             "hero_description": "Join us for the premier tech conference of 2025, featuring industry leaders from Netflix, Stripe, and GitHub",
             "hero_images": {
-                "desktop": "https://example.com/hero-desktop.jpg",
-                "mobile": "https://example.com/hero-mobile.jpg",
+                "desktop": "https://storage.sbtl.dev/spookyspot/atria-event-banner.png",
+                "mobile": "https://storage.sbtl.dev/spookyspot/atria-event-banner.png",
             },
             "event_type": "CONFERENCE",
             "event_format": "HYBRID",
@@ -110,6 +163,43 @@ def seed_events():
                 "logo_url": None,
                 "banner_url": None,
             },
+            "sponsor_tiers": [
+                {
+                    "id": "platinum",
+                    "name": "Platinum Sponsor",
+                    "order": 1,
+                    "benefits": ["Prime booth location", "5 conference passes", "Logo on all materials", "Speaking opportunity"],
+                    "color": "#e5e4e2"
+                },
+                {
+                    "id": "gold", 
+                    "name": "Gold Sponsor",
+                    "order": 2,
+                    "benefits": ["Booth space", "3 conference passes", "Logo on website", "Social media mentions"],
+                    "color": "#ffd700"
+                },
+                {
+                    "id": "silver",
+                    "name": "Silver Sponsor", 
+                    "order": 3,
+                    "benefits": ["2 conference passes", "Logo on website", "Attendee list access"],
+                    "color": "#c0c0c0"
+                },
+                {
+                    "id": "bronze",
+                    "name": "Bronze Sponsor",
+                    "order": 4,
+                    "benefits": ["1 conference pass", "Logo on website"],
+                    "color": "#cd7f32"
+                },
+                {
+                    "id": "community",
+                    "name": "Community Partner",
+                    "order": 5,
+                    "benefits": ["Special recognition", "Logo on community page"],
+                    "color": "#ff6611"
+                }
+            ],
             "sections": {
                 "welcome": {
                     "title": "Welcome to Atria TechConf 2025",
@@ -179,6 +269,35 @@ def seed_event_users():
             "speaker_title": "Senior Engineer @ GitHub",
             "speaker_bio": "DevOps and automation expert",
         },
+        # Additional attendees
+        {
+            "event_id": 1,
+            "user_id": 5,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        },
+        {
+            "event_id": 1,
+            "user_id": 6,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        },
+        {
+            "event_id": 1,
+            "user_id": 7,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        },
+        {
+            "event_id": 1,
+            "user_id": 8,
+            "role": "ORGANIZER",  # Chris as an organizer
+            "speaker_title": None,
+            "speaker_bio": None,
+        },
     ]
 
 
@@ -191,7 +310,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "KEYNOTE",
             "title": "The Future of AI in Software Development",
-            "description": "Opening keynote exploring AI's transformative impact on software development.",
+            "short_description": "Opening keynote on AI's impact on modern software development practices",
+            "description": "Join us for an inspiring opening keynote that explores how AI is revolutionizing software development. From code generation to automated testing, discover how AI tools are changing the way we build software and what this means for developers' careers in the next decade. We'll showcase real-world examples and preview upcoming innovations that will shape our industry.",
             "start_time": time(9, 0),
             "end_time": time(10, 0),
             "stream_url": "https://conference.live/day1-keynote",
@@ -204,7 +324,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "WORKSHOP",
             "title": "React Performance Optimization",
-            "description": "Hands-on workshop on optimizing React applications",
+            "short_description": "Hands-on workshop: Advanced techniques for optimizing React applications",
+            "description": "Master the art of React performance optimization in this intensive hands-on workshop. Learn profiling techniques, implement code splitting, optimize renders with memo and useMemo, and discover advanced patterns for handling large datasets. Bring your laptop and a problematic React app to optimize!",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day1-react",
@@ -216,7 +337,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "PRESENTATION",
             "title": "GraphQL Best Practices",
-            "description": "Deep dive into GraphQL schema design",
+            "short_description": "Schema design patterns and performance tips for production GraphQL",
+            "description": "Learn battle-tested GraphQL patterns from real production systems. We'll cover schema design principles, resolver optimization, caching strategies, and security considerations. Includes case studies from Netflix's GraphQL implementation serving millions of users.",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day1-graphql",
@@ -228,7 +350,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "NETWORKING",
             "title": "Lunch & Networking",
-            "description": "Network with fellow developers over lunch",
+            "short_description": "Structured networking lunch with topic tables",
+            "description": "Join themed networking tables based on your interests: Frontend, Backend, DevOps, AI/ML, Mobile, or Open Source. Each table has a facilitator to spark conversations. Vegetarian, vegan, and gluten-free options available.",
             "start_time": time(12, 0),
             "end_time": time(13, 30),
             "stream_url": None,
@@ -240,10 +363,66 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "PANEL",
             "title": "Future of Cloud Computing",
-            "description": "Industry leaders discuss cloud evolution",
+            "short_description": "Industry leaders debate multi-cloud strategies and edge computing",
+            "description": "Top engineers from Netflix, Stripe, and GitHub discuss the evolution of cloud architecture. Topics include multi-cloud strategies, edge computing, serverless at scale, and the environmental impact of cloud infrastructure. Audience Q&A included.",
             "start_time": time(14, 0),
             "end_time": time(15, 30),
             "stream_url": "https://conference.live/day1-cloud-panel",
+            "day_number": 1,
+        },
+        # Afternoon Break
+        {
+            "id": 14,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "NETWORKING",
+            "title": "Coffee Break & Expo Hall",
+            "short_description": "Visit sponsor booths and enjoy afternoon refreshments",
+            "description": "Take a break to recharge with coffee and snacks while exploring our sponsor expo. Great opportunity to learn about new tools and services that can help your development workflow.",
+            "start_time": time(15, 30),
+            "end_time": time(16, 0),
+            "stream_url": None,
+            "day_number": 1,
+        },
+        # Late Afternoon Sessions
+        {
+            "id": 15,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "WORKSHOP",
+            "title": "Building Secure APIs",
+            "short_description": "Security best practices for modern API development",
+            "description": "Learn how to build secure APIs from the ground up. Cover authentication strategies, rate limiting, input validation, and common vulnerabilities. Includes hands-on exercises with JWT, OAuth2, and API gateway patterns.",
+            "start_time": time(16, 0),
+            "end_time": time(17, 30),
+            "stream_url": "https://conference.live/day1-security",
+            "day_number": 1,
+        },
+        {
+            "id": 16,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "Scaling PostgreSQL to 1 Billion Records",
+            "short_description": "Real-world lessons from scaling PostgreSQL in production",
+            "description": "Discover proven strategies for scaling PostgreSQL to handle massive datasets. Learn about partitioning, indexing strategies, query optimization, and when to consider alternative solutions. Based on real experiences at scale.",
+            "start_time": time(16, 0),
+            "end_time": time(17, 30),
+            "stream_url": "https://conference.live/day1-postgres",
+            "day_number": 1,
+        },
+        # Evening Event
+        {
+            "id": 17,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "NETWORKING",
+            "title": "Welcome Reception",
+            "short_description": "Opening night reception with food, drinks, and networking",
+            "description": "Join us for the opening night reception! Enjoy appetizers, drinks, and great conversations with fellow attendees, speakers, and sponsors. Live music and fun activities included.",
+            "start_time": time(18, 0),
+            "end_time": time(20, 0),
+            "stream_url": None,
             "day_number": 1,
         },
         # DAY 2 - March 16, 2025
@@ -253,7 +432,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "KEYNOTE",
             "title": "DevOps Evolution: 2025 and Beyond",
-            "description": "Morning keynote on the future of DevOps",
+            "short_description": "The future of DevOps: Platform engineering, AI ops, and beyond",
+            "description": "Explore the evolution of DevOps practices and the rise of platform engineering. Learn how AI is transforming operations, the shift from DevOps to platform teams, and what skills you'll need for the future. Features live demos of cutting-edge tools.",
             "start_time": time(9, 0),
             "end_time": time(10, 0),
             "stream_url": "https://conference.live/day2-keynote",
@@ -266,7 +446,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "WORKSHOP",
             "title": "Docker Deep Dive",
-            "description": "Advanced Docker techniques and patterns",
+            "short_description": "Advanced Docker patterns: Multi-stage builds, security, and optimization",
+            "description": "Go beyond basics with advanced Docker techniques. Master multi-stage builds, implement security scanning, optimize image sizes, and learn debugging strategies. Includes hands-on labs with real-world scenarios from containerizing legacy applications.",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day2-docker",
@@ -278,7 +459,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "WORKSHOP",
             "title": "Kubernetes in Production",
-            "description": "Real-world Kubernetes deployment strategies",
+            "short_description": "Battle-tested strategies for running K8s at scale",
+            "description": "Learn from real production experiences running Kubernetes at scale. Cover cluster design, security hardening, cost optimization, and disaster recovery. Includes war stories and lessons learned from managing 1000+ node clusters.",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day2-kubernetes",
@@ -290,10 +472,79 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "PRESENTATION",
             "title": "CI/CD Best Practices",
-            "description": "Modern CI/CD pipeline development",
+            "short_description": "Building fast, reliable pipelines with modern CI/CD tools",
+            "description": "Design CI/CD pipelines that developers love. Learn about trunk-based development, progressive delivery, feature flags, and automated rollbacks. Compare GitHub Actions, GitLab CI, and other modern tools with real examples.",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day2-cicd",
+            "day_number": 2,
+        },
+        # Lunch
+        {
+            "id": 18,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "NETWORKING",
+            "title": "Lunch & Learn: Open Source Showcase",
+            "short_description": "Lightning talks from open source maintainers during lunch",
+            "description": "Enjoy lunch while learning about exciting open source projects. Features 5-minute lightning talks from project maintainers, including tools you use every day. Great opportunity to learn how to contribute.",
+            "start_time": time(12, 0),
+            "end_time": time(13, 30),
+            "stream_url": None,
+            "day_number": 2,
+        },
+        # Afternoon Sessions
+        {
+            "id": 19,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "WORKSHOP",
+            "title": "Microservices Architecture Workshop",
+            "short_description": "Design and implement microservices with best practices",
+            "description": "Hands-on workshop covering microservices design patterns, service mesh, distributed tracing, and saga patterns. Build a sample e-commerce system using microservices architecture with proper observability.",
+            "start_time": time(14, 0),
+            "end_time": time(15, 30),
+            "stream_url": "https://conference.live/day2-microservices",
+            "day_number": 2,
+        },
+        {
+            "id": 20,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "WebSocket at Scale: Real-time Systems",
+            "short_description": "Building reliable real-time features with WebSockets",
+            "description": "Learn how to build scalable real-time systems using WebSockets. Cover load balancing, horizontal scaling, reconnection strategies, and state management. Includes case studies from building real-time collaboration tools.",
+            "start_time": time(14, 0),
+            "end_time": time(15, 30),
+            "stream_url": "https://conference.live/day2-websockets",
+            "day_number": 2,
+        },
+        {
+            "id": 21,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PANEL",
+            "title": "Women in Tech Leadership Panel",
+            "short_description": "Inspiring stories and advice from women tech leaders",
+            "description": "Join accomplished women engineers and leaders for an inspiring discussion about career growth, overcoming challenges, and building inclusive teams. Moderated Q&A session included.",
+            "start_time": time(16, 0),
+            "end_time": time(17, 30),
+            "stream_url": "https://conference.live/day2-women-panel",
+            "day_number": 2,
+        },
+        # Evening Event
+        {
+            "id": 22,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "NETWORKING",
+            "title": "Conference Party & Hackathon Kickoff",
+            "short_description": "Evening party with music, games, and hackathon team formation",
+            "description": "Join us for the conference party! Live DJ, arcade games, and great food. Form teams for the overnight hackathon with prizes totaling $10,000. Non-hackers welcome to enjoy the party!",
+            "start_time": time(19, 0),
+            "end_time": time(22, 0),
+            "stream_url": None,
             "day_number": 2,
         },
         # DAY 3 - March 17, 2025
@@ -303,7 +554,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "KEYNOTE",
             "title": "The Future of Web Development",
-            "description": "Closing keynote on web development trends",
+            "short_description": "WebAssembly, Edge Computing, and the next decade of the web",
+            "description": "Explore emerging web technologies that will shape the next decade. Deep dive into WebAssembly use cases, edge computing platforms, and new web APIs. Features demos of experimental technologies and a vision for the future of web development.",
             "start_time": time(9, 0),
             "end_time": time(10, 0),
             "stream_url": "https://conference.live/day3-keynote",
@@ -315,10 +567,37 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "WORKSHOP",
             "title": "Advanced TypeScript Patterns",
-            "description": "Deep dive into TypeScript development",
+            "short_description": "Type gymnastics: Advanced TypeScript for library authors",
+            "description": "Master advanced TypeScript patterns used in popular libraries. Learn conditional types, mapped types, template literal types, and type inference tricks. Perfect for developers building type-safe libraries or complex applications.",
             "start_time": time(10, 30),
             "end_time": time(12, 0),
             "stream_url": "https://conference.live/day3-typescript",
+            "day_number": 3,
+        },
+        {
+            "id": 23,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "Machine Learning for Web Developers",
+            "short_description": "Practical ML: TensorFlow.js and on-device inference",
+            "description": "Demystify machine learning for web developers. Learn to integrate pre-trained models, perform on-device inference, and build ML-powered features. No PhD required! Includes practical examples you can implement today.",
+            "start_time": time(10, 30),
+            "end_time": time(12, 0),
+            "stream_url": "https://conference.live/day3-ml",
+            "day_number": 3,
+        },
+        {
+            "id": 24,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "Hackathon Winner Presentations",
+            "short_description": "Top 5 hackathon teams present their projects",
+            "description": "Watch the top 5 teams from last night's hackathon present their innovative projects. Amazing what can be built in 24 hours! Audience votes for People's Choice Award.",
+            "start_time": time(12, 0),
+            "end_time": time(13, 0),
+            "stream_url": "https://conference.live/day3-hackathon",
             "day_number": 3,
         },
         {
@@ -327,7 +606,8 @@ def seed_sessions():
             "status": "SCHEDULED",
             "session_type": "PANEL",
             "title": "Future of Frontend Development",
-            "description": "Panel discussion on frontend trends",
+            "short_description": "React, Vue, Angular experts debate the future of frontend",
+            "description": "Core team members from React, Vue, and Angular discuss the future of frontend frameworks. Topics include signals, server components, hydration strategies, and whether we'll ever agree on anything. Moderated by a neutral party!",
             "start_time": time(13, 30),
             "end_time": time(15, 0),
             "stream_url": "https://conference.live/day3-frontend-panel",
@@ -338,11 +618,25 @@ def seed_sessions():
             "event_id": 1,
             "status": "SCHEDULED",
             "session_type": "QA",
-            "title": "Ask Me Anything: Senior Developers",
-            "description": "Open Q&A with experienced developers",
+            "title": "Ask Me Anything: Conference Speakers",
+            "short_description": "Open Q&A session with all conference speakers",
+            "description": "Your chance to ask anything! All conference speakers gather for an open Q&A session. Career advice, technical deep dives, industry insights - no topic off limits. Submit questions via the conference app.",
             "start_time": time(15, 30),
             "end_time": time(16, 30),
             "stream_url": "https://conference.live/day3-ama",
+            "day_number": 3,
+        },
+        {
+            "id": 25,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "KEYNOTE",
+            "title": "Closing Ceremony & Awards",
+            "short_description": "Conference wrap-up, awards, and announcement of next year",
+            "description": "Join us for the closing ceremony! We'll announce hackathon winners, share conference highlights, and reveal the location and dates for Atria TechConf 2026. Don't miss the surprise announcement!",
+            "start_time": time(17, 0),
+            "end_time": time(18, 0),
+            "stream_url": "https://conference.live/day3-closing",
             "day_number": 3,
         },
     ]
@@ -389,6 +683,159 @@ def seed_session_speakers():
             "user_id": 3,  # Marcus Rodriguez
             "role": "PANELIST",
             "order": 3,
+        },
+        # Building Secure APIs
+        {
+            "session_id": 15,
+            "user_id": 6,  # Jamie Wong (DevOps)
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Scaling PostgreSQL
+        {
+            "session_id": 16,
+            "user_id": 7,  # Taylor Kim (Data Engineer)
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Day 2 DevOps Keynote
+        {
+            "session_id": 6,
+            "user_id": 4,  # Emily Johnson
+            "role": "KEYNOTE",
+            "order": 1,
+        },
+        # Docker Workshop
+        {
+            "session_id": 7,
+            "user_id": 6,  # Jamie Wong
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Kubernetes Workshop
+        {
+            "session_id": 8,
+            "user_id": 8,  # Chris Martinez (Atria)
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # CI/CD Presentation
+        {
+            "session_id": 9,
+            "user_id": 4,  # Emily Johnson
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Microservices Workshop
+        {
+            "session_id": 19,
+            "user_id": 2,  # Sarah Chen
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # WebSocket Presentation
+        {
+            "session_id": 20,
+            "user_id": 5,  # Alex Patel (Full Stack)
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Women in Tech Panel
+        {
+            "session_id": 21,
+            "user_id": 1,  # Demo User as moderator
+            "role": "MODERATOR",
+            "order": 1,
+        },
+        {
+            "session_id": 21,
+            "user_id": 2,  # Sarah Chen
+            "role": "PANELIST",
+            "order": 2,
+        },
+        {
+            "session_id": 21,
+            "user_id": 4,  # Emily Johnson
+            "role": "PANELIST",
+            "order": 3,
+        },
+        # Day 3 Keynote
+        {
+            "session_id": 10,
+            "user_id": 3,  # Marcus Rodriguez
+            "role": "KEYNOTE",
+            "order": 1,
+        },
+        # TypeScript Workshop
+        {
+            "session_id": 11,
+            "user_id": 5,  # Alex Patel
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # ML for Web Devs
+        {
+            "session_id": 23,
+            "user_id": 7,  # Taylor Kim (Data)
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        # Frontend Panel
+        {
+            "session_id": 12,
+            "user_id": 1,  # Demo User moderator
+            "role": "MODERATOR",
+            "order": 1,
+        },
+        {
+            "session_id": 12,
+            "user_id": 3,  # Marcus Rodriguez
+            "role": "PANELIST",
+            "order": 2,
+        },
+        {
+            "session_id": 12,
+            "user_id": 5,  # Alex Patel
+            "role": "PANELIST",
+            "order": 3,
+        },
+        # AMA - All speakers
+        {
+            "session_id": 13,
+            "user_id": 1,  # Demo User
+            "role": "MODERATOR",
+            "order": 1,
+        },
+        {
+            "session_id": 13,
+            "user_id": 2,  # Sarah Chen
+            "role": "SPEAKER",
+            "order": 2,
+        },
+        {
+            "session_id": 13,
+            "user_id": 3,  # Marcus Rodriguez
+            "role": "SPEAKER",
+            "order": 3,
+        },
+        {
+            "session_id": 13,
+            "user_id": 4,  # Emily Johnson
+            "role": "SPEAKER",
+            "order": 4,
+        },
+        # Closing Ceremony
+        {
+            "session_id": 25,
+            "user_id": 1,  # Demo User
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        {
+            "session_id": 25,
+            "user_id": 8,  # Chris Martinez (Atria)
+            "role": "SPEAKER",
+            "order": 2,
         },
     ]
 
@@ -443,10 +890,29 @@ def seed_chat_rooms():
             "room_type": "GLOBAL",
             "is_enabled": True,
         },
+        # Admin-only chat rooms
+        {
+            "id": 6,
+            "event_id": 1,
+            "session_id": None,
+            "name": "Staff Coordination",
+            "description": "Private room for event staff and organizers",
+            "room_type": "ADMIN",
+            "is_enabled": True,
+        },
+        {
+            "id": 7,
+            "event_id": 1,
+            "session_id": None,
+            "name": "Speaker Green Room",
+            "description": "Private space for speakers to coordinate",
+            "room_type": "ADMIN",
+            "is_enabled": True,
+        },
     ]
     
     # Add session-specific chat rooms
-    room_id = 6
+    room_id = 8
     sessions = seed_sessions()
     
     for session in sessions:
@@ -498,18 +964,125 @@ def seed_chat_messages():
             "user_id": 3,  # Marcus Rodriguez
             "content": "Hello from Stripe! Excited to share performance optimization techniques in my workshop.",
         },
-        # Messages in Q&A chat
         {
             "id": 4,
+            "room_id": 1,
+            "user_id": 5,  # Alex Patel
+            "content": "Hey all! Alex here, full stack dev. This is my first Atria conference!",
+        },
+        {
+            "id": 5,
+            "room_id": 1,
+            "user_id": 6,  # Jamie Wong
+            "content": "Welcome Alex! You're going to love it. Make sure to check out the Docker workshop.",
+        },
+        # Messages in Q&A chat
+        {
+            "id": 6,
             "room_id": 2,
             "user_id": 4,  # Emily Johnson
             "content": "I'll be answering questions about DevOps and automation here after my session.",
         },
         {
-            "id": 5,
+            "id": 7,
             "room_id": 2,
             "user_id": 1,  # Demo User
             "content": "For any logistics questions about the venue or schedule, feel free to ask here!",
+        },
+        {
+            "id": 8,
+            "room_id": 2,
+            "user_id": 7,  # Taylor Kim
+            "content": "Will the sessions be recorded? I have a conflict with two workshops I want to attend.",
+        },
+        {
+            "id": 9,
+            "room_id": 2,
+            "user_id": 1,  # Demo User
+            "content": "Yes Taylor! All sessions will be available on-demand for 30 days after the event.",
+        },
+        # Messages in Networking chat
+        {
+            "id": 10,
+            "room_id": 3,
+            "user_id": 8,  # Chris Martinez
+            "content": "Anyone interested in discussing cloud architecture over coffee? I'll be at the networking lounge.",
+        },
+        {
+            "id": 11,
+            "room_id": 3,
+            "user_id": 7,  # Taylor Kim
+            "content": "I'd love to join! I'm working on real-time data processing in the cloud.",
+        },
+        # Messages in Frontend chat
+        {
+            "id": 12,
+            "room_id": 4,
+            "user_id": 5,  # Alex Patel
+            "content": "Anyone else excited about the React performance workshop? I've been struggling with render optimization.",
+        },
+        {
+            "id": 13,
+            "room_id": 4,
+            "user_id": 3,  # Marcus Rodriguez
+            "content": "That's exactly what we'll cover! Bring your specific use cases and we can work through them.",
+        },
+        # Messages in DevOps chat
+        {
+            "id": 14,
+            "room_id": 5,
+            "user_id": 6,  # Jamie Wong
+            "content": "Looking forward to the Kubernetes workshop. We're migrating from Docker Swarm.",
+        },
+        {
+            "id": 15,
+            "room_id": 5,
+            "user_id": 4,  # Emily Johnson
+            "content": "Great timing! We'll cover migration strategies in the afternoon session.",
+        },
+        # Messages in Admin rooms
+        {
+            "id": 16,
+            "room_id": 6,  # Staff Coordination
+            "user_id": 1,  # Demo User
+            "content": "Team, please make sure all session rooms are ready 15 minutes before start time.",
+        },
+        {
+            "id": 17,
+            "room_id": 6,
+            "user_id": 8,  # Chris Martinez (Organizer)
+            "content": "Confirmed. AV team is doing final checks now.",
+        },
+        {
+            "id": 18,
+            "room_id": 7,  # Speaker Green Room
+            "user_id": 2,  # Sarah Chen
+            "content": "Is there a clicker available for the keynote presentation?",
+        },
+        {
+            "id": 19,
+            "room_id": 7,
+            "user_id": 1,  # Demo User
+            "content": "Yes Sarah, we have clickers at the AV desk. I'll have one ready for you.",
+        },
+        # Messages in session-specific chat (React Performance Workshop)
+        {
+            "id": 20,
+            "room_id": 8,  # First session chat room
+            "user_id": 3,  # Marcus Rodriguez
+            "content": "Welcome to the React Performance workshop! Feel free to ask questions here during the session.",
+        },
+        {
+            "id": 21,
+            "room_id": 8,
+            "user_id": 5,  # Alex Patel
+            "content": "Should we use React.memo for all components or just expensive ones?",
+        },
+        {
+            "id": 22,
+            "room_id": 8,
+            "user_id": 3,  # Marcus Rodriguez
+            "content": "Great question! Only use it for components that re-render often with the same props. I'll demonstrate this next.",
         },
     ]
 
@@ -654,6 +1227,160 @@ def seed_user_encryption_keys():
     ]
 
 
+def seed_sponsors():
+    return [
+        # Platinum Sponsors - Core technologies
+        {
+            "id": 1,
+            "event_id": 1,
+            "name": "React",
+            "description": "A JavaScript library for building user interfaces",
+            "website_url": "https://react.dev",
+            "logo_url": "https://ui-avatars.com/api/?name=React&size=256&background=61DAFB&color=000",
+            "tier_id": "platinum",
+            "is_active": True,
+            "featured": True,
+            "social_links": {"twitter": "https://twitter.com/reactjs", "linkedin": None},
+        },
+        {
+            "id": 2,
+            "event_id": 1,
+            "name": "PostgreSQL",
+            "description": "The world's most advanced open source database",
+            "website_url": "https://www.postgresql.org",
+            "logo_url": "https://ui-avatars.com/api/?name=PostgreSQL&size=256&background=336791&color=fff",
+            "tier_id": "platinum",
+            "is_active": True,
+            "featured": True,
+            "social_links": {"twitter": "https://twitter.com/postgresql", "linkedin": None},
+        },
+        # Gold Sponsors - Main frameworks
+        {
+            "id": 3,
+            "event_id": 1,
+            "name": "Flask",
+            "description": "A lightweight WSGI web application framework",
+            "website_url": "https://flask.palletsprojects.com",
+            "logo_url": "https://ui-avatars.com/api/?name=Flask&size=256&background=000&color=fff",
+            "tier_id": "gold",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": None, "linkedin": None},
+        },
+        {
+            "id": 4,
+            "event_id": 1,
+            "name": "Mantine",
+            "description": "Full-featured React components library",
+            "website_url": "https://mantine.dev",
+            "logo_url": "https://ui-avatars.com/api/?name=Mantine&size=256&background=339AF0&color=fff",
+            "tier_id": "gold",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": "https://twitter.com/mantinedev", "linkedin": None},
+        },
+        # Silver Sponsors - Key infrastructure
+        {
+            "id": 5,
+            "event_id": 1,
+            "name": "Socket.IO",
+            "description": "Bidirectional and low-latency communication",
+            "website_url": "https://socket.io",
+            "logo_url": "https://ui-avatars.com/api/?name=Socket.IO&size=256&background=010101&color=fff",
+            "tier_id": "silver",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": None, "linkedin": None},
+        },
+        {
+            "id": 6,
+            "event_id": 1,
+            "name": "SQLAlchemy",
+            "description": "The Python SQL Toolkit and ORM",
+            "website_url": "https://www.sqlalchemy.org",
+            "logo_url": "https://ui-avatars.com/api/?name=SQLAlchemy&size=256&background=D71E00&color=fff",
+            "tier_id": "silver",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": None, "linkedin": None},
+        },
+        # Bronze Sponsors - Supporting tools
+        {
+            "id": 7,
+            "event_id": 1,
+            "name": "MinIO",
+            "description": "High-performance object storage",
+            "website_url": "https://min.io",
+            "logo_url": "https://ui-avatars.com/api/?name=MinIO&size=256&background=C72E49&color=fff",
+            "tier_id": "bronze",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": "https://twitter.com/minio", "linkedin": None},
+        },
+        {
+            "id": 8,
+            "event_id": 1,
+            "name": "Vite",
+            "description": "Next generation frontend tooling",
+            "website_url": "https://vitejs.dev",
+            "logo_url": "https://ui-avatars.com/api/?name=Vite&size=256&background=646CFF&color=fff",
+            "tier_id": "bronze",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": "https://twitter.com/vite_js", "linkedin": None},
+        },
+        {
+            "id": 9,
+            "event_id": 1,
+            "name": "Marshmallow",
+            "description": "Object serialization/deserialization library",
+            "website_url": "https://marshmallow.readthedocs.io",
+            "logo_url": "https://ui-avatars.com/api/?name=Marshmallow&size=256&background=5F4B8B&color=fff",
+            "tier_id": "bronze",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": None, "linkedin": None},
+        },
+        {
+            "id": 10,
+            "event_id": 1,
+            "name": "Zod",
+            "description": "TypeScript-first schema validation",
+            "website_url": "https://zod.dev",
+            "logo_url": "https://ui-avatars.com/api/?name=Zod&size=256&background=3068B7&color=fff",
+            "tier_id": "bronze",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": None, "linkedin": None},
+        },
+        {
+            "id": 11,
+            "event_id": 1,
+            "name": "Swagger/OpenAPI",
+            "description": "API documentation and design tools",
+            "website_url": "https://swagger.io",
+            "logo_url": "https://ui-avatars.com/api/?name=Swagger&size=256&background=85EA2D&color=000",
+            "tier_id": "bronze",
+            "is_active": True,
+            "featured": False,
+            "social_links": {"twitter": "https://twitter.com/swaggerapi", "linkedin": None},
+        },
+        # Community Partner - Special recognition for Mozilla
+        {
+            "id": 12,
+            "event_id": 1,
+            "name": "Mozilla",
+            "description": "Building a better Internet through open source",
+            "website_url": "https://www.mozilla.org",
+            "logo_url": "https://ui-avatars.com/api/?name=Mozilla&size=256&background=FF6611&color=fff",
+            "tier_id": "community",
+            "is_active": True,
+            "featured": True,  # Featured because you like them!
+            "social_links": {"twitter": "https://twitter.com/mozilla", "linkedin": "https://linkedin.com/company/mozilla"},
+        },
+    ]
+
+
 # Make sure all functions are exported
 __all__ = [
     "seed_users",
@@ -663,6 +1390,7 @@ __all__ = [
     "seed_event_users",
     "seed_sessions",
     "seed_session_speakers",
+    "seed_sponsors",
     "seed_chat_rooms",
     "seed_chat_messages",
     "seed_connections",

--- a/frontend/src/pages/Sponsors/SponsorsList/SponsorCard/index.jsx
+++ b/frontend/src/pages/Sponsors/SponsorsList/SponsorCard/index.jsx
@@ -3,16 +3,17 @@ import { IconExternalLink, IconMail, IconPhone, IconBrandTwitter, IconBrandLinke
 import styles from './styles/index.module.css';
 
 export default function SponsorCard({ sponsor }) {
+  // Handle snake_case from API
   const { 
     name, 
     description, 
-    logoUrl, 
-    websiteUrl, 
-    tierName,
-    contactName,
-    contactEmail,
-    contactPhone,
-    socialLinks,
+    logo_url, 
+    website_url, 
+    tier_name,
+    contact_name,
+    contact_email,
+    contact_phone,
+    social_links,
     featured
   } = sponsor;
 
@@ -42,9 +43,9 @@ export default function SponsorCard({ sponsor }) {
       )}
 
       <Card.Section className={styles.logoSection}>
-        {logoUrl ? (
+        {logo_url ? (
           <Image 
-            src={logoUrl} 
+            src={logo_url} 
             alt={`${name} logo`}
             fit="contain"
             className={styles.logo}
@@ -57,7 +58,7 @@ export default function SponsorCard({ sponsor }) {
       </Card.Section>
 
       <Badge color="blue" variant="light" className={styles.tierBadge}>
-        {tierName}
+        {tier_name}
       </Badge>
 
       <Text fw={500} size="lg" mt="md" className={styles.sponsorName}>
@@ -71,8 +72,8 @@ export default function SponsorCard({ sponsor }) {
       )}
 
       <Group justify="space-between" mt="md" className={styles.actions}>
-        {websiteUrl && (
-          <Anchor href={websiteUrl} target="_blank" size="sm">
+        {website_url && (
+          <Anchor href={website_url} target="_blank" size="sm">
             <Group gap={4}>
               <IconExternalLink size={16} />
               Visit Website
@@ -80,9 +81,9 @@ export default function SponsorCard({ sponsor }) {
           </Anchor>
         )}
 
-        {socialLinks && (
+        {social_links && (
           <Group gap={8}>
-            {Object.entries(socialLinks).map(([platform, url]) => {
+            {Object.entries(social_links).map(([platform, url]) => {
               if (!url) return null;
               const Icon = socialIcons[platform];
               return (
@@ -103,21 +104,21 @@ export default function SponsorCard({ sponsor }) {
         )}
       </Group>
 
-      {(contactEmail || contactPhone) && (
+      {(contact_email || contact_phone) && (
         <Group gap="xs" mt="md" className={styles.contact}>
-          {contactEmail && (
-            <Anchor href={`mailto:${contactEmail}`} size="xs" c="dimmed">
+          {contact_email && (
+            <Anchor href={`mailto:${contact_email}`} size="xs" c="dimmed">
               <Group gap={4}>
                 <IconMail size={14} />
-                {contactName || 'Contact'}
+                {contact_name || 'Contact'}
               </Group>
             </Anchor>
           )}
-          {contactPhone && (
-            <Anchor href={`tel:${contactPhone}`} size="xs" c="dimmed">
+          {contact_phone && (
+            <Anchor href={`tel:${contact_phone}`} size="xs" c="dimmed">
               <Group gap={4}>
                 <IconPhone size={14} />
-                {contactPhone}
+                {contact_phone}
               </Group>
             </Anchor>
           )}

--- a/frontend/src/pages/Sponsors/SponsorsList/index.jsx
+++ b/frontend/src/pages/Sponsors/SponsorsList/index.jsx
@@ -3,9 +3,9 @@ import SponsorCard from './SponsorCard';
 import styles from './styles/index.module.css';
 
 export default function SponsorsList({ sponsors, tiers }) {
-  // Group sponsors by tier
+  // Group sponsors by tier (handle snake_case from API)
   const sponsorsByTier = sponsors.reduce((acc, sponsor) => {
-    const tierId = sponsor.tierId || 'other';
+    const tierId = sponsor.tier_id || 'other';
     if (!acc[tierId]) {
       acc[tierId] = [];
     }
@@ -13,8 +13,8 @@ export default function SponsorsList({ sponsors, tiers }) {
     return acc;
   }, {});
 
-  // Sort tiers by order
-  const sortedTiers = tiers.sort((a, b) => a.order - b.order);
+  // Sort tiers by order (create a copy first to avoid mutating read-only array)
+  const sortedTiers = [...tiers].sort((a, b) => a.order - b.order);
 
   // Add "Other" tier at the end if there are sponsors without a tier
   const tiersToDisplay = [
@@ -28,8 +28,10 @@ export default function SponsorsList({ sponsors, tiers }) {
         const tiersSponsors = sponsorsByTier[tier.id];
         if (!tiersSponsors || tiersSponsors.length === 0) return null;
 
-        // Sort sponsors within tier by displayOrder
-        const sortedSponsors = tiersSponsors.sort((a, b) => a.displayOrder - b.displayOrder);
+        // Sort sponsors within tier by display_order (create a copy to avoid mutating)
+        const sortedSponsors = [...tiersSponsors].sort((a, b) => 
+          (a.display_order || 999) - (b.display_order || 999)
+        );
 
         return (
           <div key={tier.id} className={styles.tierSection}>

--- a/frontend/src/pages/Sponsors/index.jsx
+++ b/frontend/src/pages/Sponsors/index.jsx
@@ -52,8 +52,8 @@ export const SponsorsPage = () => {
     );
   }
 
-  // Filter to only show active sponsors
-  const activeSponsors = sponsors.filter(sponsor => sponsor.isActive !== false);
+  // Filter to only show active sponsors (handle snake_case from API)
+  const activeSponsors = sponsors.filter(sponsor => sponsor.is_active !== false);
 
   return (
     <Container size="xl" py="xl">


### PR DESCRIPTION
- Add company_name and title to EventUser model and schema
- Expand seed data with realistic 3-day conference agenda (25 sessions)
- Add 12 technology sponsors across different tiers (including Mozilla!)
- Add more users with proper roles and companies
- Enhance chat messages across all room types
- Fix sponsors page crash due to immutable array sorting
- Fix sponsor display by handling snake_case API responses
- Update event banner to use MinIO-hosted image
- Assign speakers to all sessions based on expertise

Breaking change: Frontend now expects snake_case from sponsors API