### PR TITLE
fix: Standardize action menu styling across admin tables

### DIFF
--- a/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomRow/index.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Table, Switch, ActionIcon, Menu, Text, Indicator } from '@mantine/core';
-import { IconDotsVertical, IconEdit, IconTrash, IconMessages } from '@tabler/icons-react';
+import { IconDots, IconEdit, IconTrash, IconMessages } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
@@ -105,20 +105,26 @@ const ChatRoomRow = ({ room, color, onEdit, isTableRow }) => {
         </div>
       </Table.Td>
       <Table.Td style={{ textAlign: 'center' }}>
-        <Menu position="bottom-end" withArrow>
+        <Menu 
+          shadow="md" 
+          width={200} 
+          position="bottom-end"
+        >
           <Menu.Target>
-            <ActionIcon variant="subtle">
-              <IconDotsVertical size={16} />
+            <ActionIcon variant="subtle" color="gray" className={styles.actionIcon}>
+              <IconDots size={16} />
             </ActionIcon>
           </Menu.Target>
-          <Menu.Dropdown>
+          <Menu.Dropdown className={styles.menuDropdown}>
             <Menu.Item 
+              className={styles.menuItem}
               leftSection={<IconMessages size={14} />}
               onClick={handleViewChat}
             >
               View Chat
             </Menu.Item>
             <Menu.Item 
+              className={styles.menuItem}
               leftSection={<IconEdit size={14} />}
               onClick={() => onEdit(room)}
             >
@@ -126,6 +132,7 @@ const ChatRoomRow = ({ room, color, onEdit, isTableRow }) => {
             </Menu.Item>
             <Menu.Divider />
             <Menu.Item 
+              className={styles.menuItem}
               leftSection={<IconTrash size={14} />}
               color="red"
               onClick={handleDelete}

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorRow/index.jsx
@@ -176,9 +176,13 @@ const SponsorRow = ({
         </ActionIcon>
       </Table.Td>
       <Table.Td className={styles.actionsCell}>
-        <Menu position="bottom-end">
+        <Menu 
+          shadow="md" 
+          width={200} 
+          position="bottom-end"
+        >
           <Menu.Target>
-            <ActionIcon variant="subtle" className={styles.actionButton}>
+            <ActionIcon variant="subtle" color="gray" className={styles.actionIcon}>
               <IconDots size={16} />
             </ActionIcon>
           </Menu.Target>


### PR DESCRIPTION
- Update ChatRoomRow:
  - Change from vertical dots (IconDotsVertical) to horizontal dots (IconDots)
  - Add consistent Menu props (shadow, width, position)
  - Add gray color and actionIcon class to match other components
  - Add menuItem and menuDropdown classes for consistency

- Update SponsorRow:
  - Add Menu shadow and width props to match AttendeeRow
  - Change actionButton class to actionIcon for consistency
  - Add gray color to ActionIcon

All admin table rows now have consistent three-dot menu styling with horizontal dots and matching dropdown appearance.

