### PR TITLE
fix: improve Firefox scroll performance on landing page

### DIFF
--- a/frontend/src/pages/Landing/App.jsx
+++ b/frontend/src/pages/Landing/App.jsx
@@ -23,7 +23,7 @@ gsap.registerPlugin(useGSAP, ScrollTrigger, ScrambleTextPlugin);
 // Configure ScrollTrigger for better performance
 ScrollTrigger.config({
   limitCallbacks: true, // Improves performance by limiting callback frequency
-  syncInterval: 100, // Throttle scroll sync (default is 20)
+  syncInterval: 20, // Default value for smooth scrolling
   autoRefreshEvents: 'visibilitychange,DOMContentLoaded,load', // When to auto-refresh
 });
 

--- a/frontend/src/pages/Landing/OpenSourceSplit/index.jsx
+++ b/frontend/src/pages/Landing/OpenSourceSplit/index.jsx
@@ -74,6 +74,7 @@ const OpenSourceSplit = () => {
         anticipatePin: 1,
         invalidateOnRefresh: true,
         fastScrollEnd: true,
+        preventOverlaps: true,
       }
     })
     
@@ -197,10 +198,13 @@ const OpenSourceSplit = () => {
                   )}
                 </div>
 
-                <motion.button 
+                <motion.a 
+                  href={panel.type === 'opensource' ? 'https://github.com/thesubtleties/atria' : 'mailto:steven@sbtl.dev'}
                   className={`${styles.ctaButton} ${panel.type === 'enterprise' ? styles.enterpriseButton : ''}`}
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
+                  target={panel.type === 'opensource' ? '_blank' : undefined}
+                  rel={panel.type === 'opensource' ? 'noopener noreferrer' : undefined}
                 >
                   {panel.ctaIcon === 'github' && (
                     <svg className={styles.githubIcon} width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
@@ -208,7 +212,7 @@ const OpenSourceSplit = () => {
                     </svg>
                   )}
                   {panel.cta}
-                </motion.button>
+                </motion.a>
               </div>
             </div>
             

--- a/frontend/src/pages/Landing/PlatformDemo/index.jsx
+++ b/frontend/src/pages/Landing/PlatformDemo/index.jsx
@@ -199,6 +199,8 @@ const PlatformDemo = () => {
         pin: true,
         pinSpacing: true,
         invalidateOnRefresh: true,
+        fastScrollEnd: true,
+        preventOverlaps: true,
         onEnter: () => {
           // Reset to first card when entering from above
           currentIndexRef.current = 0


### PR DESCRIPTION
- Reduce ScrollTrigger syncInterval from 100ms to 20ms for smoother scrolling
- Add preventOverlaps to horizontal scroll sections to prevent animation conflicts
- Add fastScrollEnd to PlatformDemo for better fast-scroll handling
- Update OpenSourceSplit GitHub button to link to repo
- Add mailto link to Talk to Sales button

