### PR TITLE
feat: increase image upload limit to 10MB and improve error messaging

### DIFF
--- a/backend/atria/api/api/routes/uploads.py
+++ b/backend/atria/api/api/routes/uploads.py
@@ -29,7 +29,7 @@ class ImageUploadResource(MethodView):
     @blp.response(201, ImageUploadResponseSchema)
     @blp.doc(
         summary="Upload an image",
-        description="Upload an image file to storage. Supports JPEG, PNG, GIF, and WebP formats up to 5MB.",
+        description="Upload an image file to storage. Supports JPEG, PNG, GIF, and WebP formats up to 10MB.",
         responses={
             400: {"description": "Invalid file or validation error"},
             401: {"description": "Authentication required"},

--- a/backend/atria/api/services/storage.py
+++ b/backend/atria/api/services/storage.py
@@ -23,7 +23,7 @@ class StorageService:
     """Service for handling file storage with MinIO using three-tier bucket structure."""
     
     ALLOWED_IMAGE_EXTENSIONS = {'jpg', 'jpeg', 'png', 'gif', 'webp'}
-    MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB
+    MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB
     
     # Max dimensions by context
     MAX_DIMENSIONS = {

--- a/frontend/src/pages/EventAdmin/EventSettings/BrandingSection/index.jsx
+++ b/frontend/src/pages/EventAdmin/EventSettings/BrandingSection/index.jsx
@@ -101,9 +101,10 @@ const BrandingSection = ({ event, eventId }) => {
         color: 'green',
       });
     } catch (error) {
+      const errorMessage = error.data?.message || error.message || `Failed to upload ${field === 'logo_url' ? 'logo' : 'hero image'}`;
       notifications.show({
         title: 'Error',
-        message: `Failed to upload ${field === 'logo_url' ? 'logo' : 'hero image'}`,
+        message: errorMessage,
         color: 'red',
       });
     }


### PR DESCRIPTION
- Increase MAX_IMAGE_SIZE from 5MB to 10MB in storage service
- Update API documentation to reflect new 10MB limit
- Fix frontend error handling to display actual backend error messages
  - Now shows specific errors like "File too large. Maximum size: 10MB"
  - Previously only showed generic "Failed to upload" message

