### PR TITLE
fix(session): add smooth slide-in animation for chat content

### DIFF
--- a/frontend/src/pages/Session/SessionChat/index.jsx
+++ b/frontend/src/pages/Session/SessionChat/index.jsx
@@ -54,7 +54,7 @@ export const SessionChat = ({ sessionId, isEnabled = true, onToggle }) => {
       )}
 
       {/* Expanded State - Show full chat */}
-      {isOpen && (
+      <div className={`${styles.chatContainer} ${isOpen ? styles.chatOpen : styles.chatClosed}`}>
         <Card className={styles.chatSidebar} p={0}>
           <SessionChatHeader
             sessionData={sessionData}
@@ -68,7 +68,7 @@ export const SessionChat = ({ sessionId, isEnabled = true, onToggle }) => {
             error={error}
           />
         </Card>
-      )}
+      </div>
     </>
   );
 };

--- a/frontend/src/pages/Session/SessionChat/styles/index.module.css
+++ b/frontend/src/pages/Session/SessionChat/styles/index.module.css
@@ -1,12 +1,31 @@
+.chatContainer {
+  width: 370px;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  overflow: hidden;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.chatContainer.chatClosed {
+  transform: translateX(370px);
+  opacity: 0;
+}
+
+.chatContainer.chatOpen {
+  transform: translateX(0);
+  opacity: 1;
+}
+
 .chatSidebar {
-  width: 100%;
+  width: 370px;
   height: 100%;
   display: flex;
   flex-direction: column;
   background: white;
   border-radius: var(--mantine-radius-md);
   border: 1px solid var(--mantine-color-gray-2);
-  transition: all 0.3s ease;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }

--- a/frontend/src/pages/Session/styles/index.module.css
+++ b/frontend/src/pages/Session/styles/index.module.css
@@ -25,15 +25,9 @@
   height: calc(100vh - 200px);
   padding-top: 16px;
   overflow: hidden;
-  transition: all 0.3s ease;
   display: flex;
   align-items: flex-start;
-  justify-content: flex-end;
-}
-
-/* When chat is closed, wrapper becomes narrow */
-.chatClosed .chatWrapper {
-  width: 60px;
+  justify-content: center;
 }
 
 .floatingChatButton {


### PR DESCRIPTION
- Chat content slides in from right while grid column expands
- Prevents text reflow and squishing during animation
- Synchronized 0.3s transitions for both grid and content
- Content maintains fixed 370px width throughout animation