### PR TITLE
fix: Replace not-allowed cursor with default cursor for disabled elem…

### DIFF
--- a/frontend/src/pages/Agenda/DateNavigation/styles/index.module.css
+++ b/frontend/src/pages/Agenda/DateNavigation/styles/index.module.css
@@ -63,7 +63,7 @@
 
 .navButton:disabled {
   color: rgba(0, 0, 0, 0.3);
-  cursor: not-allowed;
+  cursor: default;
   opacity: 0.5;
 }
 

--- a/frontend/src/pages/Landing/PlatformDemo/PlatformDemo.module.css
+++ b/frontend/src/pages/Landing/PlatformDemo/PlatformDemo.module.css
@@ -623,7 +623,7 @@
 
 .chatInputField:disabled {
   background: rgba(255, 255, 255, 0.5);
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .chatSendBtn {

--- a/frontend/src/pages/Landing/PlatformDemo/components/NetworkingDemo/NetworkingDemo.module.css
+++ b/frontend/src/pages/Landing/PlatformDemo/components/NetworkingDemo/NetworkingDemo.module.css
@@ -135,7 +135,7 @@
   background: rgba(148, 163, 184, 0.1);
   color: #94A3B8;
   border: 1px solid rgba(148, 163, 184, 0.15);
-  cursor: not-allowed;
+  cursor: default;
   opacity: 0.6;
 }
 

--- a/frontend/src/pages/Landing/shared/MagneticButton/MagneticButton.module.css
+++ b/frontend/src/pages/Landing/shared/MagneticButton/MagneticButton.module.css
@@ -109,7 +109,7 @@
 /* Loading state */
 .button:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
+  cursor: default;
   transform: none !important;
 }
 

--- a/frontend/src/pages/Landing/ui/Buttons/Button.module.css
+++ b/frontend/src/pages/Landing/ui/Buttons/Button.module.css
@@ -79,7 +79,7 @@
 /* States */
 .disabled {
   opacity: 0.5;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .fullWidth {

--- a/frontend/src/pages/Networking/ChatArea/styles/index.module.css
+++ b/frontend/src/pages/Networking/ChatArea/styles/index.module.css
@@ -58,7 +58,7 @@
 
 .roomTab:disabled {
   opacity: 0.5;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .roomTabActive {

--- a/frontend/src/pages/Networking/RequestsList/RequestCard/styles/index.module.css
+++ b/frontend/src/pages/Networking/RequestsList/RequestCard/styles/index.module.css
@@ -103,7 +103,7 @@
 
 .acceptButton:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .declineButton {
@@ -121,7 +121,7 @@
 
 .declineButton:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 

--- a/frontend/src/shared/components/PersonCard/styles/index.module.css
+++ b/frontend/src/shared/components/PersonCard/styles/index.module.css
@@ -194,7 +194,7 @@
   color: #F59E0B;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  cursor: not-allowed;
+  cursor: default;
   opacity: 0.8;
 }
 

--- a/frontend/src/shared/components/buttons/Button.module.css
+++ b/frontend/src/shared/components/buttons/Button.module.css
@@ -20,7 +20,7 @@
 
 .btn:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 /* Primary button variant */

--- a/frontend/src/shared/components/modals/auth/ForgotPasswordModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/auth/ForgotPasswordModal/styles/index.module.css
@@ -11,7 +11,7 @@
 /* Form Elements */
 .form input:disabled {
   opacity: 0.7;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 /* Custom input styling */

--- a/frontend/src/shared/components/modals/auth/LoginModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/auth/LoginModal/styles/index.module.css
@@ -28,7 +28,7 @@
 /* Form Elements */
 .form input:disabled {
   opacity: 0.7;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 /* Custom input styling */

--- a/frontend/src/shared/components/modals/auth/SignupModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/auth/SignupModal/styles/index.module.css
@@ -28,7 +28,7 @@
 /* Form Elements */
 .form input:disabled {
   opacity: 0.7;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 /* Custom input styling */

--- a/frontend/src/shared/components/modals/event/EventModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/event/EventModal/styles/index.module.css
@@ -49,7 +49,7 @@
 .formSelect input:disabled,
 .formTextarea textarea:disabled {
   opacity: 0.6;
-  cursor: not-allowed;
+  cursor: default;
   background: rgba(248, 250, 252, 0.5);
 }
 

--- a/frontend/src/shared/components/modals/organization/InviteUserModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/organization/InviteUserModal/styles/index.module.css
@@ -8,7 +8,7 @@
 
 .form input:disabled {
   opacity: 0.7;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .form {

--- a/frontend/src/shared/components/modals/organization/OrganizationModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/organization/OrganizationModal/styles/index.module.css
@@ -8,7 +8,7 @@
 
 .form input:disabled {
   opacity: 0.7;
-  cursor: not-allowed;
+  cursor: default;
 }
 
 .form {

--- a/frontend/src/styles/reset.css
+++ b/frontend/src/styles/reset.css
@@ -150,3 +150,27 @@ textarea:not([rows]) {
 .mantine-Menu-label {
   line-height: 1.2;
 }
+
+/* Override disabled cursor for all Mantine components */
+.mantine-Button-root:disabled,
+.mantine-ActionIcon-root:disabled,
+.mantine-Checkbox-input:disabled,
+.mantine-Radio-input:disabled,
+.mantine-Switch-input:disabled,
+.mantine-Select-input:disabled,
+.mantine-TextInput-input:disabled,
+.mantine-Textarea-input:disabled,
+.mantine-NumberInput-input:disabled,
+.mantine-DateInput-input:disabled,
+.mantine-TimeInput-input:disabled,
+.mantine-Slider-root:disabled,
+.mantine-Tabs-tab:disabled,
+.mantine-Pagination-control:disabled,
+.mantine-SegmentedControl-label:disabled,
+.mantine-Chip-label:disabled,
+.mantine-Pill-root:disabled,
+.mantine-CloseButton-root:disabled,
+[data-disabled],
+[data-disabled] * {
+  cursor: default !important;
+}


### PR DESCRIPTION
…ents

- Changed cursor from not-allowed to default in 15 CSS module files
- Added global overrides in reset.css for all Mantine disabled components
- Improves aesthetic by removing red "no-go" circle cursor throughout the site
- Maintains consistent cursor behavior for disabled states

