### PR TITLE
feat: update email templates with new design system

### DIFF
--- a/backend/atria/api/config.py
+++ b/backend/atria/api/config.py
@@ -78,7 +78,7 @@ APISPEC_SPEC = {
 # Email settings
 SMTP2GO_API_KEY = os.getenv("SMTP2GO_API_KEY")
 MAIL_DEFAULT_SENDER = os.getenv(
-    "MAIL_DEFAULT_SENDER", "atria-noreply@sbtl.dev"
+    "MAIL_DEFAULT_SENDER", "noreply@atria.gg"
 )
 FRONTEND_URL = os.getenv("FRONTEND_URL", "https://atria.gg")
 

--- a/backend/atria/api/email_templates/base.html
+++ b/backend/atria/api/email_templates/base.html
@@ -4,111 +4,129 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Atria{% endblock %}</title>
-    <style>
-        /* Email-safe CSS */
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 0;
-            background-color: #f4f4f4;
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #64748b; margin: 0; padding: 0; background-color: #fbfaff;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #fbfaff;">
+        <tr>
+            <td align="center" style="padding: 20px 0;">
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="max-width: 600px; margin: 0 auto;">
+                    <tr>
+                        <td>
+                            <!-- Email Container with Glass Effect -->
+                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #ffffff; border-radius: 12px; box-shadow: 0 4px 20px rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.06); overflow: hidden;">
+                                <!-- Header -->
+                                <tr>
+                                    <td style="background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); padding: 40px 30px; text-align: center; border-radius: 12px 12px 0 0;">
+                                        <h1 style="margin: 0; font-size: 32px; font-weight: 300; color: #ffffff; letter-spacing: -0.02em;">atria</h1>
+                                        {% block header_subtitle %}
+                                        <p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Event Management & Networking Platform</p>
+                                        {% endblock %}
+                                    </td>
+                                </tr>
+                                
+                                <!-- Body -->
+                                <tr>
+                                    <td style="padding: 40px 30px; background-color: #ffffff;">
+                                        {% block content %}{% endblock %}
+                                    </td>
+                                </tr>
+                                
+                                <!-- Footer -->
+                                <tr>
+                                    <td style="background-color: rgba(139, 92, 246, 0.04); padding: 30px; text-align: center; border-top: 1px solid rgba(139, 92, 246, 0.08);">
+                                        {% block footer %}
+                                        <p style="margin: 0 0 12px 0; font-size: 14px; color: #64748b;">
+                                            This email was sent by atria. If you have any questions, 
+                                            please contact our support team at <a href="mailto:support@atria.gg" style="color: #8b5cf6; text-decoration: none;">support@atria.gg</a>
+                                        </p>
+                                        <p style="margin: 0; font-size: 13px; color: #94a3b8;">
+                                            © {{ current_year }} atria. All rights reserved.
+                                        </p>
+                                        {% endblock %}
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    
+    <!-- Style definitions for content blocks -->
+    <style type="text/css">
+        /* These styles will be used inline in the actual email content */
+        /* Primary Button Style */
+        .button-primary {
+            /* inline: display: inline-block; padding: 14px 32px; margin: 20px 0; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2); */
         }
-        .email-container {
-            background-color: #ffffff;
-            margin: 20px auto;
-            padding: 0;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .email-header {
-            background-color: #000000;
-            color: #ffffff;
-            padding: 30px;
-            text-align: center;
-            border-radius: 8px 8px 0 0;
-        }
-        .email-header h1 {
-            margin: 0;
-            font-size: 24px;
-            font-weight: 600;
-        }
-        .email-body {
-            padding: 30px;
-        }
-        .email-footer {
-            background-color: #f8f9fa;
-            padding: 20px 30px;
-            text-align: center;
-            font-size: 14px;
-            color: #666;
-            border-radius: 0 0 8px 8px;
-        }
-        .button {
-            display: inline-block;
-            padding: 12px 30px;
-            margin: 20px 0;
-            background-color: #007bff;
-            color: #ffffff !important;
-            text-decoration: none;
-            border-radius: 5px;
-            font-weight: 500;
-        }
-        .button:hover {
-            background-color: #0056b3;
-        }
+        
+        /* Secondary Button Style */
         .button-secondary {
-            background-color: #6c757d;
+            /* inline: display: inline-block; padding: 14px 32px; margin: 20px 0; background-color: rgba(139, 92, 246, 0.08); color: #8b5cf6 !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; border: 1px solid rgba(139, 92, 246, 0.15); */
         }
-        .button-secondary:hover {
-            background-color: #545b62;
-        }
-        h2 {
-            color: #000;
-            margin-top: 0;
-        }
+        
+        /* Info Box Style (Glass Effect) */
         .info-box {
-            background-color: #f8f9fa;
-            border-left: 4px solid #007bff;
-            padding: 15px;
-            margin: 20px 0;
+            /* inline: background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0; */
         }
+        
+        /* Success Box Style */
+        .success-box {
+            /* inline: background-color: rgba(34, 197, 94, 0.04); border: 1px solid rgba(34, 197, 94, 0.08); border-left: 4px solid #16a34a; border-radius: 8px; padding: 20px; margin: 24px 0; */
+        }
+        
+        /* Warning Box Style */
+        .warning-box {
+            /* inline: background-color: rgba(245, 158, 11, 0.04); border: 1px solid rgba(245, 158, 11, 0.08); border-left: 4px solid #f59e0b; border-radius: 8px; padding: 20px; margin: 24px 0; */
+        }
+        
+        /* Danger Box Style */
+        .danger-box {
+            /* inline: background-color: rgba(220, 38, 38, 0.04); border: 1px solid rgba(220, 38, 38, 0.08); border-left: 4px solid #dc2626; border-radius: 8px; padding: 20px; margin: 24px 0; */
+        }
+        
+        /* Typography Styles */
+        .h2 {
+            /* inline: font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.3; */
+        }
+        
+        .h3 {
+            /* inline: font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 12px 0; line-height: 1.4; */
+        }
+        
         .text-muted {
-            color: #6c757d;
+            /* inline: color: #94a3b8; font-size: 14px; */
         }
-        ul {
-            padding-left: 20px;
+        
+        .text-primary {
+            /* inline: color: #8b5cf6; */
         }
-        li {
-            margin-bottom: 8px;
+        
+        /* List Styles */
+        .styled-list {
+            /* inline for ul: padding-left: 20px; margin: 16px 0; */
+            /* inline for li: margin-bottom: 10px; color: #64748b; */
+        }
+        
+        /* Divider */
+        .divider {
+            /* inline: border-top: 1px solid rgba(139, 92, 246, 0.08); margin: 32px 0; */
+        }
+        
+        /* Quote/Message Style */
+        .quote-block {
+            /* inline: background-color: rgba(139, 92, 246, 0.04); border-left: 3px solid #8b5cf6; padding: 16px 20px; margin: 20px 0; border-radius: 0 6px 6px 0; font-style: italic; color: #64748b; */
         }
     </style>
-</head>
-<body>
-    <div class="email-container">
-        <div class="email-header">
-            <h1>Atria</h1>
-            {% block header_subtitle %}
-            <p style="margin: 10px 0 0 0; opacity: 0.9;">Event Management & Networking Platform</p>
-            {% endblock %}
-        </div>
-        
-        <div class="email-body">
-            {% block content %}{% endblock %}
-        </div>
-        
-        <div class="email-footer">
-            {% block footer %}
-            <p>
-                This email was sent by Atria. If you have any questions, 
-                please contact our support team.
-            </p>
-            <p class="text-muted">
-                © {{ current_year }} Atria. All rights reserved.
-            </p>
-            {% endblock %}
-        </div>
-    </div>
 </body>
 </html>

--- a/backend/atria/api/email_templates/connection_request.html
+++ b/backend/atria/api/email_templates/connection_request.html
@@ -1,42 +1,60 @@
 {% extends "base.html" %}
 
-{% block title %}New connection request{% endblock %}
+{% block title %}New Connection Request{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Networking Request</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Someone wants to connect with you!</p>
 {% endblock %}
 
 {% block content %}
-<h2>{{ requester_name }} wants to connect with you!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 24px 0; line-height: 1.3;">{{ requester_name }} wants to connect!</h2>
 
-<div class="info-box">
-    <h3 style="margin-top: 0;">About {{ requester_name }}</h3>
-    <ul style="margin-bottom: 0;">
-        <li><strong>Name:</strong> {{ requester_name }}</li>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.4;">About {{ requester_name }}</h3>
+    <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Name:</strong> {{ requester_name }}
+            </td>
+        </tr>
         {% if requester_title %}
-        <li><strong>Title:</strong> {{ requester_title }}</li>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Title:</strong> {{ requester_title }}
+            </td>
+        </tr>
         {% endif %}
         {% if requester_company %}
-        <li><strong>Company:</strong> {{ requester_company }}</li>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Company:</strong> {{ requester_company }}
+            </td>
+        </tr>
         {% endif %}
         {% if event_title %}
-        <li><strong>Event:</strong> {{ event_title }}</li>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Event:</strong> {{ event_title }}
+            </td>
+        </tr>
         {% endif %}
-    </ul>
+    </table>
 </div>
 
-<h3>Their message to you:</h3>
-<div style="background-color: #f8f9fa; padding: 20px; border-radius: 5px; font-style: italic;">
+<h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 24px 0 12px 0; line-height: 1.4;">Their message to you:</h3>
+<div style="background-color: rgba(139, 92, 246, 0.04); border-left: 3px solid #8b5cf6; padding: 16px 20px; margin: 20px 0; border-radius: 0 6px 6px 0; font-style: italic; color: #64748b;">
     "{{ icebreaker_message }}"
 </div>
 
-<p>Would you like to connect? Once connected, you'll be able to chat directly with each other.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0;">Would you like to connect? Once connected, you'll be able to chat directly with each other.</p>
 
-<div style="text-align: center;">
-    <a href="{{ accept_url }}" class="button">View Request</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ accept_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">View Request</a>
 </div>
 
-<p class="text-muted" style="font-size: 14px;">
-    You can accept or decline this request by logging into your Atria account.
-</p>
+<div style="background-color: rgba(139, 92, 246, 0.02); border-radius: 6px; padding: 16px; text-align: center;">
+    <p style="color: #94a3b8; font-size: 14px; margin: 0;">
+        You can accept or decline this request by logging into your Atria account.
+    </p>
+</div>
 {% endblock %}

--- a/backend/atria/api/email_templates/email_verification.html
+++ b/backend/atria/api/email_templates/email_verification.html
@@ -3,43 +3,45 @@
 {% block title %}Verify Your Atria Account{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Almost there! Let's verify your email</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Almost there! Let's verify your email</p>
 {% endblock %}
 
 {% block content %}
-<h2>Welcome to Atria, {{ user_name }}!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.3;">Welcome to Atria, {{ user_name }}!</h2>
 
-<p>Thanks for signing up! You're just one click away from accessing all the features Atria has to offer.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">Thanks for signing up! You're just one click away from accessing all the features Atria has to offer.</p>
 
-<p>Please verify your email address by clicking the button below:</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">Please verify your email address by clicking the button below:</p>
 
-<div style="text-align: center;">
-    <a href="{{ verification_url }}" class="button">Verify Email Address</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ verification_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Verify Email Address</a>
 </div>
 
-<div class="info-box">
-    <p><strong>Why verify your email?</strong></p>
-    <ul>
-        <li>Secure your account and protect your data</li>
-        <li>Receive important event updates and invitations</li>
-        <li>Enable password recovery options</li>
-        <li>Connect with other attendees and speakers</li>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <p style="font-size: 16px; font-weight: 600; color: #1e293b; margin: 0 0 12px 0;">Why verify your email?</p>
+    <ul style="padding-left: 20px; margin: 16px 0;">
+        <li style="margin-bottom: 10px; color: #64748b;">Secure your account and protect your data</li>
+        <li style="margin-bottom: 10px; color: #64748b;">Receive important event updates and invitations</li>
+        <li style="margin-bottom: 10px; color: #64748b;">Enable password recovery options</li>
+        <li style="margin-bottom: 10px; color: #64748b;">Connect with other attendees and speakers</li>
     </ul>
 </div>
 
-<p class="text-muted">
-    This verification link will expire in <strong>{{ expires_in }}</strong>.
+<p style="color: #94a3b8; font-size: 14px; margin: 20px 0;">
+    This verification link will expire in <strong style="color: #8b5cf6;">{{ expires_in }}</strong>.
 </p>
 
-<p class="text-muted">
+<p style="color: #94a3b8; font-size: 14px; margin: 20px 0;">
     If you didn't create an account on Atria, please ignore this email.
 </p>
 
-<hr style="margin: 30px 0; border: none; border-top: 1px solid #e0e0e0;">
+<hr style="border: none; border-top: 1px solid rgba(139, 92, 246, 0.08); margin: 32px 0;">
 
-<p class="text-muted" style="font-size: 14px;">
-    <strong>Having trouble?</strong><br>
-    If the button above doesn't work, copy and paste this link into your browser:<br>
-    <span style="font-size: 12px; word-break: break-all;">{{ verification_url }}</span>
-</p>
+<div style="background-color: rgba(139, 92, 246, 0.02); border-radius: 6px; padding: 16px;">
+    <p style="color: #94a3b8; font-size: 14px; margin: 0;">
+        <strong style="color: #64748b;">Having trouble?</strong><br>
+        If the button above doesn't work, copy and paste this link into your browser:
+    </p>
+    <p style="font-size: 12px; word-break: break-all; color: #8b5cf6; margin: 12px 0 0 0;">{{ verification_url }}</p>
+</div>
 {% endblock %}

--- a/backend/atria/api/email_templates/event_invitation_existing.html
+++ b/backend/atria/api/email_templates/event_invitation_existing.html
@@ -3,37 +3,55 @@
 {% block title %}You're invited to {{ event_title }}{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Event Invitation</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Event Invitation</p>
 {% endblock %}
 
 {% block content %}
-<h2>You're invited to join {{ event_title }}!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 24px 0; line-height: 1.3;">You're invited to join {{ event_title }}!</h2>
 
-<p>Hi there,</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">Hi there,</p>
 
-<p>{{ inviter_name }} has invited you to join <strong>{{ event_title }}</strong> as a <strong>{{ role }}</strong>.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">{{ inviter_name }} has invited you to join <strong style="color: #8b5cf6;">{{ event_title }}</strong> as a <strong style="color: #8b5cf6;">{{ role }}</strong>.</p>
 
-<div class="info-box">
-    <h3 style="margin-top: 0;">Event Details</h3>
-    <ul style="margin-bottom: 0;">
-        <li><strong>Event:</strong> {{ event_title }}</li>
-        <li><strong>Company:</strong> {{ company_name }}</li>
-        <li><strong>Dates:</strong> {{ event_start_date }} - {{ event_end_date }}</li>
-        <li><strong>Your Role:</strong> {{ role }}</li>
-    </ul>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.4;">Event Details</h3>
+    <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Event:</strong> {{ event_title }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Company:</strong> {{ company_name }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Dates:</strong> {{ event_start_date }} - {{ event_end_date }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Your Role:</strong> {{ role }}
+            </td>
+        </tr>
+    </table>
 </div>
 
 {% if event_description %}
-<p>{{ event_description }}</p>
+<div style="background-color: rgba(139, 92, 246, 0.02); border-radius: 6px; padding: 16px; margin: 24px 0;">
+    <p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0;">{{ event_description }}</p>
+</div>
 {% endif %}
 
-<p>Since you already have an Atria account, you can accept this invitation with just one click!</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0;">Since you already have an Atria account, you can accept this invitation with just one click!</p>
 
-<div style="text-align: center;">
-    <a href="{{ invitation_url }}" class="button">Accept Invitation</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ invitation_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Accept Invitation</a>
 </div>
 
-<p class="text-muted" style="font-size: 14px;">
+<p style="color: #94a3b8; font-size: 14px; text-align: center; margin: 20px 0;">
     This invitation will expire in 7 days. If you don't want to join this event, 
     you can safely ignore this email.
 </p>

--- a/backend/atria/api/email_templates/event_invitation_new.html
+++ b/backend/atria/api/email_templates/event_invitation_new.html
@@ -3,46 +3,66 @@
 {% block title %}You're invited to {{ event_title }}{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Event Invitation</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Event Invitation</p>
 {% endblock %}
 
 {% block content %}
-<h2>You're invited to join {{ event_title }}!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 24px 0; line-height: 1.3;">You're invited to join {{ event_title }}!</h2>
 
-<p>Hi there,</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">Hi there,</p>
 
-<p>{{ inviter_name }} has invited you to join <strong>{{ event_title }}</strong> as a <strong>{{ role }}</strong>.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">{{ inviter_name }} has invited you to join <strong style="color: #8b5cf6;">{{ event_title }}</strong> as a <strong style="color: #8b5cf6;">{{ role }}</strong>.</p>
 
-<div class="info-box">
-    <h3 style="margin-top: 0;">Event Details</h3>
-    <ul style="margin-bottom: 0;">
-        <li><strong>Event:</strong> {{ event_title }}</li>
-        <li><strong>Company:</strong> {{ company_name }}</li>
-        <li><strong>Dates:</strong> {{ event_start_date }} - {{ event_end_date }}</li>
-        <li><strong>Your Role:</strong> {{ role }}</li>
-    </ul>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.4;">Event Details</h3>
+    <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Event:</strong> {{ event_title }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Company:</strong> {{ company_name }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Dates:</strong> {{ event_start_date }} - {{ event_end_date }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Your Role:</strong> {{ role }}
+            </td>
+        </tr>
+    </table>
 </div>
 
 {% if event_description %}
-<p>{{ event_description }}</p>
+<div style="background-color: rgba(139, 92, 246, 0.02); border-radius: 6px; padding: 16px; margin: 24px 0;">
+    <p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0;">{{ event_description }}</p>
+</div>
 {% endif %}
 
-<p>To accept this invitation, you'll need to create an Atria account. It only takes a minute!</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0;">To accept this invitation, you'll need to create an Atria account. It only takes a minute!</p>
 
-<div style="text-align: center;">
-    <a href="{{ invitation_url }}" class="button">Accept Invitation & Create Account</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ invitation_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Accept Invitation & Create Account</a>
 </div>
 
-<p class="text-muted" style="font-size: 14px;">
+<p style="color: #94a3b8; font-size: 14px; text-align: center; margin: 20px 0;">
     This invitation will expire in 7 days. If you don't want to join this event, 
     you can safely ignore this email.
 </p>
 
-<hr style="border: none; border-top: 1px solid #e0e0e0; margin: 30px 0;">
+<hr style="border: none; border-top: 1px solid rgba(139, 92, 246, 0.08); margin: 32px 0;">
 
-<p class="text-muted" style="font-size: 14px;">
-    <strong>What is Atria?</strong><br>
-    Atria is an event management and networking platform that helps you connect 
-    with other attendees, participate in sessions, and make the most of your event experience.
-</p>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <p style="color: #1e293b; font-size: 16px; font-weight: 600; margin: 0 0 12px 0;">What is Atria?</p>
+    <p style="color: #64748b; font-size: 14px; margin: 0; line-height: 1.6;">
+        Atria is an event management and networking platform that helps you connect 
+        with other attendees, participate in sessions, and make the most of your event experience.
+    </p>
+</div>
 {% endblock %}

--- a/backend/atria/api/email_templates/organization_invitation_existing.html
+++ b/backend/atria/api/email_templates/organization_invitation_existing.html
@@ -3,38 +3,46 @@
 {% block title %}You're invited to join {{ organization_name }}{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Organization Invitation</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Organization Invitation</p>
 {% endblock %}
 
 {% block content %}
-<h2>You're invited to join {{ organization_name }}!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 24px 0; line-height: 1.3;">You're invited to join {{ organization_name }}!</h2>
 
-<p>Hi there,</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">Hi there,</p>
 
-<p>{{ inviter_name }} has invited you to join <strong>{{ organization_name }}</strong> as a <strong>{{ role }}</strong>.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">{{ inviter_name }} has invited you to join <strong style="color: #8b5cf6;">{{ organization_name }}</strong> as a <strong style="color: #8b5cf6;">{{ role }}</strong>.</p>
 
-<div class="info-box">
-    <h3 style="margin-top: 0;">Organization Details</h3>
-    <ul style="margin-bottom: 0;">
-        <li><strong>Organization:</strong> {{ organization_name }}</li>
-        <li><strong>Your Role:</strong> {{ role }}</li>
-    </ul>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.4;">Organization Details</h3>
+    <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Organization:</strong> {{ organization_name }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Your Role:</strong> {{ role }}
+            </td>
+        </tr>
+    </table>
 </div>
 
-<p>As a member of {{ organization_name }}, you'll be able to:</p>
-<ul>
-    <li>Create and manage events</li>
-    <li>Collaborate with other organization members</li>
-    <li>Access organization-wide resources and tools</li>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0 12px 0;">As a member of {{ organization_name }}, you'll be able to:</p>
+<ul style="padding-left: 20px; margin: 16px 0 24px 0;">
+    <li style="margin-bottom: 10px; color: #64748b;">Create and manage events</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Collaborate with other organization members</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Access organization-wide resources and tools</li>
 </ul>
 
-<p>Since you already have an Atria account, you can accept this invitation with just one click!</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0;">Since you already have an Atria account, you can accept this invitation with just one click!</p>
 
-<div style="text-align: center;">
-    <a href="{{ invitation_url }}" class="button">Accept Invitation</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ invitation_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Accept Invitation</a>
 </div>
 
-<p class="text-muted" style="font-size: 14px;">
+<p style="color: #94a3b8; font-size: 14px; text-align: center; margin: 20px 0;">
     This invitation will expire in 7 days. If you don't want to join this organization, 
     you can safely ignore this email.
 </p>

--- a/backend/atria/api/email_templates/organization_invitation_new.html
+++ b/backend/atria/api/email_templates/organization_invitation_new.html
@@ -3,41 +3,51 @@
 {% block title %}You're invited to join {{ organization_name }}{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Organization Invitation</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Organization Invitation</p>
 {% endblock %}
 
 {% block content %}
-<h2>You're invited to join {{ organization_name }}!</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 24px 0; line-height: 1.3;">You're invited to join {{ organization_name }}!</h2>
 
-<p>Hi there,</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">Hi there,</p>
 
-<p>{{ inviter_name }} has invited you to join <strong>{{ organization_name }}</strong> as a <strong>{{ role }}</strong>.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">{{ inviter_name }} has invited you to join <strong style="color: #8b5cf6;">{{ organization_name }}</strong> as a <strong style="color: #8b5cf6;">{{ role }}</strong>.</p>
 
-<div class="info-box">
-    <h3 style="margin-top: 0;">Organization Details</h3>
-    <ul style="margin-bottom: 0;">
-        <li><strong>Organization:</strong> {{ organization_name }}</li>
-        <li><strong>Your Role:</strong> {{ role }}</li>
-    </ul>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.4;">Organization Details</h3>
+    <table cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Organization:</strong> {{ organization_name }}
+            </td>
+        </tr>
+        <tr>
+            <td style="padding: 8px 0; color: #64748b;">
+                <strong style="color: #8b5cf6;">Your Role:</strong> {{ role }}
+            </td>
+        </tr>
+    </table>
 </div>
 
-<p>As a member of {{ organization_name }}, you'll be able to:</p>
-<ul>
-    <li>Create and manage events</li>
-    <li>Collaborate with other organization members</li>
-    <li>Access organization-wide resources and tools</li>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0 12px 0;">As a member of {{ organization_name }}, you'll be able to:</p>
+<ul style="padding-left: 20px; margin: 16px 0 24px 0;">
+    <li style="margin-bottom: 10px; color: #64748b;">Create and manage events</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Collaborate with other organization members</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Access organization-wide resources and tools</li>
 </ul>
 
-<p>To accept this invitation, you'll need to create a free Atria account. It only takes a minute!</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0;">To accept this invitation, you'll need to create a free Atria account. It only takes a minute!</p>
 
-<div style="text-align: center;">
-    <a href="{{ invitation_url }}" class="button">Create Account & Accept Invitation</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ invitation_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Create Account & Accept Invitation</a>
 </div>
 
-<h3>What is Atria?</h3>
-<p>Atria is a comprehensive event management and networking platform that helps organizations create memorable events and foster meaningful connections between attendees.</p>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 20px; margin: 32px 0;">
+    <h3 style="font-size: 18px; font-weight: 600; color: #1e293b; margin: 0 0 12px 0; line-height: 1.4;">What is Atria?</h3>
+    <p style="font-size: 14px; color: #64748b; margin: 0; line-height: 1.6;">Atria is a comprehensive event management and networking platform that helps organizations create memorable events and foster meaningful connections between attendees.</p>
+</div>
 
-<p class="text-muted" style="font-size: 14px;">
+<p style="color: #94a3b8; font-size: 14px; text-align: center; margin: 20px 0;">
     This invitation will expire in 7 days. If you don't want to join this organization, 
     you can safely ignore this email.
 </p>

--- a/backend/atria/api/email_templates/password_reset.html
+++ b/backend/atria/api/email_templates/password_reset.html
@@ -3,43 +3,47 @@
 {% block title %}Reset Your Atria Password{% endblock %}
 
 {% block header_subtitle %}
-<p style="margin: 10px 0 0 0; opacity: 0.9;">Password Reset Request</p>
+<p style="margin: 12px 0 0 0; color: rgba(255, 255, 255, 0.9); font-size: 16px; font-weight: 400;">Password Reset Request</p>
 {% endblock %}
 
 {% block content %}
-<h2>Hi {{ user_name }},</h2>
+<h2 style="font-size: 24px; font-weight: 600; color: #1e293b; margin: 0 0 16px 0; line-height: 1.3;">Hi {{ user_name }},</h2>
 
-<p>We received a request to reset the password for your Atria account.</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 20px 0;">We received a request to reset the password for your Atria account.</p>
 
-<p>If you requested this password reset, click the button below to create a new password:</p>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 0 0 24px 0;">If you requested this password reset, click the button below to create a new password:</p>
 
-<div style="text-align: center;">
-    <a href="{{ reset_url }}" class="button">Reset Password</a>
+<div style="text-align: center; margin: 32px 0;">
+    <a href="{{ reset_url }}" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%); color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 500; font-size: 16px; box-shadow: 0 2px 8px rgba(139, 92, 246, 0.2);">Reset Password</a>
 </div>
 
-<div class="info-box" style="background-color: #fff3cd; border-left-color: #ffc107;">
-    <p><strong>⚠️ Security Notice</strong></p>
-    <p>This password reset link will expire in <strong>{{ expires_in }}</strong> for your security.</p>
-    <p>If you didn't request this password reset, you can safely ignore this email. Your password won't be changed.</p>
+<div style="background-color: rgba(245, 158, 11, 0.04); border: 1px solid rgba(245, 158, 11, 0.08); border-left: 4px solid #f59e0b; border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <p style="font-size: 16px; font-weight: 600; color: #1e293b; margin: 0 0 12px 0;">⚠️ Security Notice</p>
+    <p style="font-size: 14px; color: #64748b; margin: 0 0 8px 0; line-height: 1.6;">This password reset link will expire in <strong style="color: #f59e0b;">{{ expires_in }}</strong> for your security.</p>
+    <p style="font-size: 14px; color: #64748b; margin: 0; line-height: 1.6;">If you didn't request this password reset, you can safely ignore this email. Your password won't be changed.</p>
 </div>
 
-<p>After resetting your password, you'll be able to:</p>
-<ul>
-    <li>Access your events and connections</li>
-    <li>Manage your organization settings</li>
-    <li>Connect with other attendees</li>
-    <li>Join event sessions and chat rooms</li>
+<p style="font-size: 16px; color: #64748b; line-height: 1.6; margin: 24px 0 12px 0;">After resetting your password, you'll be able to:</p>
+<ul style="padding-left: 20px; margin: 16px 0;">
+    <li style="margin-bottom: 10px; color: #64748b;">Access your events and connections</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Manage your organization settings</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Connect with other attendees</li>
+    <li style="margin-bottom: 10px; color: #64748b;">Join event sessions and chat rooms</li>
 </ul>
 
-<hr style="margin: 30px 0; border: none; border-top: 1px solid #e0e0e0;">
+<hr style="border: none; border-top: 1px solid rgba(139, 92, 246, 0.08); margin: 32px 0;">
 
-<p class="text-muted" style="font-size: 14px;">
-    <strong>Having trouble?</strong><br>
-    If the button above doesn't work, copy and paste this link into your browser:<br>
-    <span style="font-size: 12px; word-break: break-all;">{{ reset_url }}</span>
-</p>
+<div style="background-color: rgba(139, 92, 246, 0.02); border-radius: 6px; padding: 16px; margin: 20px 0;">
+    <p style="color: #94a3b8; font-size: 14px; margin: 0;">
+        <strong style="color: #64748b;">Having trouble?</strong><br>
+        If the button above doesn't work, copy and paste this link into your browser:
+    </p>
+    <p style="font-size: 12px; word-break: break-all; color: #8b5cf6; margin: 12px 0 0 0;">{{ reset_url }}</p>
+</div>
 
-<p class="text-muted" style="font-size: 14px;">
-    <strong>Security tip:</strong> Never share your password or this reset link with anyone. Atria staff will never ask for your password.
-</p>
+<div style="background-color: rgba(139, 92, 246, 0.04); border: 1px solid rgba(139, 92, 246, 0.08); border-radius: 8px; padding: 16px; margin: 24px 0;">
+    <p style="color: #64748b; font-size: 14px; margin: 0; line-height: 1.6;">
+        <strong style="color: #8b5cf6;">🔒 Security tip:</strong> Never share your password or this reset link with anyone. Atria staff will never ask for your password.
+    </p>
+</div>
 {% endblock %}

--- a/backend/atria/api/services/email.py
+++ b/backend/atria/api/services/email.py
@@ -35,7 +35,7 @@ class ThreadedEmailBackend(EmailBackend):
         from flask import current_app
         app = current_app._get_current_object()
         smtp2go_api_key = current_app.config.get('SMTP2GO_API_KEY')
-        mail_sender = current_app.config.get('MAIL_DEFAULT_SENDER', 'noreply@atria.app')
+        mail_sender = current_app.config.get('MAIL_DEFAULT_SENDER', 'noreply@atria.gg')
         
         thread = Thread(
             target=self._send_sync,


### PR DESCRIPTION
- Apply glassmorphism design philosophy to all email templates
- Update color scheme to use primary purple (#8b5cf6) throughout
- Change header branding from "Atria" to lowercase "atria"
- Update email addresses:
  - Support email: support@sbtl.ai → support@atria.gg
  - Sender email: atria-noreply@sbtl.dev → noreply@atria.gg
- Implement email-safe glass effects with subtle backgrounds and borders
- Improve typography hierarchy and spacing per design guide
- Add gradient buttons with shadows for better visual appeal
- Fix email service fallback address (was using non-owned atria.app domain)

