### PR TITLE
feat: integrate GREEN_ROOM chat type in frontend networking area

### DIFF
--- a/frontend/src/pages/Networking/ChatArea/styles/index.module.css
+++ b/frontend/src/pages/Networking/ChatArea/styles/index.module.css
@@ -72,13 +72,33 @@
   justify-content: center;
 }
 
-.adminTab {
-  color: var(--mantine-color-red-7);
+.tabContent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.adminTab[data-active="true"] {
-  border-bottom-color: var(--mantine-color-red-6);
-  color: var(--mantine-color-red-7);
+/* Modern squared role badges matching PersonCard styling */
+.roomTypeLabel {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  line-height: 1.2;
+}
+
+.adminLabel {
+  background-color: var(--mantine-color-grape-1);
+  color: var(--mantine-color-grape-7);
+}
+
+.speakerLabel {
+  background-color: var(--mantine-color-blue-1);
+  color: var(--mantine-color-blue-7);
 }
 
 .restricted {


### PR DESCRIPTION
- Update backend chat room route to properly filter room types based on user permissions
- Add GREEN_ROOM (Speaker Green Room) support with microphone icon in frontend
- Replace red Mantine Badge with custom styled labels matching PersonCard design
- Fix chat rooms not displaying after service implementation change
- Ensure proper pagination response format for frontend compatibility

Changes:
- Backend: Use paginate helper and filter room types in query
- Frontend: Add getRoomIcon and getRoomTypeLabel functions
- Frontend: Style room type labels with grape (admin) and blue (speaker) colors
- Frontend: Display "Speakers" label for GREEN_ROOM, "Admin" for ADMIN rooms


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 license and I agree to the Contributor License Agreement with SBTL LLC.*