### PR TITLE
fix(networking-section): update icebreaker badge styling to match des…

### DIFF
--- a/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/index.jsx
+++ b/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/index.jsx
@@ -306,6 +306,7 @@ const NetworkingSection = ({ event, eventId }) => {
                   <Badge 
                     variant="light" 
                     size="lg"
+                    radius="sm"
                     className={styles.countBadge}
                   >
                     {icebreakers.length} icebreaker{icebreakers.length !== 1 ? 's' : ''}

--- a/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/styles.module.css
@@ -98,9 +98,13 @@
 
 /* Count badge */
 .countBadge {
-  background: rgba(139, 92, 246, 0.08);
-  color: #8B5CF6;
-  border: 1px solid rgba(139, 92, 246, 0.15);
+  background: rgba(139, 92, 246, 0.08) !important;
+  color: #8B5CF6 !important;
+  border: 1px solid rgba(139, 92, 246, 0.15) !important;
+  border-radius: 6px !important;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
 /* Modal styles */


### PR DESCRIPTION
…ign system

- Add radius='sm' prop for 6px border-radius
- Override Mantine default blue color with purple theme using \!important
- Add proper padding and typography for consistency
- Ensures badge matches modern glassmorphism design patterns

