### PR TITLE
fix(ui): Standardize three-dots menu styling across EventAdmin compon…

### DIFF
--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
@@ -219,7 +219,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
         {/* Actions Menu */}
         <Menu position="bottom-end" withinPortal>
           <Menu.Target>
-            <ActionIcon variant="subtle">
+            <ActionIcon variant="subtle" color="gray">
               <IconDots size={16} />
             </ActionIcon>
           </Menu.Target>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorCard/index.jsx
@@ -182,7 +182,7 @@ const SponsorCard = ({
 
           <Menu position="bottom-end">
             <Menu.Target>
-              <ActionIcon variant="subtle" className={styles.actionButton}>
+              <ActionIcon variant="subtle" color="gray" className={styles.actionButton}>
                 <IconDots size={18} />
               </ActionIcon>
             </Menu.Target>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorRow/index.jsx
@@ -182,7 +182,7 @@ const SponsorRow = ({
           position="bottom-end"
         >
           <Menu.Target>
-            <ActionIcon variant="subtle" color="gray" className={styles.actionIcon}>
+            <ActionIcon variant="subtle" color="gray" className={styles.actionButton}>
               <IconDots size={16} />
             </ActionIcon>
           </Menu.Target>


### PR DESCRIPTION
…ents

- Add color='gray' prop to ActionIcon components in SponsorCard, SponsorRow, and SessionCard
- Ensures consistent gray color instead of Mantine's default blue
- Matches styling pattern used in ChatRoomRow and SpeakerRow components

