### PR TITLE
feat: Add moderation capabilities to SessionChat

### DIFF
--- a/frontend/src/pages/Organizations/OrganizationDashboard/OrganizationHeader/index.jsx
+++ b/frontend/src/pages/Organizations/OrganizationDashboard/OrganizationHeader/index.jsx
@@ -128,7 +128,8 @@ const OrganizationHeader = ({ organization, currentUserRole }) => {
           </div>
         </div>
 
-        <div className={styles.headerActions}>
+        {/* Settings button - commented out for now, will add later */}
+        {/* <div className={styles.headerActions}>
           {canViewSettings && (
             <ActionIcon
               size="lg"
@@ -140,7 +141,7 @@ const OrganizationHeader = ({ organization, currentUserRole }) => {
               <IconSettings size={22} />
             </ActionIcon>
           )}
-        </div>
+        </div> */}
       </div>
 
       {organization.description && (

--- a/frontend/src/pages/Session/SessionChat/ChatRoomView/index.jsx
+++ b/frontend/src/pages/Session/SessionChat/ChatRoomView/index.jsx
@@ -8,7 +8,8 @@ export function ChatRoomView({
   inputValue, 
   onInputChange, 
   onSendMessage,
-  isActive 
+  isActive,
+  canModerate 
 }) {
   if (!room) {
     return (
@@ -27,6 +28,7 @@ export function ChatRoomView({
         onInputChange={onInputChange}
         onSendMessage={onSendMessage}
         isActive={isActive}
+        canModerate={canModerate}
       />
     </div>
   );

--- a/frontend/src/pages/Session/SessionChat/ChatTabs/index.jsx
+++ b/frontend/src/pages/Session/SessionChat/ChatTabs/index.jsx
@@ -9,7 +9,8 @@ export function ChatTabs({
   chatRooms, 
   sessionData,
   isLoading,
-  error 
+  error,
+  canModerate 
 }) {
   const [activeTab, setActiveTab] = useState('public');
   const [inputValues, setInputValues] = useState({});
@@ -108,6 +109,7 @@ export function ChatTabs({
           onInputChange={(value) => handleInputChange(publicRoom?.id, value)}
           onSendMessage={() => handleSendMessage(publicRoom?.id)}
           isActive={activeTab === 'public'}
+          canModerate={canModerate}
         />
       </Tabs.Panel>
 
@@ -120,6 +122,7 @@ export function ChatTabs({
             onInputChange={(value) => handleInputChange(backstageRoom.id, value)}
             onSendMessage={() => handleSendMessage(backstageRoom.id)}
             isActive={activeTab === 'backstage'}
+            canModerate={canModerate}
           />
         </Tabs.Panel>
       )}

--- a/frontend/src/pages/Session/SessionChat/index.jsx
+++ b/frontend/src/pages/Session/SessionChat/index.jsx
@@ -3,6 +3,7 @@ import { Card, ActionIcon, Transition } from '@mantine/core';
 import { IconMessage } from '@tabler/icons-react';
 import { useGetSessionChatRoomsQuery } from '@/app/features/chat/api';
 import { useGetSessionQuery } from '@/app/features/sessions/api';
+import { useGetEventQuery } from '@/app/features/events/api';
 import {
   joinSessionChatRooms,
   leaveSessionChatRooms,
@@ -16,6 +17,9 @@ export const SessionChat = ({ sessionId, isEnabled = true, isOpen = true, onTogg
 
   const sessionIdNum = sessionId ? parseInt(sessionId) : null;
   const { data: sessionData } = useGetSessionQuery(sessionIdNum);
+  const { data: eventData } = useGetEventQuery(sessionData?.event_id, {
+    skip: !sessionData?.event_id,
+  });
   const {
     data: chatRooms,
     isLoading,
@@ -23,6 +27,9 @@ export const SessionChat = ({ sessionId, isEnabled = true, isOpen = true, onTogg
   } = useGetSessionChatRoomsQuery(sessionIdNum, {
     skip: !sessionIdNum || !isEnabled,
   });
+
+  // Determine if current user can moderate messages
+  const canModerate = eventData?.user_role === 'ADMIN' || eventData?.user_role === 'ORGANIZER';
 
   // Join/leave session chat rooms via socket
   useEffect(() => {
@@ -50,6 +57,7 @@ export const SessionChat = ({ sessionId, isEnabled = true, isOpen = true, onTogg
           sessionData={sessionData}
           isLoading={isLoading}
           error={error}
+          canModerate={canModerate}
         />
       </Card>
     </div>


### PR DESCRIPTION
- Import useGetEventQuery to access event user role data
- Calculate canModerate based on ADMIN/ORGANIZER roles
- Pass canModerate prop through SessionChat -> ChatTabs -> ChatRoomView -> ChatRoom
- Ensures session chats have same moderation features as networking chat rooms
- Deleted messages now properly show for admins/organizers in session context
- Also commented out organization settings gear icon for future implementation

