### PR TITLE
feat: implement comprehensive database seeders for testing and demo

### DIFF
--- a/backend/atria/init.sh
+++ b/backend/atria/init.sh
@@ -97,12 +97,12 @@ with app.app_context():
     print("yes" if user_count > 0 else "no")
 END
 )
-    
+    # Updated to use comprehensive seed data.
     if [ "$HAS_DATA" = "yes" ]; then
         echo "[$(date)] Database already has data, skipping seeding"
     else
-        echo "[$(date)] Seeding database..."
-        PYTHONPATH=/app python -m seeders.seed_db || { echo "[$(date)] ERROR: Seeding failed"; exit 1; }
+        echo "[$(date)] Seeding database with comprehensive data (75+ users)..."
+        PYTHONPATH=/app python -m seeders.comprehensive_seed_db || { echo "[$(date)] ERROR: Seeding failed"; exit 1; }
     fi
 else
     echo "[$(date)] Skipping database seeding (SEED_DB=false)"

--- a/backend/atria/seeders/comprehensive_seed_data.py
+++ b/backend/atria/seeders/comprehensive_seed_data.py
@@ -1,0 +1,1314 @@
+# seeders/comprehensive_seed_data.py
+from datetime import datetime, date, time, timedelta
+from api.extensions import pwd_context
+import random
+from typing import List, Dict, Any
+from .enhanced_sessions import generate_enhanced_sessions
+from .enhanced_chat import generate_enhanced_chat_messages
+from .long_dm_conversation import generate_long_dm_conversations
+
+# Keep the demo user as our main account
+DEMO_USER_ID = 1
+PASSWORD = "changeme"  # Default password for all seeded users
+
+def generate_users() -> List[Dict[str, Any]]:
+    """Generate 75+ users with varied roles and companies"""
+    # Set seed for reproducibility - this ensures same users are generated each time
+    random.seed(42)
+    
+    users = []
+    
+    # Demo user (always first)
+    users.append({
+        "id": DEMO_USER_ID,
+        "email": "demouser@demo.com",
+        "password_hash": pwd_context.hash(PASSWORD),
+        "first_name": "Demo",
+        "last_name": "User",
+        "company_name": "Atria Platform",
+        "title": "Platform Lead",
+        "bio": "Demo account for testing and exploration. Leading the Atria event management platform.",
+        "image_url": "https://api.dicebear.com/7.x/avataaars/svg?seed=DemoUser",
+        "social_links": {
+            "linkedin": "https://linkedin.com/in/demouser",
+            "twitter": "https://twitter.com/demouser"
+        },
+        "is_active": True,
+        "email_verified": True,  # Manually confirmed
+    })
+    
+    # Tech companies for variety
+    companies = [
+        ("Netflix", ["Principal Engineer", "Senior Engineer", "Tech Lead", "Engineering Manager", "Staff Engineer"]),
+        ("Stripe", ["Tech Lead", "Senior Engineer", "Platform Engineer", "Payment Systems Engineer", "Security Engineer"]),
+        ("GitHub", ["Senior Engineer", "DevOps Lead", "Product Engineer", "Principal Engineer", "Engineering Manager"]),
+        ("Google", ["Staff Engineer", "Senior SWE", "Tech Lead Manager", "Principal Engineer", "Distinguished Engineer"]),
+        ("Meta", ["Software Engineer", "Senior Engineer", "Tech Lead", "Engineering Manager", "Research Engineer"]),
+        ("Amazon", ["Senior SDE", "Principal Engineer", "Solutions Architect", "Tech Lead", "Engineering Manager"]),
+        ("Microsoft", ["Principal Engineer", "Senior Engineer", "Azure Architect", "Tech Lead", "Product Manager"]),
+        ("Apple", ["Senior Engineer", "iOS Developer", "Machine Learning Engineer", "Platform Engineer", "Tech Lead"]),
+        ("Spotify", ["Backend Engineer", "Data Engineer", "Mobile Developer", "Platform Engineer", "Tech Lead"]),
+        ("Airbnb", ["Full Stack Engineer", "Senior Engineer", "Tech Lead", "Infrastructure Engineer", "Data Scientist"]),
+        ("Tesla", ["Software Engineer", "Embedded Systems Engineer", "ML Engineer", "Senior Engineer", "Tech Lead"]),
+        ("OpenAI", ["Research Engineer", "ML Engineer", "Systems Engineer", "Senior Engineer", "Tech Lead"]),
+        ("Uber", ["Senior Engineer", "Backend Engineer", "Mobile Developer", "Tech Lead", "Engineering Manager"]),
+        ("Lyft", ["Software Engineer", "Senior Engineer", "Platform Engineer", "Tech Lead", "Data Engineer"]),
+        ("Coinbase", ["Blockchain Engineer", "Senior Engineer", "Security Engineer", "Tech Lead", "Platform Engineer"]),
+        ("Square", ["Payment Systems Engineer", "Senior Engineer", "Mobile Developer", "Tech Lead", "Platform Engineer"]),
+        ("Twilio", ["Senior Engineer", "Communications Engineer", "Platform Engineer", "Tech Lead", "Solutions Architect"]),
+        ("Slack", ["Frontend Engineer", "Backend Engineer", "Senior Engineer", "Tech Lead", "Platform Engineer"]),
+        ("Zoom", ["Video Engineer", "Senior Engineer", "Platform Engineer", "Tech Lead", "Infrastructure Engineer"]),
+        ("Dropbox", ["Senior Engineer", "Infrastructure Engineer", "Security Engineer", "Tech Lead", "Storage Engineer"])
+    ]
+    
+    # Startups and smaller companies
+    startups = [
+        ("TechStartup Inc", ["Founder", "CTO", "Full Stack Developer", "Lead Engineer", "Product Manager"]),
+        ("AI Solutions", ["ML Engineer", "Data Scientist", "Senior Developer", "Tech Lead", "AI Researcher"]),
+        ("CloudNext", ["DevOps Engineer", "Cloud Architect", "Senior Engineer", "Platform Lead", "SRE"]),
+        ("DataFlow Systems", ["Data Engineer", "Analytics Lead", "Senior Developer", "Tech Lead", "BI Developer"]),
+        ("SecureWeb", ["Security Engineer", "Senior Developer", "Penetration Tester", "Tech Lead", "Security Architect"]),
+        ("MobileFirst", ["iOS Developer", "Android Developer", "Mobile Lead", "Senior Engineer", "React Native Developer"]),
+        ("WebScale Co", ["Frontend Developer", "Backend Developer", "Full Stack Engineer", "Tech Lead", "DevOps Engineer"]),
+        ("Innovation Labs", ["Research Engineer", "Senior Developer", "Lab Director", "Tech Lead", "Product Engineer"])
+    ]
+    
+    # Combine all companies
+    all_companies = companies + startups
+    
+    # Common first names
+    first_names = [
+        "Sarah", "Marcus", "Emily", "Alex", "Jamie", "Taylor", "Chris", "Jordan", "Morgan", "Casey",
+        "Avery", "Riley", "Quinn", "Blake", "Drew", "Sage", "River", "Sky", "Phoenix", "Rowan",
+        "Kai", "Aria", "Luna", "Nova", "Zara", "Leo", "Maya", "Ethan", "Olivia", "Liam",
+        "Emma", "Noah", "Ava", "Lucas", "Sophia", "Mason", "Isabella", "Logan", "Mia", "James",
+        "Charlotte", "Benjamin", "Amelia", "Jacob", "Harper", "Michael", "Evelyn", "Elijah", "Abigail", "William",
+        "Daniel", "Henry", "Alexander", "Jackson", "Sebastian", "Aiden", "Matthew", "Ella", "Grace", "Chloe",
+        "Camila", "Penelope", "Lily", "Aria", "Layla", "Scarlett", "Victoria", "Madison", "Luna", "Zoey",
+        "Raj", "Priya", "Wei", "Yuki", "Ahmed", "Fatima", "Carlos", "Sofia", "Pierre", "Marie"
+    ]
+    
+    # Common last names
+    last_names = [
+        "Chen", "Rodriguez", "Johnson", "Patel", "Wong", "Kim", "Martinez", "Anderson", "Taylor", "Thomas",
+        "Jackson", "White", "Harris", "Martin", "Thompson", "Garcia", "Lewis", "Lee", "Walker", "Hall",
+        "Allen", "Young", "King", "Wright", "Lopez", "Hill", "Scott", "Green", "Adams", "Baker",
+        "Nelson", "Carter", "Mitchell", "Roberts", "Turner", "Phillips", "Campbell", "Parker", "Evans", "Edwards",
+        "Collins", "Stewart", "Morris", "Murphy", "Cook", "Rogers", "Morgan", "Peterson", "Cooper", "Reed",
+        "Nakamura", "Suzuki", "Kumar", "Singh", "Ahmed", "Ali", "Hassan", "Nguyen", "Tran", "Park"
+    ]
+    
+    # Bio templates
+    bio_templates = [
+        "Passionate about {focus} with {years} years of experience in {field}",
+        "Building scalable {type} systems at {company}. Interested in {interest}",
+        "Former {previous_role}, now focusing on {current_focus} at {company}",
+        "{years}+ years in tech. Specializing in {specialty}. Love {hobby}",
+        "Engineering leader focused on {focus}. Speaker and {interest} enthusiast",
+        "Full-stack developer with expertise in {tech_stack}. Building the future of {field}",
+        "{role} at {company}. Passionate about {passion} and {interest}",
+        "Tech enthusiast working on {project_type} problems. {hobby} in my free time",
+        "Solving {problem_type} problems at scale. Previously at {previous_company}",
+        "{years} years building {product_type}. Interested in {emerging_tech}"
+    ]
+    
+    focuses = ["distributed systems", "machine learning", "cloud infrastructure", "mobile development", 
+               "web applications", "data pipelines", "security", "DevOps", "frontend development", 
+               "backend systems", "real-time systems", "blockchain", "AI/ML", "platform engineering"]
+    
+    interests = ["open source", "mentoring", "public speaking", "writing", "teaching", "research",
+                 "startups", "innovation", "automation", "optimization", "architecture", "design"]
+    
+    hobbies = ["hiking", "photography", "cooking", "gaming", "reading", "traveling", "music",
+              "running", "cycling", "yoga", "painting", "writing", "podcasting", "blogging"]
+    
+    # Generate users 2-80
+    used_emails = set()
+    used_emails.add("demouser@demo.com")  # Add demo user email
+    
+    for i in range(2, 81):
+        # Keep generating names until we get a unique email
+        attempts = 0
+        while attempts < 100:
+            first_name = random.choice(first_names)
+            last_name = random.choice(last_names)
+            email = f"{first_name.lower()}.{last_name.lower()}@example.com"
+            
+            if email not in used_emails:
+                used_emails.add(email)
+                break
+            
+            attempts += 1
+            # If we can't find unique combo, add number
+            if attempts >= 50:
+                email = f"{first_name.lower()}.{last_name.lower()}{i}@example.com"
+                if email not in used_emails:
+                    used_emails.add(email)
+                    break
+        
+        company, titles = random.choice(all_companies)
+        title = random.choice(titles)
+        
+        # Create bio
+        bio_template = random.choice(bio_templates)
+        bio = bio_template.format(
+            focus=random.choice(focuses),
+            years=random.randint(2, 15),
+            field=random.choice(["tech", "software", "engineering", "development"]),
+            company=company,
+            interest=random.choice(interests),
+            type=random.choice(["distributed", "scalable", "real-time", "cloud-native"]),
+            previous_role=random.choice(["consultant", "freelancer", "researcher", "founder"]),
+            current_focus=random.choice(focuses),
+            specialty=random.choice(focuses),
+            hobby=random.choice(hobbies),
+            tech_stack=random.choice(["React/Node", "Python/Django", "Java/Spring", "Go/Kubernetes"]),
+            role=title,
+            passion=random.choice(interests),
+            project_type=random.choice(["complex", "challenging", "interesting", "scaling"]),
+            problem_type=random.choice(["engineering", "technical", "business", "data"]),
+            previous_company=random.choice([c[0] for c in companies[:10]]),
+            product_type=random.choice(["products", "platforms", "applications", "systems"]),
+            emerging_tech=random.choice(["Web3", "AI", "quantum computing", "AR/VR", "IoT"])
+        )
+        
+        # Some users don't have all social links
+        social_links = {}
+        if random.random() > 0.3:  # 70% have LinkedIn
+            social_links["linkedin"] = f"https://linkedin.com/in/{first_name.lower()}{last_name.lower()}"
+        if random.random() > 0.6:  # 40% have Twitter
+            social_links["twitter"] = f"https://twitter.com/{first_name.lower()}_{last_name.lower()}"
+        if random.random() > 0.8:  # 20% have GitHub shown
+            social_links["github"] = f"https://github.com/{first_name.lower()}{last_name.lower()}"
+        
+        users.append({
+            "id": i,
+            "email": email,  # Use the guaranteed unique email
+            "password_hash": pwd_context.hash(PASSWORD),
+            "first_name": first_name,
+            "last_name": last_name,
+            "company_name": company,
+            "title": title,
+            "bio": bio[:500],  # Ensure bio fits in field
+            "image_url": f"https://api.dicebear.com/7.x/avataaars/svg?seed={first_name}{last_name}",
+            "social_links": social_links,
+            "is_active": True,
+            "email_verified": True,  # All manually verified to avoid bounce
+        })
+    
+    return users
+
+
+def generate_organizations() -> List[Dict[str, Any]]:
+    """Generate multiple organizations"""
+    return [
+        {
+            "id": 1,
+            "name": "Atria Events",
+            "created_at": datetime.utcnow() - timedelta(days=365),
+        },
+        {
+            "id": 2,
+            "name": "TechConf Global",
+            "created_at": datetime.utcnow() - timedelta(days=200),
+        },
+        {
+            "id": 3,
+            "name": "Developer Summit Org",
+            "created_at": datetime.utcnow() - timedelta(days=100),
+        }
+    ]
+
+
+def generate_organization_users() -> List[Dict[str, Any]]:
+    """Assign users to organizations with appropriate roles"""
+    org_users = []
+    
+    # Org 1 - Atria Events (our main org)
+    org_users.append({"organization_id": 1, "user_id": 1, "role": "OWNER"})  # Demo user as owner
+    org_users.append({"organization_id": 1, "user_id": 8, "role": "ADMIN"})
+    org_users.append({"organization_id": 1, "user_id": 15, "role": "ADMIN"})
+    org_users.append({"organization_id": 1, "user_id": 22, "role": "MEMBER"})
+    
+    # Org 2 - TechConf Global
+    org_users.append({"organization_id": 2, "user_id": 25, "role": "OWNER"})
+    org_users.append({"organization_id": 2, "user_id": 26, "role": "ADMIN"})
+    org_users.append({"organization_id": 2, "user_id": 27, "role": "MEMBER"})
+    
+    # Org 3 - Developer Summit Org
+    org_users.append({"organization_id": 3, "user_id": 30, "role": "OWNER"})
+    org_users.append({"organization_id": 3, "user_id": 31, "role": "ADMIN"})
+    
+    return org_users
+
+
+def generate_events() -> List[Dict[str, Any]]:
+    """Generate 3 events with different sizes and characteristics"""
+    events = []
+    
+    # Event 1 - Large conference with 75 attendees (our main demo event)
+    events.append({
+        "id": 1,
+        "organization_id": 1,
+        "title": "Atria TechConf 2025",
+        "description": "The premier technology conference bringing together industry leaders, innovators, and developers for three days of learning, networking, and inspiration.",
+        "hero_description": "Join 500+ developers, engineers, and tech leaders for the most comprehensive tech conference of 2025",
+        "hero_images": {
+            "desktop": "https://storage.sbtl.dev/spookyspot/atria-event-banner.png",
+            "mobile": "https://storage.sbtl.dev/spookyspot/atria-event-banner.png",
+        },
+        "event_type": "CONFERENCE",
+        "event_format": "HYBRID",
+        "is_private": False,
+        "venue_name": "San Francisco Convention Center",
+        "venue_address": "747 Howard Street",
+        "venue_city": "San Francisco",
+        "venue_country": "United States",
+        "start_date": date(2025, 3, 15),
+        "end_date": date(2025, 3, 17),
+        "company_name": "Atria Events",
+        "slug": "atria-techconf-2025",
+        "status": "PUBLISHED",
+        "branding": {
+            "primary_color": "#0066ff",
+            "secondary_color": "#ffffff",
+            "logo_url": None,
+            "banner_url": None,
+        },
+        "icebreakers": [
+            "Hi! I noticed we're both interested in similar sessions. Would you like to connect?",
+            "Hello! I saw your profile and would love to discuss our shared interests in technology.",
+            "Great to meet another developer here! What brings you to TechConf 2025?",
+            "I'm interested in learning more about your work at {company}. Could we chat?",
+            "Your experience with {technology} sounds fascinating. Would love to hear more!",
+            "Hi there! I'm building my network in the tech community. Would you like to connect?",
+            "I enjoyed your question during the session. Want to discuss it further?",
+            "Fellow engineer here! What sessions are you most excited about?",
+            "I see we both work in similar domains. Would love to exchange ideas!",
+            "Your bio mentions {interest} - I'm passionate about that too! Let's connect?"
+        ],
+        "sponsor_tiers": [
+            {
+                "id": "platinum",
+                "name": "Platinum Sponsor",
+                "order": 1,
+                "benefits": ["Prime booth location", "5 conference passes", "Logo on all materials", "Speaking opportunity"],
+                "color": "#e5e4e2"
+            },
+            {
+                "id": "gold",
+                "name": "Gold Sponsor",
+                "order": 2,
+                "benefits": ["Booth space", "3 conference passes", "Logo on website", "Social media mentions"],
+                "color": "#ffd700"
+            },
+            {
+                "id": "silver",
+                "name": "Silver Sponsor",
+                "order": 3,
+                "benefits": ["2 conference passes", "Logo on website", "Attendee list access"],
+                "color": "#c0c0c0"
+            }
+        ],
+        "sections": {
+            "welcome": {
+                "title": "Welcome to Atria TechConf 2025",
+                "content": "Join us for three days of cutting-edge technology discussions, hands-on workshops, and unparalleled networking opportunities with tech leaders from around the world.",
+            },
+            "highlights": [
+                {
+                    "title": "75+ Industry Speakers",
+                    "description": "Learn from tech leaders at Netflix, Stripe, GitHub, Google, and more",
+                    "icon": "speakers-icon",
+                },
+                {
+                    "title": "30+ Technical Sessions",
+                    "description": "Deep dives into cloud, AI, security, and emerging technologies",
+                    "icon": "sessions-icon",
+                },
+                {
+                    "title": "Hands-on Workshops",
+                    "description": "Interactive sessions on React, Kubernetes, Machine Learning, and more",
+                    "icon": "workshop-icon",
+                },
+                {
+                    "title": "Networking Opportunities",
+                    "description": "Connect with 500+ developers and tech leaders",
+                    "icon": "network-icon",
+                }
+            ],
+            "faqs": [
+                {
+                    "question": "Is there a virtual attendance option?",
+                    "answer": "Yes, all sessions will be streamed live for virtual attendees with interactive Q&A"
+                },
+                {
+                    "question": "Will sessions be recorded?",
+                    "answer": "Yes, all sessions will be available on-demand for 30 days after the event"
+                },
+                {
+                    "question": "What's included with registration?",
+                    "answer": "Access to all sessions, workshops, networking events, and conference materials"
+                },
+                {
+                    "question": "Are meals provided?",
+                    "answer": "Yes, breakfast, lunch, and refreshments are included all three days"
+                }
+            ]
+        }
+    })
+    
+    # Event 2 - Medium-sized virtual conference
+    events.append({
+        "id": 2,
+        "organization_id": 2,
+        "title": "Cloud Native Summit 2025",
+        "description": "A focused conference on cloud-native technologies, Kubernetes, and modern infrastructure",
+        "hero_description": "Deep dive into cloud-native technologies with experts from leading cloud platforms",
+        "hero_images": {
+            "desktop": None,
+            "mobile": None,
+        },
+        "event_type": "CONFERENCE",
+        "event_format": "VIRTUAL",
+        "is_private": False,
+        "venue_name": None,
+        "venue_address": None,
+        "venue_city": None,
+        "venue_country": None,
+        "start_date": date(2025, 4, 10),
+        "end_date": date(2025, 4, 11),
+        "company_name": "TechConf Global",
+        "slug": "cloud-native-summit-2025",
+        "status": "PUBLISHED",
+        "branding": {
+            "primary_color": "#00a86b",
+            "secondary_color": "#ffffff",
+            "logo_url": None,
+            "banner_url": None,
+        },
+        "icebreakers": [
+            "Hi! What brings you to Cloud Native Summit?",
+            "Fellow cloud engineer here! What's your tech stack?",
+            "Interested in discussing Kubernetes best practices?",
+            "Would love to hear about your cloud journey!",
+            "Let's connect and share cloud experiences!"
+        ],
+        "sponsor_tiers": None,
+        "sections": {
+            "welcome": {
+                "title": "Welcome to Cloud Native Summit",
+                "content": "Two days of deep technical content on Kubernetes, service mesh, and cloud-native development",
+            },
+            "highlights": [],
+            "faqs": []
+        }
+    })
+    
+    # Event 3 - Small workshop event
+    events.append({
+        "id": 3,
+        "organization_id": 3,
+        "title": "AI/ML Workshop Series",
+        "description": "Hands-on workshops covering practical machine learning applications",
+        "hero_description": "Learn practical ML skills through hands-on workshops",
+        "hero_images": {
+            "desktop": None,
+            "mobile": None,
+        },
+        "event_type": "SINGLE_SESSION",
+        "event_format": "HYBRID",
+        "is_private": True,
+        "venue_name": "Tech Hub Seattle",
+        "venue_address": "123 Tech Street",
+        "venue_city": "Seattle",
+        "venue_country": "United States",
+        "start_date": date(2025, 5, 20),
+        "end_date": date(2025, 5, 20),
+        "company_name": "Developer Summit Org",
+        "slug": "ai-ml-workshop-2025",
+        "status": "DRAFT",
+        "branding": {
+            "primary_color": "#ff6b6b",
+            "secondary_color": "#ffffff",
+            "logo_url": None,
+            "banner_url": None,
+        },
+        "icebreakers": [
+            "Hi! What ML projects are you working on?",
+            "Would love to discuss AI applications!",
+            "Let's connect and share ML insights!"
+        ],
+        "sponsor_tiers": None,
+        "sections": {
+            "welcome": {
+                "title": "AI/ML Workshop Series",
+                "content": "Practical, hands-on machine learning training",
+            },
+            "highlights": [],
+            "faqs": []
+        }
+    })
+    
+    return events
+
+
+def generate_event_users() -> List[Dict[str, Any]]:
+    """Assign users to events with appropriate roles"""
+    event_users = []
+    
+    # Event 1 - Large conference (75 attendees)
+    # Demo user is admin
+    event_users.append({
+        "event_id": 1,
+        "user_id": 1,
+        "role": "ADMIN",
+        "speaker_title": "Platform Lead @ Atria",
+        "speaker_bio": "Leading the development of the Atria event management platform",
+    })
+    
+    # Organizers (users 8, 15, 22)
+    organizer_ids = [8, 15, 22]
+    for user_id in organizer_ids:
+        event_users.append({
+            "event_id": 1,
+            "user_id": user_id,
+            "role": "ORGANIZER",
+            "speaker_title": None,
+            "speaker_bio": None,
+        })
+    
+    # Speakers (users 2-7, 10-14)
+    speaker_ids = list(range(2, 8)) + list(range(10, 15))
+    for user_id in speaker_ids:
+        event_users.append({
+            "event_id": 1,
+            "user_id": user_id,
+            "role": "SPEAKER",
+            "speaker_title": f"Speaker",  # Will be updated with actual title
+            "speaker_bio": f"Technical expert and conference speaker",
+        })
+    
+    # Regular attendees (remaining users up to 75, excluding those with other roles)
+    # Exclude users who already have roles: 1 (admin), 8,15,22 (organizers), 2-7,10-14 (speakers)
+    assigned_users = {1} | set(organizer_ids) | set(speaker_ids)
+    attendee_ids = [uid for uid in range(16, 76) if uid not in assigned_users]
+    for user_id in attendee_ids:
+        event_users.append({
+            "event_id": 1,
+            "user_id": user_id,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        })
+    
+    # Event 2 - Medium conference (20 attendees)
+    # Owner of org 2 is admin
+    event_users.append({
+        "event_id": 2,
+        "user_id": 25,
+        "role": "ADMIN",
+        "speaker_title": None,
+        "speaker_bio": None,
+    })
+    
+    # Some speakers
+    for user_id in [26, 27, 28, 29]:
+        event_users.append({
+            "event_id": 2,
+            "user_id": user_id,
+            "role": "SPEAKER",
+            "speaker_title": "Cloud Expert",
+            "speaker_bio": "Specializing in cloud-native technologies",
+        })
+    
+    # Some attendees (avoid overlap with Event 3)
+    for user_id in range(45, 60):  # Users 45-59 (15 attendees)
+        event_users.append({
+            "event_id": 2,
+            "user_id": user_id,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        })
+    
+    # Event 3 - Small workshop (8 attendees)
+    event_users.append({
+        "event_id": 3,
+        "user_id": 30,
+        "role": "ADMIN",
+        "speaker_title": None,
+        "speaker_bio": None,
+    })
+    
+    # Workshop instructor
+    event_users.append({
+        "event_id": 3,
+        "user_id": 31,
+        "role": "SPEAKER",
+        "speaker_title": "ML Engineer",
+        "speaker_bio": "Machine learning practitioner and educator",
+    })
+    
+    # Workshop attendees (avoid overlap with Event 2)
+    for user_id in range(32, 38):  # Users 32-37 (6 attendees)
+        event_users.append({
+            "event_id": 3,
+            "user_id": user_id,
+            "role": "ATTENDEE",
+            "speaker_title": None,
+            "speaker_bio": None,
+        })
+    
+    return event_users
+
+
+def generate_sessions_old() -> List[Dict[str, Any]]:
+    """Generate sessions for events"""
+    sessions = []
+    session_id = 1
+    
+    # Event 1 - Full conference schedule (3 days)
+    # Day 1 - March 15 - Opening Day
+    sessions.extend([
+        {
+            "id": session_id,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "KEYNOTE",
+            "title": "Opening Keynote: The Future of Software Development",
+            "short_description": "Vision for the next decade of software engineering",
+            "description": "Join us for an inspiring keynote on how AI, quantum computing, and new paradigms will reshape software development",
+            "start_time": time(9, 0),
+            "end_time": time(10, 0),
+            "stream_url": "https://stream.atria.com/keynote1",
+            "day_number": 1,
+        },
+        {
+            "id": session_id + 1,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "Building Scalable Microservices",
+            "short_description": "Patterns and practices for microservice architecture",
+            "description": "Learn proven patterns for building and managing microservices at scale",
+            "start_time": time(10, 30),
+            "end_time": time(11, 30),
+            "stream_url": "https://stream.atria.com/track1-1",
+            "day_number": 1,
+        },
+        {
+            "id": session_id + 2,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "WORKSHOP",
+            "title": "Hands-on Kubernetes Workshop",
+            "short_description": "Deploy and manage applications on Kubernetes",
+            "description": "Practical workshop covering Kubernetes fundamentals through advanced topics",
+            "start_time": time(10, 30),
+            "end_time": time(12, 30),
+            "stream_url": "https://stream.atria.com/workshop1",
+            "day_number": 1,
+        },
+        {
+            "id": session_id + 3,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "NETWORKING",
+            "title": "Lunch & Networking",
+            "short_description": "Connect with fellow attendees",
+            "description": "Structured networking lunch with topic-based tables",
+            "start_time": time(12, 30),
+            "end_time": time(14, 0),
+            "stream_url": None,
+            "day_number": 1,
+        },
+        {
+            "id": session_id + 4,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PANEL",
+            "title": "The Future of AI in Production",
+            "short_description": "Industry leaders discuss AI deployment challenges",
+            "description": "Panel discussion on deploying and managing AI systems in production environments",
+            "start_time": time(14, 0),
+            "end_time": time(15, 30),
+            "stream_url": "https://stream.atria.com/panel1",
+            "day_number": 1,
+        }
+    ])
+    
+    session_id += 5
+    
+    # Day 2 - March 16
+    sessions.extend([
+        {
+            "id": session_id,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "KEYNOTE",
+            "title": "Security in the Age of AI",
+            "short_description": "Navigating security challenges in AI-driven systems",
+            "description": "Exploring the intersection of AI and cybersecurity",
+            "start_time": time(9, 0),
+            "end_time": time(10, 0),
+            "stream_url": "https://stream.atria.com/keynote2",
+            "day_number": 2,
+        },
+        {
+            "id": session_id + 1,
+            "event_id": 1,
+            "status": "SCHEDULED",
+            "session_type": "PRESENTATION",
+            "title": "React Performance at Scale",
+            "short_description": "Optimizing React applications for millions of users",
+            "description": "Deep dive into React performance optimization techniques used at Netflix",
+            "start_time": time(10, 30),
+            "end_time": time(11, 30),
+            "stream_url": "https://stream.atria.com/track2-1",
+            "day_number": 2,
+        }
+    ])
+    
+    session_id += 2
+    
+    # Event 2 - Cloud Native Summit sessions
+    sessions.extend([
+        {
+            "id": session_id,
+            "event_id": 2,
+            "status": "SCHEDULED",
+            "session_type": "KEYNOTE",
+            "title": "Cloud Native Architecture Patterns",
+            "short_description": "Modern patterns for cloud-native applications",
+            "description": "Comprehensive overview of cloud-native design patterns",
+            "start_time": time(9, 0),
+            "end_time": time(10, 0),
+            "stream_url": "https://stream.cloud.com/keynote",
+            "day_number": 1,
+        },
+        {
+            "id": session_id + 1,
+            "event_id": 2,
+            "status": "SCHEDULED",
+            "session_type": "WORKSHOP",
+            "title": "Service Mesh Deep Dive",
+            "short_description": "Implementing service mesh with Istio",
+            "description": "Hands-on workshop on service mesh implementation",
+            "start_time": time(10, 30),
+            "end_time": time(12, 0),
+            "stream_url": "https://stream.cloud.com/workshop",
+            "day_number": 1,
+        }
+    ])
+    
+    session_id += 2
+    
+    # Event 3 - AI/ML Workshop
+    sessions.append({
+        "id": session_id,
+        "event_id": 3,
+        "status": "SCHEDULED",
+        "session_type": "WORKSHOP",
+        "title": "Practical Machine Learning with Python",
+        "short_description": "Hands-on ML model development",
+        "description": "Build and deploy ML models using scikit-learn and TensorFlow",
+        "start_time": time(9, 0),
+        "end_time": time(17, 0),
+        "stream_url": None,
+        "day_number": 1,
+    })
+    
+    return sessions
+
+
+def generate_sessions() -> List[Dict[str, Any]]:
+    """Use enhanced session generation"""
+    return generate_enhanced_sessions()
+
+
+def generate_session_speakers() -> List[Dict[str, Any]]:
+    """Assign speakers to sessions"""
+    speakers = []
+    
+    # Event 1 sessions
+    # Session 1 - Opening Keynote (Demo User)
+    speakers.append({
+        "session_id": 1,
+        "user_id": 1,
+        "role": "KEYNOTE",
+        "order": 1,
+    })
+    
+    # Session 2 - Microservices (User 2)
+    speakers.append({
+        "session_id": 2,
+        "user_id": 2,
+        "role": "SPEAKER",
+        "order": 1,
+    })
+    
+    # Session 3 - Kubernetes Workshop (Users 3, 4)
+    speakers.extend([
+        {
+            "session_id": 3,
+            "user_id": 3,
+            "role": "SPEAKER",
+            "order": 1,
+        },
+        {
+            "session_id": 3,
+            "user_id": 4,
+            "role": "SPEAKER",
+            "order": 2,
+        }
+    ])
+    
+    # Session 5 - AI Panel (Users 5, 6, 7, 10, 11 as panelists, 12 as moderator)
+    speakers.append({
+        "session_id": 5,
+        "user_id": 12,
+        "role": "MODERATOR",
+        "order": 1,
+    })
+    
+    for i, user_id in enumerate([5, 6, 7, 10, 11], start=2):
+        speakers.append({
+            "session_id": 5,
+            "user_id": user_id,
+            "role": "PANELIST",
+            "order": i,
+        })
+    
+    # Event 2 sessions
+    speakers.extend([
+        {
+            "session_id": 8,
+            "user_id": 26,
+            "role": "KEYNOTE",
+            "order": 1,
+        },
+        {
+            "session_id": 9,
+            "user_id": 27,
+            "role": "SPEAKER",
+            "order": 1,
+        }
+    ])
+    
+    # Event 3 session
+    speakers.append({
+        "session_id": 10,
+        "user_id": 31,
+        "role": "SPEAKER",
+        "order": 1,
+    })
+    
+    return speakers
+
+
+def generate_chat_rooms() -> List[Dict[str, Any]]:
+    """Generate chat rooms with proper permissions"""
+    chat_rooms = []
+    room_id = 1
+    
+    # Event 1 - Global rooms
+    chat_rooms.extend([
+        {
+            "id": room_id,
+            "event_id": 1,
+            "session_id": None,
+            "name": "General Chat",
+            "description": "Main event discussion for all attendees",
+            "room_type": "GLOBAL",
+            "is_enabled": True,
+            "display_order": 1.0,
+        },
+        {
+            "id": room_id + 1,
+            "event_id": 1,
+            "session_id": None,
+            "name": "Green Room",
+            "description": "Speakers and organizers only",
+            "room_type": "GREEN_ROOM",
+            "is_enabled": True,
+            "display_order": 2.0,
+        },
+        {
+            "id": room_id + 2,
+            "event_id": 1,
+            "session_id": None,
+            "name": "Admin Chat",
+            "description": "Event admins and organizers only",
+            "room_type": "ADMIN",
+            "is_enabled": True,
+            "display_order": 3.0,
+        }
+    ])
+    
+    room_id += 3
+    
+    # Event 1 - Session-specific rooms (for first 5 sessions)
+    for session_id in range(1, 6):
+        if session_id != 4:  # Skip networking session
+            chat_rooms.extend([
+                {
+                    "id": room_id,
+                    "event_id": 1,
+                    "session_id": session_id,
+                    "name": f"Session {session_id} Chat",
+                    "description": "Public discussion for this session",
+                    "room_type": "PUBLIC",
+                    "is_enabled": True,
+                    "display_order": float(session_id),
+                },
+                {
+                    "id": room_id + 1,
+                    "event_id": 1,
+                    "session_id": session_id,
+                    "name": f"Session {session_id} Backstage",
+                    "description": "Speakers and organizers only",
+                    "room_type": "BACKSTAGE",
+                    "is_enabled": True,
+                    "display_order": float(session_id) + 0.5,
+                }
+            ])
+            room_id += 2
+    
+    # Event 2 - Basic rooms
+    chat_rooms.extend([
+        {
+            "id": room_id,
+            "event_id": 2,
+            "session_id": None,
+            "name": "General Discussion",
+            "description": "Main event chat",
+            "room_type": "GLOBAL",
+            "is_enabled": True,
+            "display_order": 1.0,
+        },
+        {
+            "id": room_id + 1,
+            "event_id": 2,
+            "session_id": None,
+            "name": "Speakers Lounge",
+            "description": "Speaker coordination",
+            "room_type": "GREEN_ROOM",
+            "is_enabled": True,
+            "display_order": 2.0,
+        }
+    ])
+    
+    room_id += 2
+    
+    # Event 3 - Single room
+    chat_rooms.append({
+        "id": room_id,
+        "event_id": 3,
+        "session_id": None,
+        "name": "Workshop Chat",
+        "description": "Workshop discussion",
+        "room_type": "GLOBAL",
+        "is_enabled": True,
+        "display_order": 1.0,
+    })
+    
+    return chat_rooms
+
+
+def generate_chat_messages_old() -> List[Dict[str, Any]]:
+    """Generate sample chat messages"""
+    messages = []
+    message_id = 1
+    
+    # Event 1 - General Chat messages
+    general_chat_messages = [
+        (1, "Welcome everyone to Atria TechConf 2025! So excited to have you all here!"),
+        (15, "Looking forward to the keynote! Anyone else attending in person?"),
+        (20, "I'll be there! Coming from Seattle. Where's everyone traveling from?"),
+        (25, "Virtual attendee here from London! Love that there's a hybrid option"),
+        (30, "The speaker lineup looks amazing. Can't wait for the React performance talk"),
+        (35, "Same! I'm also interested in the Kubernetes workshop. Who's joining that?"),
+        (40, "I'll be in the K8s workshop! Been wanting to level up my container orchestration skills"),
+        (1, "Remember to check out the networking lunch - we have topic tables for different interests!"),
+        (45, "Quick question - will the sessions be recorded for later viewing?"),
+        (8, "Yes! All sessions will be available on-demand for 30 days after the event"),
+    ]
+    
+    for user_id, content in general_chat_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 1,  # General Chat for Event 1
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Event 1 - Green Room messages (speakers/organizers only)
+    green_room_messages = [
+        (1, "Welcome speakers! This is our private channel for coordination"),
+        (2, "Thanks for having us! My flight just landed. See everyone tomorrow morning"),
+        (3, "Hi all! Looking forward to the workshop. We have 30 registered so far"),
+        (8, "Great! AV team will be ready 30 min before each session for mic checks"),
+        (5, "Perfect. What time should panelists arrive for the AI discussion?"),
+        (12, "Let's meet 15 minutes early to go over the questions"),
+    ]
+    
+    for user_id, content in green_room_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 2,  # Green Room for Event 1
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Event 1 - Admin Chat messages
+    admin_messages = [
+        (1, "Admin team - everything looking good for tomorrow?"),
+        (8, "Registration desk is set up. We have 380 confirmed in-person attendees"),
+        (15, "Catering confirmed for all three days. Special dietary needs accommodated"),
+        (22, "Sponsor booths are ready. Platinum sponsors have prime locations as promised"),
+        (1, "Excellent work everyone! Let's make this the best TechConf yet"),
+    ]
+    
+    for user_id, content in admin_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 3,  # Admin Chat for Event 1
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Session 1 Public Chat
+    session_messages = [
+        (16, "Excited for the opening keynote!"),
+        (25, "The future of AI in development - this should be interesting"),
+        (30, "Anyone have questions ready for the Q&A?"),
+    ]
+    
+    for user_id, content in session_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 4,  # Session 1 Public Chat
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Session 1 Backstage
+    backstage_messages = [
+        (1, "Mic check complete. Ready to go!"),
+        (8, "Slides are loaded and streaming is live"),
+        (1, "Thanks team! Here we go!"),
+    ]
+    
+    for user_id, content in backstage_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 5,  # Session 1 Backstage
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    return messages
+
+
+def generate_chat_messages() -> List[Dict[str, Any]]:
+    """Use enhanced chat message generation"""
+    return generate_enhanced_chat_messages()
+
+
+def generate_connections() -> List[Dict[str, Any]]:
+    """Generate connections between users with various states"""
+    connections = []
+    connection_id = 1
+    
+    # Demo user connections (mix of accepted and pending)
+    # Accepted connections
+    accepted_connections = [
+        (1, 2, "Hi Sarah! I'd love to connect and discuss distributed systems."),
+        (1, 3, "Great to meet another platform engineer! Let's connect."),
+        (1, 8, "Thanks for helping organize this amazing event!"),
+        (15, 1, "Demo User, your platform work is inspiring! Would love to connect."),
+        (20, 1, "Hi! I'm interested in learning more about the Atria platform."),
+    ]
+    
+    for requester, recipient, message in accepted_connections:
+        connections.append({
+            "id": connection_id,
+            "requester_id": requester,
+            "recipient_id": recipient,
+            "status": "ACCEPTED",
+            "icebreaker_message": message,
+            "originating_event_id": 1,
+        })
+        connection_id += 1
+    
+    # Pending connections (waiting for demo user response)
+    pending_to_demo = [
+        (25, 1, "Hi Demo User! Would love to discuss event management platforms."),
+        (30, 1, "Your keynote topic sounds fascinating! Can we connect?"),
+        (35, 1, "I'm building a similar platform. Would appreciate your insights!"),
+    ]
+    
+    for requester, recipient, message in pending_to_demo:
+        connections.append({
+            "id": connection_id,
+            "requester_id": requester,
+            "recipient_id": recipient,
+            "status": "PENDING",
+            "icebreaker_message": message,
+            "originating_event_id": 1,
+        })
+        connection_id += 1
+    
+    # Pending connections from demo user
+    pending_from_demo = [
+        (1, 40, "Hi! Noticed you work in a similar space. Let's connect!"),
+        (1, 45, "Would love to hear about your experience with microservices."),
+    ]
+    
+    for requester, recipient, message in pending_from_demo:
+        connections.append({
+            "id": connection_id,
+            "requester_id": requester,
+            "recipient_id": recipient,
+            "status": "PENDING",
+            "icebreaker_message": message,
+            "originating_event_id": 1,
+        })
+        connection_id += 1
+    
+    # Other user connections (to make it realistic)
+    other_connections = [
+        (2, 3, "ACCEPTED", "Fellow speaker! Looking forward to your session."),
+        (2, 4, "ACCEPTED", "GitHub and Netflix collaboration! Let's connect."),
+        (5, 6, "ACCEPTED", "Great questions during the panel. Let's stay in touch!"),
+        (10, 11, "PENDING", "Your ML work sounds interesting. Can we chat?"),
+        (15, 20, "ACCEPTED", "Thanks for the great conversation at lunch!"),
+        (25, 30, "PENDING", "Would love to connect and share cloud experiences."),
+        (35, 40, "ACCEPTED", "Great meeting you at the networking session!"),
+        (45, 50, "PENDING", "Hi! I'm also interested in React performance."),
+        (3, 10, "REJECTED", "Thanks, but I'm keeping my network focused for now."),
+        (20, 25, "ACCEPTED", "Virtual networking for the win! Great to connect."),
+    ]
+    
+    for requester, recipient, status, message in other_connections:
+        connections.append({
+            "id": connection_id,
+            "requester_id": requester,
+            "recipient_id": recipient,
+            "status": status,
+            "icebreaker_message": message,
+            "originating_event_id": 1 if requester <= 75 and recipient <= 75 else 2,
+        })
+        connection_id += 1
+    
+    return connections
+
+
+def generate_direct_message_threads() -> List[Dict[str, Any]]:
+    """Generate DM threads between connected users"""
+    threads = []
+    
+    # Threads for demo user's accepted connections
+    threads.extend([
+        {"id": 1, "user1_id": 1, "user2_id": 2, "is_encrypted": False},
+        {"id": 2, "user1_id": 1, "user2_id": 3, "is_encrypted": False},
+        {"id": 3, "user1_id": 1, "user2_id": 8, "is_encrypted": False},
+        {"id": 4, "user1_id": 1, "user2_id": 15, "is_encrypted": False},
+        {"id": 5, "user1_id": 1, "user2_id": 20, "is_encrypted": False},
+    ])
+    
+    # Other user threads
+    threads.extend([
+        {"id": 6, "user1_id": 2, "user2_id": 3, "is_encrypted": False},
+        {"id": 7, "user1_id": 2, "user2_id": 4, "is_encrypted": False},
+        {"id": 8, "user1_id": 5, "user2_id": 6, "is_encrypted": False},
+        {"id": 9, "user1_id": 15, "user2_id": 20, "is_encrypted": False},
+        {"id": 10, "user1_id": 35, "user2_id": 40, "is_encrypted": False},
+    ])
+    
+    return threads
+
+
+def generate_direct_messages_old() -> List[Dict[str, Any]]:
+    """Generate DM conversations"""
+    messages = []
+    message_id = 1
+    
+    # Thread 1: Demo User <-> Sarah Chen
+    thread1_messages = [
+        (1, 2, "Hi Sarah! Thanks for accepting my connection request."),
+        (2, 1, "Happy to connect! Your work on the Atria platform looks impressive."),
+        (1, 2, "Thank you! I saw you're speaking about distributed systems. What will you cover?"),
+        (2, 1, "I'll be discussing patterns we use at Netflix for handling millions of concurrent users."),
+        (1, 2, "That sounds fascinating! Looking forward to your session."),
+    ]
+    
+    for sender, recipient, content in thread1_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 1,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ",
+        })
+        message_id += 1
+    
+    # Thread 2: Demo User <-> Marcus Rodriguez
+    thread2_messages = [
+        (3, 1, "Thanks for connecting! Excited about the conference."),
+        (1, 3, "Me too! Your Kubernetes workshop looks great."),
+        (3, 1, "We'll cover a lot of practical examples. Bring your laptop!"),
+        (1, 3, "Will do! Any prerequisites I should review?"),
+        (3, 1, "Basic Docker knowledge would be helpful, but we'll cover the fundamentals."),
+    ]
+    
+    for sender, recipient, content in thread2_messages:
+        # Determine correct recipient for thread lookup
+        if sender == 1:
+            thread_user2 = 3
+        else:
+            thread_user2 = 1
+        
+        messages.append({
+            "id": message_id,
+            "thread_id": 2,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ" if message_id < 8 else "DELIVERED",
+        })
+        message_id += 1
+    
+    # Thread 3: Demo User <-> Chris Martinez (Organizer)
+    thread3_messages = [
+        (8, 1, "Hey! Everything ready for your keynote?"),
+        (1, 8, "Yes! Just finished the final slides. Thanks for checking in."),
+        (8, 1, "Perfect. AV team will be ready 30 min early for setup."),
+        (1, 8, "Great, I'll be there. How's registration looking?"),
+        (8, 1, "We're at 380 in-person and 200+ virtual. Great turnout!"),
+        (1, 8, "That's amazing! This is going to be a great event."),
+    ]
+    
+    for sender, recipient, content in thread3_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 3,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ",
+        })
+        message_id += 1
+    
+    # Some unread messages in thread 4
+    thread4_messages = [
+        (15, 1, "Hi! Quick question about the platform."),
+        (1, 15, "Sure, happy to help! What would you like to know?"),
+        (15, 1, "Is Atria open source or available for licensing?"),
+        (15, 1, "We're considering it for our internal events."),
+    ]
+    
+    for sender, recipient, content in thread4_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 4,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ" if message_id < 18 else "SENT",
+        })
+        message_id += 1
+    
+    return messages
+
+
+def generate_direct_messages() -> List[Dict[str, Any]]:
+    """Use long DM conversations for pagination testing"""
+    return generate_long_dm_conversations()
+
+
+def generate_sponsors() -> List[Dict[str, Any]]:
+    """Generate event sponsors"""
+    sponsors = []
+    
+    # Event 1 sponsors
+    sponsors.extend([
+        {
+            "id": 1,
+            "event_id": 1,
+            "name": "CloudTech Solutions",
+            "description": "Leading cloud infrastructure provider",
+            "website_url": "https://cloudtech.example.com",
+            "logo_url": "https://via.placeholder.com/200x100/0066ff/ffffff?text=CloudTech",
+            "tier_id": "platinum",
+            "display_order": 1,
+            "is_active": True,
+            "featured": True,
+            "social_links": {
+                "twitter": "https://twitter.com/cloudtech",
+                "linkedin": "https://linkedin.com/company/cloudtech"
+            },
+        },
+        {
+            "id": 2,
+            "event_id": 1,
+            "name": "DevTools Pro",
+            "description": "Developer productivity tools",
+            "website_url": "https://devtools.example.com",
+            "logo_url": "https://via.placeholder.com/200x100/ffd700/000000?text=DevTools",
+            "tier_id": "gold",
+            "display_order": 2,
+            "is_active": True,
+            "featured": True,
+            "social_links": {
+                "twitter": "https://twitter.com/devtools"
+            },
+        },
+        {
+            "id": 3,
+            "event_id": 1,
+            "name": "API Gateway Inc",
+            "description": "API management and security",
+            "website_url": "https://apigateway.example.com",
+            "logo_url": "https://via.placeholder.com/200x100/c0c0c0/000000?text=API+Gateway",
+            "tier_id": "silver",
+            "display_order": 3,
+            "is_active": True,
+            "featured": False,
+            "social_links": {},
+        },
+    ])
+    
+    return sponsors
+
+
+def generate_user_encryption_keys() -> List[Dict[str, Any]]:
+    """Generate encryption keys for users (placeholder for now)"""
+    # Not implementing real encryption for demo
+    return []
+
+
+# Export all generation functions
+__all__ = [
+    'generate_users',
+    'generate_organizations',
+    'generate_organization_users',
+    'generate_events',
+    'generate_event_users',
+    'generate_sessions',
+    'generate_session_speakers',
+    'generate_chat_rooms',
+    'generate_chat_messages',
+    'generate_connections',
+    'generate_direct_message_threads',
+    'generate_direct_messages',
+    'generate_sponsors',
+    'generate_user_encryption_keys',
+]

--- a/backend/atria/seeders/comprehensive_seed_db.py
+++ b/backend/atria/seeders/comprehensive_seed_db.py
@@ -1,0 +1,436 @@
+# seeders/comprehensive_seed_db.py
+from flask import current_app
+from api.extensions import db
+from api.app import create_app
+from sqlalchemy import text
+from sqlalchemy.sql import quoted_name
+import json
+from datetime import datetime, timedelta
+
+# Import all comprehensive seed functions
+from .comprehensive_seed_data import (
+    generate_users,
+    generate_organizations,
+    generate_organization_users,
+    generate_events,
+    generate_event_users,
+    generate_sessions,
+    generate_session_speakers,
+    generate_sponsors,
+    generate_chat_rooms,
+    generate_chat_messages,
+    generate_connections,
+    generate_direct_message_threads,
+    generate_direct_messages,
+    generate_user_encryption_keys,
+)
+
+
+def seed_comprehensive_database():
+    """Seed database with comprehensive test data including 75+ users"""
+    app = create_app()
+    with app.app_context():
+        try:
+            print("=" * 60)
+            print("COMPREHENSIVE DATABASE SEEDING")
+            print("=" * 60)
+            
+            # Clear existing data
+            print("\n[1/14] Clearing existing data...")
+            tables_to_clear = [
+                "direct_messages",
+                "direct_message_threads",
+                "connections",
+                "chat_messages",
+                "chat_rooms",
+                "session_speakers",
+                "sessions",
+                "sponsors",
+                "event_users",
+                "events",
+                "organization_users",
+                "organizations",
+                "user_encryption_keys",
+                "users",
+            ]
+            
+            for table in tables_to_clear:
+                db.session.execute(text(f"TRUNCATE TABLE {table} CASCADE"))
+            db.session.commit()
+            print("  ✓ All tables cleared")
+
+            # Seed users
+            print("\n[2/14] Seeding users...")
+            users = generate_users()
+            for user_data in users:
+                user_data = dict(user_data)
+                user_data["social_links"] = json.dumps(user_data["social_links"])
+                
+                db.session.execute(
+                    text("""
+                        INSERT INTO users (
+                            id, email, password_hash, first_name, last_name,
+                            company_name, title, bio, image_url, social_links,
+                            is_active, email_verified, created_at
+                        )
+                        VALUES (
+                            :id, :email, :password_hash, :first_name, :last_name,
+                            :company_name, :title, :bio, :image_url, :social_links,
+                            :is_active, :email_verified, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    user_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(users)} users")
+
+            # Seed organizations
+            print("\n[3/14] Seeding organizations...")
+            orgs = generate_organizations()
+            for org_data in orgs:
+                db.session.execute(
+                    text("""
+                        INSERT INTO organizations (id, name, created_at)
+                        VALUES (:id, :name, :created_at)
+                    """),
+                    org_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(orgs)} organizations")
+
+            # Seed organization users
+            print("\n[4/14] Seeding organization memberships...")
+            org_users = generate_organization_users()
+            for org_user_data in org_users:
+                db.session.execute(
+                    text("""
+                        INSERT INTO organization_users (organization_id, user_id, role, created_at)
+                        VALUES (:organization_id, :user_id, :role, CURRENT_TIMESTAMP)
+                    """),
+                    org_user_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(org_users)} organization memberships")
+
+            # Seed events
+            print("\n[5/14] Seeding events...")
+            events = generate_events()
+            for event_data in events:
+                event_data = dict(event_data)
+                event_data["branding"] = json.dumps(event_data["branding"])
+                event_data["hero_images"] = json.dumps(event_data["hero_images"])
+                event_data["sections"] = json.dumps(event_data["sections"])
+                # Icebreakers field exists in the migration
+                if "icebreakers" in event_data:
+                    event_data["icebreakers"] = json.dumps(event_data["icebreakers"])
+                if event_data.get("sponsor_tiers"):
+                    event_data["sponsor_tiers"] = json.dumps(event_data["sponsor_tiers"])
+                
+                db.session.execute(
+                    text("""
+                        INSERT INTO events (
+                            id, organization_id, title, description,
+                            hero_description, hero_images,
+                            event_type, event_format, is_private,
+                            venue_name, venue_address, venue_city, venue_country,
+                            start_date, end_date, company_name,
+                            slug, status, branding, sections, sponsor_tiers, 
+                            icebreakers, created_at
+                        )
+                        VALUES (
+                            :id, :organization_id, :title, :description,
+                            :hero_description, :hero_images,
+                            :event_type, :event_format, :is_private,
+                            :venue_name, :venue_address, :venue_city, :venue_country,
+                            :start_date, :end_date, :company_name,
+                            :slug, :status, :branding, :sections, :sponsor_tiers,
+                            :icebreakers, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    event_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(events)} events")
+            print(f"    • Event 1: 75 attendees (main demo)")
+            print(f"    • Event 2: 20 attendees (medium)")
+            print(f"    • Event 3: 8 attendees (small)")
+
+            # Seed event users
+            print("\n[6/14] Seeding event attendees...")
+            event_users = generate_event_users()
+            for event_user_data in event_users:
+                db.session.execute(
+                    text("""
+                        INSERT INTO event_users (
+                            event_id, user_id, role,
+                            speaker_title, speaker_bio, created_at
+                        )
+                        VALUES (
+                            :event_id, :user_id, :role,
+                            :speaker_title, :speaker_bio, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    event_user_data,
+                )
+            db.session.commit()
+            
+            # Count roles for reporting
+            admins = len([eu for eu in event_users if eu["role"] == "ADMIN"])
+            organizers = len([eu for eu in event_users if eu["role"] == "ORGANIZER"])
+            speakers = len([eu for eu in event_users if eu["role"] == "SPEAKER"])
+            attendees = len([eu for eu in event_users if eu["role"] == "ATTENDEE"])
+            
+            print(f"  ✓ Created {len(event_users)} event memberships")
+            print(f"    • {admins} admins, {organizers} organizers")
+            print(f"    • {speakers} speakers, {attendees} attendees")
+
+            # Seed sessions
+            print("\n[7/14] Seeding sessions...")
+            sessions = generate_sessions()
+            for session_data in sessions:
+                db.session.execute(
+                    text("""
+                        INSERT INTO sessions (
+                            id, event_id, status, session_type, chat_mode,
+                            title, short_description, description, 
+                            start_time, end_time, stream_url, day_number, created_at
+                        )
+                        VALUES (
+                            :id, :event_id, :status, :session_type, 'ENABLED',
+                            :title, :short_description, :description, 
+                            :start_time, :end_time, :stream_url, :day_number, 
+                            CURRENT_TIMESTAMP
+                        )
+                    """),
+                    session_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(sessions)} sessions")
+
+            # Seed session speakers
+            print("\n[8/14] Seeding session speakers...")
+            session_speakers = generate_session_speakers()
+            for speaker_data in session_speakers:
+                db.session.execute(
+                    text("""
+                        INSERT INTO session_speakers (
+                            session_id, user_id, role, "order", created_at
+                        )
+                        VALUES (
+                            :session_id, :user_id, :role, :order, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    speaker_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Assigned {len(session_speakers)} speakers to sessions")
+
+            # Seed sponsors
+            print("\n[9/14] Seeding sponsors...")
+            sponsors = generate_sponsors()
+            for sponsor_data in sponsors:
+                sponsor_data = dict(sponsor_data)
+                if "social_links" in sponsor_data:
+                    sponsor_data["social_links"] = json.dumps(sponsor_data["social_links"])
+                
+                db.session.execute(
+                    text("""
+                        INSERT INTO sponsors (
+                            id, event_id, name, description, website_url,
+                            logo_url, tier_id, display_order, is_active, 
+                            featured, social_links, created_at
+                        )
+                        VALUES (
+                            :id, :event_id, :name, :description, :website_url,
+                            :logo_url, :tier_id, :display_order, :is_active, 
+                            :featured, :social_links, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    sponsor_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(sponsors)} sponsors")
+
+            # Seed chat rooms
+            print("\n[10/14] Seeding chat rooms...")
+            chat_rooms = generate_chat_rooms()
+            for chat_room_data in chat_rooms:
+                db.session.execute(
+                    text("""
+                        INSERT INTO chat_rooms (
+                            id, event_id, session_id, name, description, 
+                            room_type, is_enabled, display_order, created_at
+                        )
+                        VALUES (
+                            :id, :event_id, :session_id, :name, :description, 
+                            :room_type, :is_enabled, :display_order, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    chat_room_data,
+                )
+            db.session.commit()
+            
+            # Count room types
+            global_rooms = len([r for r in chat_rooms if r["room_type"] == "GLOBAL"])
+            green_rooms = len([r for r in chat_rooms if r["room_type"] == "GREEN_ROOM"])
+            admin_rooms = len([r for r in chat_rooms if r["room_type"] == "ADMIN"])
+            public_rooms = len([r for r in chat_rooms if r["room_type"] == "PUBLIC"])
+            backstage_rooms = len([r for r in chat_rooms if r["room_type"] == "BACKSTAGE"])
+            
+            print(f"  ✓ Created {len(chat_rooms)} chat rooms")
+            print(f"    • {global_rooms} global, {green_rooms} green room, {admin_rooms} admin")
+            print(f"    • {public_rooms} public session, {backstage_rooms} backstage")
+
+            # Seed chat messages with incremental timestamps
+            print("\n[11/14] Seeding chat messages...")
+            chat_messages = generate_chat_messages()
+            base_time = datetime.now() - timedelta(hours=2)  # Start messages 2 hours ago
+            for i, message_data in enumerate(chat_messages):
+                # Add 30 seconds between each message for realistic timing
+                message_timestamp = base_time + timedelta(seconds=i * 30)
+                db.session.execute(
+                    text("""
+                        INSERT INTO chat_messages (id, room_id, user_id, content, created_at)
+                        VALUES (:id, :room_id, :user_id, :content, :timestamp)
+                    """),
+                    {**message_data, "timestamp": message_timestamp},
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(chat_messages)} chat messages")
+
+            # Seed connections
+            print("\n[12/14] Seeding user connections...")
+            connections = generate_connections()
+            for connection_data in connections:
+                db.session.execute(
+                    text("""
+                        INSERT INTO connections (
+                            id, requester_id, recipient_id, status, 
+                            icebreaker_message, originating_event_id, created_at
+                        )
+                        VALUES (
+                            :id, :requester_id, :recipient_id, :status, 
+                            :icebreaker_message, :originating_event_id, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    connection_data,
+                )
+            db.session.commit()
+            
+            # Count connection states
+            accepted = len([c for c in connections if c["status"] == "ACCEPTED"])
+            pending = len([c for c in connections if c["status"] == "PENDING"])
+            rejected = len([c for c in connections if c["status"] == "REJECTED"])
+            
+            print(f"  ✓ Created {len(connections)} connections")
+            print(f"    • {accepted} accepted, {pending} pending, {rejected} rejected")
+
+            # Seed direct message threads
+            print("\n[13/14] Seeding direct message threads...")
+            dm_threads = generate_direct_message_threads()
+            for thread_data in dm_threads:
+                db.session.execute(
+                    text("""
+                        INSERT INTO direct_message_threads (
+                            id, user1_id, user2_id, is_encrypted, 
+                            created_at, last_message_at
+                        )
+                        VALUES (
+                            :id, :user1_id, :user2_id, :is_encrypted, 
+                            CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                        )
+                    """),
+                    thread_data,
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(dm_threads)} DM threads")
+
+            # Seed direct messages with incremental timestamps
+            print("\n[14/14] Seeding direct messages...")
+            direct_messages = generate_direct_messages()
+            dm_base_time = datetime.now() - timedelta(days=1)  # Start DMs 1 day ago
+            for i, message_data in enumerate(direct_messages):
+                if "encrypted_content" not in message_data:
+                    message_data["encrypted_content"] = None
+                
+                # Add 2 hours between each DM for realistic timing
+                dm_timestamp = dm_base_time + timedelta(hours=i * 2)
+                
+                db.session.execute(
+                    text("""
+                        INSERT INTO direct_messages (
+                            id, thread_id, sender_id, content, 
+                            encrypted_content, status, created_at
+                        )
+                        VALUES (
+                            :id, :thread_id, :sender_id, :content, 
+                            :encrypted_content, :status, :timestamp
+                        )
+                    """),
+                    {**message_data, "timestamp": dm_timestamp},
+                )
+            db.session.commit()
+            print(f"  ✓ Created {len(direct_messages)} direct messages")
+
+            # Reset sequences
+            print("\n[FINAL] Resetting sequences...")
+            sequences_to_reset = [
+                ("users_id_seq", "users"),
+                ("organizations_id_seq", "organizations"),
+                ("events_id_seq", "events"),
+                ("sessions_id_seq", "sessions"),
+                ("sponsors_id_seq", "sponsors"),
+                ("chat_rooms_id_seq", "chat_rooms"),
+                ("chat_messages_id_seq", "chat_messages"),
+                ("connections_id_seq", "connections"),
+                ("direct_message_threads_id_seq", "direct_message_threads"),
+                ("direct_messages_id_seq", "direct_messages"),
+            ]
+            
+            for seq_name, table_name in sequences_to_reset:
+                try:
+                    # Validate identifiers
+                    if not all(c.isalnum() or c == '_' for c in seq_name):
+                        raise ValueError(f"Invalid sequence name: {seq_name}")
+                    if not all(c.isalnum() or c == '_' for c in table_name):
+                        raise ValueError(f"Invalid table name: {table_name}")
+                    
+                    query = text(f"""
+                        SELECT setval('"{seq_name}"'::regclass, 
+                            (SELECT COALESCE(MAX(id), 0) FROM "{table_name}") + 1, 
+                            false
+                        )
+                    """)
+                    db.session.execute(query)
+                except Exception as e:
+                    print(f"  ⚠ Warning: Could not reset sequence {seq_name}: {str(e)}")
+            
+            db.session.commit()
+            print("  ✓ Sequences reset")
+
+            print("\n" + "=" * 60)
+            print("✨ COMPREHENSIVE DATABASE SEEDING COMPLETE!")
+            print("=" * 60)
+            print("\n📊 Summary:")
+            print(f"  • {len(users)} users created")
+            print(f"  • {len(orgs)} organizations")
+            print(f"  • {len(events)} events (75, 20, and 8 attendees)")
+            print(f"  • {len(sessions)} sessions across all events")
+            print(f"  • {len(chat_rooms)} chat rooms with permission-based access")
+            print(f"  • {len(connections)} user connections")
+            print(f"  • {len(dm_threads)} DM conversations")
+            print("\n🔑 Demo Account:")
+            print("  Email: demouser@demo.com")
+            print("  Password: changeme")
+            print("  Role: Platform Owner & Event Admin")
+            print("\n⚠️  Note: All user emails are manually verified to avoid bounce issues")
+            print("=" * 60)
+
+        except Exception as e:
+            db.session.rollback()
+            print(f"\n❌ Error seeding database: {str(e)}")
+            raise e
+
+
+if __name__ == "__main__":
+    seed_comprehensive_database()

--- a/backend/atria/seeders/enhanced_chat.py
+++ b/backend/atria/seeders/enhanced_chat.py
@@ -1,0 +1,410 @@
+# Enhanced chat message generation with realistic conversations
+import random
+from typing import List, Dict, Any
+
+def generate_enhanced_chat_messages() -> List[Dict[str, Any]]:
+    """Generate 50+ messages in popular chat rooms for realistic feel"""
+    messages = []
+    message_id = 1
+    
+    # Room 1 - General Chat (Event 1) - Very active with 75+ messages
+    general_chat_messages = [
+        # Morning messages
+        (16, "Good morning everyone! Excited for day 1! 🎉"),
+        (23, "Can't wait for the opening keynote!"),
+        (35, "Anyone know if coffee is available yet?"),
+        (42, "Coffee station is open near the main entrance!"),
+        (35, "Thanks! Heading there now"),
+        (18, "The venue is amazing! So much bigger than last year"),
+        (45, "First time at this conference, any tips?"),
+        (16, "@User45 Don't miss the networking sessions, great for connections!"),
+        (52, "WiFi password anyone?"),
+        (42, "ATRIA2025 - all caps"),
+        (52, "Thanks!"),
+        (19, "Which track are you all planning to attend?"),
+        (27, "I'm going for the microservices talk"),
+        (33, "Kubernetes workshop for me!"),
+        (48, "Same here, K8s workshop looks great"),
+        
+        # Mid-morning buzz
+        (1, "Welcome everyone! I'm one of the organizers. Feel free to ask any questions!"),
+        (58, "Where's the best place to sit for the keynote?"),
+        (1, "Middle section has the best view of both screens"),
+        (63, "Are the sessions being recorded?"),
+        (1, "Yes! All sessions will be available to attendees post-conference"),
+        (71, "That's awesome, thanks!"),
+        (24, "Anyone else having trouble with the event app?"),
+        (36, "Try logging out and back in, worked for me"),
+        (24, "That worked, thanks!"),
+        
+        # Keynote reactions
+        (17, "Keynote starting in 5 minutes!"),
+        (29, "Already in my seat, so hyped!"),
+        (41, "The opening video is incredible!"),
+        (53, "This keynote is mind-blowing 🤯"),
+        (65, "The AI demo is insane!"),
+        (20, "Did anyone catch that GitHub repo they mentioned?"),
+        (31, "github.com/atria/future-stack"),
+        (20, "Perfect, thanks!"),
+        (44, "Best keynote I've seen in years"),
+        (56, "The quantum computing part was fascinating"),
+        (68, "I need to rewatch this later, so much to absorb"),
+        
+        # Post-keynote discussions
+        (22, "What sessions is everyone heading to next?"),
+        (34, "Microservices track for me"),
+        (46, "GraphQL vs REST comparison sounds interesting"),
+        (59, "Kubernetes workshop is filling up fast!"),
+        (70, "Already in line for the workshop"),
+        (25, "How long is the lunch break?"),
+        (1, "90 minutes, from 12:00 to 13:30"),
+        (37, "Any vegetarian options for lunch?"),
+        (1, "Yes! Full vegetarian station near the west entrance"),
+        (37, "Excellent, thank you!"),
+        
+        # Afternoon discussions
+        (28, "The microservices talk was exactly what I needed"),
+        (40, "Kubernetes workshop is hands-on heaven!"),
+        (51, "Anyone at the GraphQL talk? How is it?"),
+        (64, "Really good! Lots of practical examples"),
+        (21, "Panel discussion starting soon in main hall"),
+        (32, "AI panel has an amazing lineup"),
+        (43, "Getting in line now"),
+        (54, "Standing room only for the AI panel!"),
+        (66, "They're streaming it in overflow room B"),
+        (38, "The panelists' insights on MLOps are gold"),
+        (49, "Someone please share notes from the panel later!"),
+        (60, "I'm taking detailed notes, will share"),
+        (49, "You're the best!"),
+        
+        # Late afternoon
+        (26, "Last session of the day coming up"),
+        (39, "WebAssembly talk or Redis patterns?"),
+        (50, "WASM talk is supposed to be amazing"),
+        (61, "Redis talk has great reviews from other conferences"),
+        (72, "Why not split up and share notes later?"),
+        (39, "Great idea!"),
+        
+        # Evening networking
+        (30, "Welcome reception starting at 5!"),
+        (41, "Free drinks and food?"),
+        (1, "Yes! Full bar and appetizers"),
+        (53, "See everyone there!"),
+        (65, "Great first day everyone!"),
+        (18, "Learned so much already"),
+        (47, "Tomorrow's lineup looks even better"),
+        (55, "Don't forget to charge your devices tonight"),
+        (67, "Good reminder!"),
+        (73, "What time do doors open tomorrow?"),
+        (1, "Doors open at 8:30 AM"),
+        (73, "Perfect, thanks!"),
+        
+        # Day 2 Morning - Add 50+ more messages for pagination testing
+        (19, "Good morning day 2! Who's ready?"),
+        (31, "Already caffeinated and excited!"),
+        (42, "The security keynote this morning should be interesting"),
+        (54, "I'm heading to the React performance talk after"),
+        (66, "Same! Netflix's scale insights will be valuable"),
+        (23, "Anyone tried the breakfast yet?"),
+        (35, "Yes! Great selection today"),
+        (47, "The pastries are amazing"),
+        (59, "Conference food has really improved"),
+        (20, "True! Remember when it was just bagels?"),
+        (32, "Those were dark times 😂"),
+        (44, "Security keynote starting soon!"),
+        (56, "Already heading to the main hall"),
+        (68, "Save me a seat!"),
+        (21, "The sponsor booths have great swag today"),
+        (33, "Got some nice t-shirts!"),
+        (45, "The GitHub booth has stickers"),
+        (57, "Love conference stickers"),
+        (69, "My laptop is running out of space for them"),
+        (22, "First world problems!"),
+        
+        # Day 2 Sessions
+        (34, "React Server Components talk was mind-blowing"),
+        (46, "The performance gains are incredible"),
+        (58, "But the mental model shift is real"),
+        (70, "Worth it for the UX improvements"),
+        (24, "Go vs Rust debate was heated!"),
+        (36, "Both have their place IMO"),
+        (48, "Rust for systems, Go for services"),
+        (60, "Why not both? 🤷"),
+        (25, "GitOps workshop is hands-on gold"),
+        (37, "ArgoCD is a game changer"),
+        (49, "Finally understanding the workflow"),
+        (61, "This will save us so much time"),
+        
+        # Lunch discussions
+        (26, "Lightning talks during lunch were brilliant"),
+        (38, "5 minute talks are perfect format"),
+        (50, "Got more value than some hour-long sessions"),
+        (62, "Should do this every day"),
+        (27, "Multi-cloud panel starting"),
+        (39, "Vendor lock-in discussion should be spicy"),
+        (51, "AWS vs Azure vs GCP - fight!"),
+        (63, "Plot twist: they all have trade-offs"),
+        (28, "Serverless talk is packed!"),
+        (40, "Standing room only"),
+        (52, "The cold start problem discussion was great"),
+        (64, "Edge computing is the future"),
+        
+        # Afternoon buzz
+        (29, "Real-time data pipeline workshop is intense"),
+        (41, "Kafka + Flink is powerful"),
+        (53, "But complex to operate"),
+        (65, "Vector databases talk blew my mind"),
+        (71, "AI is changing everything"),
+        (30, "Zero trust architecture session was eye-opening"),
+        (42, "Security can't be an afterthought"),
+        (54, "Implementing this Monday!"),
+        (66, "Supply chain security is scary"),
+        (74, "So many vulnerabilities"),
+        (31, "Pen testing automation saves so much time"),
+        (43, "CI/CD integration is key"),
+        
+        # Day 3 anticipation
+        (55, "Can't believe it's the last day tomorrow"),
+        (67, "Quantum computing session will be interesting"),
+        (75, "Blockchain workshop too"),
+        (32, "AR/VR with WebXR sounds fun"),
+        (44, "The closing keynote speaker is amazing"),
+        (56, "Awards ceremony should be good"),
+        (68, "Best conference in years"),
+        (19, "Agreed! So much practical knowledge"),
+        (33, "The networking alone was worth it"),
+        (45, "Made so many connections"),
+        (57, "Already planning for next year"),
+        (69, "Early bird tickets?"),
+        (1, "We'll announce soon! 😉"),
+        (34, "Can't wait!"),
+        (46, "This community is the best"),
+        (58, "See everyone tomorrow for the finale!"),
+        (70, "Last day, let's make it count!"),
+        (21, "Meeting up for drinks after?"),
+        (35, "Absolutely!"),
+        (47, "Count me in"),
+        (59, "Let's celebrate a great conference"),
+        (22, "Perfect way to end it"),
+        (36, "What a journey this has been"),
+        (48, "Learned more in 3 days than 3 months"),
+        (60, "Implementation ideas overflowing"),
+        (23, "My notebook is completely full"),
+        (37, "Thank goodness for session recordings"),
+        (49, "Going to rewatch so many"),
+        (61, "The workshops especially"),
+        (24, "Team is going to love these insights"),
+        (38, "Monday standup will be interesting"),
+        (50, "So many things to try"),
+        (62, "Prioritization will be key"),
+        (25, "Start small, iterate fast"),
+        (39, "Best advice from the conference"),
+        (51, "Ship it!"),
+        (63, "But test first 😄"),
+        (26, "Anyone doing the certification exam?"),
+        (40, "Thinking about it"),
+        (52, "The cloud native cert looks valuable"),
+        (64, "Study group?"),
+        (27, "I'm in!"),
+        (41, "Me too"),
+        (53, "Let's ace it together"),
+        (65, "Community learning is the best"),
+        (28, "This chat has been so helpful"),
+        (42, "Better than Slack!"),
+        (54, "Real-time conference chat is brilliant"),
+        (66, "Should be standard at every event"),
+        (1, "Thanks everyone! You make it special"),
+        (29, "Thank YOU for organizing!"),
+        (43, "Incredible event"),
+        (55, "See you all tomorrow!"),
+        (67, "Bright and early"),
+        (74, "Worth every minute"),
+        (75, "💯"),
+    ]
+    
+    for user_id, content in general_chat_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 1,  # General Chat
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Room 2 - Green Room (Speakers) - Moderate activity (30+ messages)
+    green_room_messages = [
+        (1, "Welcome speakers! This is your private space to connect"),
+        (2, "Thanks for having us! Looking forward to presenting"),
+        (3, "Anyone else nervous about their talk?"),
+        (4, "Always get butterflies, even after 50+ talks"),
+        (5, "That's actually reassuring to hear"),
+        (6, "Pro tip: Power poses before going on stage really help"),
+        (7, "I do breathing exercises"),
+        (10, "My slides are still not perfect 😅"),
+        (11, "Perfectionism is the enemy of done!"),
+        (12, "True! They're good enough"),
+        (2, "Anyone want to practice together?"),
+        (3, "I'm in! Meet in speaker prep room?"),
+        (2, "See you in 10"),
+        (13, "How's the AV setup this year?"),
+        (1, "All updated! HDMI and USB-C available, wireless presenting too"),
+        (14, "Fantastic! Wireless is a game changer"),
+        (4, "Clicker batteries died last year mid-talk 😂"),
+        (5, "Nightmare fuel!"),
+        (6, "Always bring backup batteries"),
+        (7, "And backup slides on USB"),
+        (10, "And backup laptop..."),
+        (11, "At this rate, bring a backup speaker too!"),
+        (12, "😂😂😂"),
+        (2, "Good luck everyone with your sessions today!"),
+        (3, "Break a leg!"),
+        (4, "You're all going to be amazing"),
+        (1, "Proud of our speaker lineup this year"),
+        (13, "Best conference speaker experience I've had"),
+        (14, "The green room snacks are elite"),
+        (5, "That coffee machine is saving my life"),
+        (6, "Same! On my third cup"),
+    ]
+    
+    for user_id, content in green_room_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 2,  # Green Room
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Room 3 - Admin Room (Organizers) - Moderate activity (25+ messages)
+    admin_messages = [
+        (1, "Team, everything ready for opening?"),
+        (8, "Registration desk is set up and staffed"),
+        (15, "AV check complete for main hall"),
+        (22, "Catering confirmed and arriving at 7:30"),
+        (1, "Excellent! Let's make this amazing"),
+        (8, "Slight backup at registration"),
+        (15, "Sending two more volunteers"),
+        (8, "That helped, queue moving now"),
+        (22, "Coffee stations need refill already!"),
+        (1, "The coffee addiction is real 😄"),
+        (15, "Keynote speaker has arrived"),
+        (1, "Perfect! Please escort to green room"),
+        (8, "Workshop room C projector issues"),
+        (15, "IT on the way"),
+        (15, "Fixed! Loose cable"),
+        (22, "Lunch setup starting at 11:30"),
+        (1, "Remember all-hands at 6 PM today"),
+        (8, "WiFi holding up well, 450 concurrent users"),
+        (15, "Stream quality looks good"),
+        (22, "Had a medical incident, handled well"),
+        (1, "Great job on quick response"),
+        (8, "Attendee feedback is overwhelmingly positive!"),
+        (15, "Social media is buzzing about the keynote"),
+        (22, "Tomorrow's schedule confirmed with all speakers"),
+        (1, "Team, you're all doing amazing work!"),
+    ]
+    
+    for user_id, content in admin_messages:
+        messages.append({
+            "id": message_id,
+            "room_id": 3,  # Admin Room
+            "user_id": user_id,
+            "content": content,
+        })
+        message_id += 1
+    
+    # Session-specific public rooms with varied activity
+    # Room IDs: 4=Session1 Chat, 6=Session2 Chat, 8=Session3 Chat, 10=Session5 Chat
+    session_rooms = [
+        (8, [  # Session 3 Chat (Kubernetes Workshop)
+            (3, "Instructor here! Setting up now"),
+            (33, "So excited for this workshop!"),
+            (48, "Is this beginner friendly?"),
+            (3, "Absolutely! We'll start with basics"),
+            (70, "Should we have kubectl installed?"),
+            (3, "We'll use a cloud environment, no local setup needed"),
+            (59, "Perfect!"),
+            (4, "I'll be assisting today"),
+            (33, "This hands-on approach is perfect"),
+            (48, "Deployments are making sense now!"),
+            (70, "The examples are so practical"),
+            (3, "Feel free to ask questions anytime!"),
+        ]),
+        (4, [  # Session 1 Chat (Opening Keynote)
+            (16, "Can't wait for this to start!"),
+            (28, "Demo User's talks are always inspiring"),
+            (40, "The topic sounds fascinating"),
+            (52, "Already taking notes"),
+            (64, "This is going to be epic!"),
+        ]),
+        (10, [  # Session 5 Chat (AI Panel)
+            (12, "Panel starting in 10 minutes"),
+            (5, "Looking forward to the MLOps discussion"),
+            (6, "Hope they cover deployment challenges"),
+            (7, "And scaling issues"),
+            (10, "Monitoring ML models in prod is my pain point"),
+            (11, "Same here!"),
+            (38, "This panel is fire! 🔥"),
+            (49, "Best insights on model drift I've heard"),
+            (60, "The production tips are gold"),
+        ]),
+    ]
+    
+    for room_id, room_messages in session_rooms:
+        for user_id, content in room_messages:
+            messages.append({
+                "id": message_id,
+                "room_id": room_id,
+                "user_id": user_id,
+                "content": content,
+            })
+            message_id += 1
+    
+    # Event 2 chat rooms (moderate activity)
+    event2_messages = [
+        (12, [  # Room 12 is General Discussion for Event 2
+            (25, "Welcome to Cloud Native Summit!"),
+            (26, "Great to be here"),
+            (27, "Looking forward to the service mesh workshop"),
+            (28, "Container security panel should be interesting"),
+            (29, "Anyone tried Istio in production?"),
+            (45, "Yes, bit of a learning curve but worth it"),
+            (46, "KEDA talk later looks promising"),
+            (47, "Autoscaling is always a hot topic"),
+        ]),
+    ]
+    
+    for room_id, room_messages in event2_messages:
+        for user_id, content in room_messages:
+            messages.append({
+                "id": message_id,
+                "room_id": room_id,
+                "user_id": user_id,
+                "content": content,
+            })
+            message_id += 1
+    
+    # Event 3 (small workshop) - minimal messages
+    # Use room 14 which is Workshop Chat for Event 2 (we can repurpose for Event 3 messages)
+    messages.extend([
+        {
+            "id": message_id,
+            "room_id": 14,  # Workshop Chat
+            "user_id": 30,
+            "content": "Welcome to the ML workshop!",
+        },
+        {
+            "id": message_id + 1,
+            "room_id": 14,
+            "user_id": 31,
+            "content": "We'll start with environment setup",
+        },
+        {
+            "id": message_id + 2,
+            "room_id": 14,
+            "user_id": 32,
+            "content": "Ready to learn!",
+        },
+    ])
+    
+    return messages

--- a/backend/atria/seeders/enhanced_sessions.py
+++ b/backend/atria/seeders/enhanced_sessions.py
@@ -1,0 +1,230 @@
+# Enhanced session generation with full 3-day schedule
+from datetime import time
+from typing import List, Dict, Any
+
+def generate_enhanced_sessions() -> List[Dict[str, Any]]:
+    """Generate comprehensive session schedule for all events"""
+    sessions = []
+    session_id = 1
+    
+    # Event 1 - Full 3-day conference schedule
+    # Day 1 - March 15 - Opening Day (15 sessions)
+    day1_sessions = [
+        # Morning
+        {"type": "KEYNOTE", "title": "Opening Keynote: The Future of Software Development", 
+         "short": "Vision for the next decade", "start": time(9, 0), "end": time(10, 0)},
+        
+        # Morning Track A
+        {"type": "PRESENTATION", "title": "Building Scalable Microservices", 
+         "short": "Patterns for microservice architecture", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "Event-Driven Architecture at Scale", 
+         "short": "Kafka, EventBridge, and beyond", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Morning Track B  
+        {"type": "WORKSHOP", "title": "Hands-on Kubernetes Workshop", 
+         "short": "Deploy and manage K8s applications", "start": time(10, 15), "end": time(12, 0)},
+        
+        # Morning Track C
+        {"type": "PRESENTATION", "title": "GraphQL vs REST: Choosing the Right API", 
+         "short": "API design patterns comparison", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "Securing Your APIs in 2025", 
+         "short": "Modern API security best practices", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Lunch
+        {"type": "NETWORKING", "title": "Lunch & Networking", 
+         "short": "Connect with fellow attendees", "start": time(12, 0), "end": time(13, 30)},
+        
+        # Afternoon Track A
+        {"type": "PANEL", "title": "The Future of AI in Production", 
+         "short": "Industry leaders discuss AI deployment", "start": time(13, 30), "end": time(14, 45)},
+        {"type": "PRESENTATION", "title": "Machine Learning Operations (MLOps)", 
+         "short": "Deploying ML models at scale", "start": time(15, 0), "end": time(15, 45)},
+        {"type": "PRESENTATION", "title": "Observability in Distributed Systems", 
+         "short": "Monitoring microservices effectively", "start": time(16, 0), "end": time(16, 45)},
+        
+        # Afternoon Track B
+        {"type": "WORKSHOP", "title": "React Performance Workshop", 
+         "short": "Optimize React apps for production", "start": time(13, 30), "end": time(15, 30)},
+        {"type": "PRESENTATION", "title": "WebAssembly: The Future of Web Performance", 
+         "short": "WASM in production applications", "start": time(15, 45), "end": time(16, 45)},
+        
+        # Afternoon Track C
+        {"type": "PRESENTATION", "title": "Database Design for Scale", 
+         "short": "PostgreSQL optimization techniques", "start": time(13, 30), "end": time(14, 30)},
+        {"type": "PRESENTATION", "title": "Redis Beyond Caching", 
+         "short": "Advanced Redis patterns", "start": time(14, 45), "end": time(15, 45)},
+        
+        # Evening
+        {"type": "NETWORKING", "title": "Welcome Reception", 
+         "short": "Evening networking event", "start": time(17, 0), "end": time(19, 0)},
+    ]
+    
+    # Day 2 - March 16 - Deep Dive Day (18 sessions)
+    day2_sessions = [
+        # Morning Keynote
+        {"type": "KEYNOTE", "title": "Security in the Age of AI", 
+         "short": "AI and cybersecurity intersection", "start": time(9, 0), "end": time(10, 0)},
+        
+        # Morning Track A - Frontend
+        {"type": "PRESENTATION", "title": "React Server Components Deep Dive", 
+         "short": "Next.js 14 and RSC patterns", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "State Management in 2025", 
+         "short": "Zustand, Jotai, and Valtio comparison", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Morning Track B - Backend
+        {"type": "PRESENTATION", "title": "Go vs Rust for Backend Services", 
+         "short": "Performance and productivity comparison", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "Building with Bun and Hono", 
+         "short": "Modern JavaScript backend stack", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Morning Track C - DevOps
+        {"type": "WORKSHOP", "title": "GitOps with ArgoCD", 
+         "short": "Kubernetes deployments with GitOps", "start": time(10, 15), "end": time(12, 0)},
+        
+        # Morning Track D - Mobile
+        {"type": "PRESENTATION", "title": "Flutter vs React Native in 2025", 
+         "short": "Cross-platform mobile development", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "iOS Development with SwiftUI", 
+         "short": "Modern iOS app architecture", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Lunch
+        {"type": "NETWORKING", "title": "Tech Talks Lunch", 
+         "short": "Lightning talks during lunch", "start": time(12, 0), "end": time(13, 30)},
+        
+        # Afternoon Track A - Cloud
+        {"type": "PANEL", "title": "Multi-Cloud Strategy Panel", 
+         "short": "AWS vs Azure vs GCP", "start": time(13, 30), "end": time(14, 45)},
+        {"type": "PRESENTATION", "title": "Serverless at Scale", 
+         "short": "Lambda, Functions, and Edge computing", "start": time(15, 0), "end": time(15, 45)},
+        {"type": "PRESENTATION", "title": "Cost Optimization in the Cloud", 
+         "short": "FinOps best practices", "start": time(16, 0), "end": time(16, 45)},
+        
+        # Afternoon Track B - Data
+        {"type": "WORKSHOP", "title": "Real-time Data Pipelines", 
+         "short": "Kafka, Flink, and Spark Streaming", "start": time(13, 30), "end": time(15, 30)},
+        {"type": "PRESENTATION", "title": "Vector Databases for AI", 
+         "short": "Pinecone, Weaviate, and Qdrant", "start": time(15, 45), "end": time(16, 45)},
+        
+        # Afternoon Track C - Security
+        {"type": "PRESENTATION", "title": "Zero Trust Architecture", 
+         "short": "Implementing zero trust in practice", "start": time(13, 30), "end": time(14, 30)},
+        {"type": "PRESENTATION", "title": "Supply Chain Security", 
+         "short": "Securing your dependencies", "start": time(14, 45), "end": time(15, 45)},
+        {"type": "PRESENTATION", "title": "Penetration Testing Automation", 
+         "short": "Security testing in CI/CD", "start": time(16, 0), "end": time(16, 45)},
+        
+        # Evening
+        {"type": "NETWORKING", "title": "Sponsor Showcase & Happy Hour", 
+         "short": "Meet our sponsors", "start": time(17, 0), "end": time(19, 0)},
+    ]
+    
+    # Day 3 - March 17 - Innovation Day (12 sessions)
+    day3_sessions = [
+        # Morning Keynote
+        {"type": "KEYNOTE", "title": "Closing Keynote: Building the Future Together", 
+         "short": "Community and open source", "start": time(9, 0), "end": time(10, 0)},
+        
+        # Morning Sessions
+        {"type": "PRESENTATION", "title": "Quantum Computing for Developers", 
+         "short": "Introduction to quantum algorithms", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "Edge Computing Architecture", 
+         "short": "Computing at the edge", "start": time(11, 15), "end": time(12, 0)},
+        
+        {"type": "WORKSHOP", "title": "Building Your First Blockchain App", 
+         "short": "Smart contracts and Web3", "start": time(10, 15), "end": time(12, 0)},
+        
+        {"type": "PRESENTATION", "title": "AR/VR Development with WebXR", 
+         "short": "Building immersive web experiences", "start": time(10, 15), "end": time(11, 0)},
+        {"type": "PRESENTATION", "title": "IoT Architecture Patterns", 
+         "short": "Scalable IoT solutions", "start": time(11, 15), "end": time(12, 0)},
+        
+        # Lunch
+        {"type": "NETWORKING", "title": "Farewell Lunch", 
+         "short": "Final networking opportunity", "start": time(12, 0), "end": time(13, 30)},
+        
+        # Afternoon Sessions
+        {"type": "PANEL", "title": "The Next Big Thing in Tech", 
+         "short": "VCs discuss emerging technologies", "start": time(13, 30), "end": time(14, 45)},
+        {"type": "PRESENTATION", "title": "Open Source Sustainability", 
+         "short": "Maintaining OSS projects", "start": time(15, 0), "end": time(15, 45)},
+        {"type": "PRESENTATION", "title": "Building Inclusive Tech Teams", 
+         "short": "Diversity and inclusion strategies", "start": time(16, 0), "end": time(16, 45)},
+        
+        {"type": "WORKSHOP", "title": "Career Growth Workshop", 
+         "short": "Planning your tech career", "start": time(13, 30), "end": time(15, 30)},
+        
+        # Closing
+        {"type": "KEYNOTE", "title": "Closing Ceremony & Awards", 
+         "short": "Conference wrap-up", "start": time(17, 0), "end": time(17, 30)},
+    ]
+    
+    # Generate Event 1 sessions
+    for day_num, day_sessions in enumerate([(day1_sessions, 1), (day2_sessions, 2), (day3_sessions, 3)], 1):
+        for session in day_sessions[0]:
+            sessions.append({
+                "id": session_id,
+                "event_id": 1,
+                "status": "SCHEDULED",
+                "session_type": session["type"],
+                "title": session["title"],
+                "short_description": session["short"],
+                "description": f"Join us for {session['title']}. {session['short']}. This session will provide valuable insights and practical knowledge.",
+                "start_time": session["start"],
+                "end_time": session["end"],
+                "stream_url": f"https://stream.atria.com/session{session_id}" if session["type"] != "NETWORKING" else None,
+                "day_number": day_sessions[1],
+            })
+            session_id += 1
+    
+    # Event 2 - Cloud Native Summit (8 sessions)
+    event2_sessions = [
+        {"type": "KEYNOTE", "title": "Cloud Native Architecture Patterns", 
+         "short": "Modern cloud-native design", "start": time(9, 0), "end": time(10, 0)},
+        {"type": "WORKSHOP", "title": "Service Mesh Deep Dive", 
+         "short": "Implementing Istio", "start": time(10, 30), "end": time(12, 30)},
+        {"type": "PRESENTATION", "title": "Observability with OpenTelemetry", 
+         "short": "Distributed tracing", "start": time(10, 30), "end": time(11, 30)},
+        {"type": "NETWORKING", "title": "Lunch Break", 
+         "short": "Networking lunch", "start": time(12, 30), "end": time(13, 30)},
+        {"type": "PANEL", "title": "Container Security Best Practices", 
+         "short": "Securing containerized apps", "start": time(13, 30), "end": time(14, 45)},
+        {"type": "PRESENTATION", "title": "CI/CD for Kubernetes", 
+         "short": "GitOps workflows", "start": time(15, 0), "end": time(16, 0)},
+        {"type": "PRESENTATION", "title": "Scaling with KEDA", 
+         "short": "Event-driven autoscaling", "start": time(16, 15), "end": time(17, 15)},
+        {"type": "KEYNOTE", "title": "Future of Cloud Computing", 
+         "short": "Closing keynote", "start": time(17, 30), "end": time(18, 30)},
+    ]
+    
+    for session in event2_sessions:
+        sessions.append({
+            "id": session_id,
+            "event_id": 2,
+            "status": "SCHEDULED",
+            "session_type": session["type"],
+            "title": session["title"],
+            "short_description": session["short"],
+            "description": f"{session['title']} - {session['short']}. Join industry experts for this insightful session.",
+            "start_time": session["start"],
+            "end_time": session["end"],
+            "stream_url": f"https://stream.cloud.com/session{session_id}" if session["type"] != "NETWORKING" else None,
+            "day_number": 1,
+        })
+        session_id += 1
+    
+    # Event 3 - AI/ML Workshop (1 intensive session)
+    sessions.append({
+        "id": session_id,
+        "event_id": 3,
+        "status": "SCHEDULED",
+        "session_type": "WORKSHOP",
+        "title": "Practical Machine Learning with Python",
+        "short_description": "Hands-on ML model development",
+        "description": "Build and deploy ML models using scikit-learn, TensorFlow, and PyTorch. This intensive workshop covers the entire ML pipeline.",
+        "start_time": time(9, 0),
+        "end_time": time(17, 0),
+        "stream_url": None,
+        "day_number": 1,
+    })
+    
+    return sessions

--- a/backend/atria/seeders/long_dm_conversation.py
+++ b/backend/atria/seeders/long_dm_conversation.py
@@ -1,0 +1,177 @@
+# Long DM conversation for pagination testing
+from typing import List, Dict, Any
+
+def generate_long_dm_conversations() -> List[Dict[str, Any]]:
+    """Generate 50+ message DM conversation for pagination testing"""
+    messages = []
+    message_id = 1
+    
+    # Thread 1: Demo User <-> Sarah Chen - LONG technical discussion (60+ messages)
+    thread1_messages = [
+        (1, 2, "Hi Sarah! Thanks for accepting my connection request."),
+        (2, 1, "Happy to connect! Your work on the Atria platform looks impressive."),
+        (1, 2, "Thank you! I saw you're speaking about distributed systems. What will you cover?"),
+        (2, 1, "I'll be discussing patterns we use at Netflix for handling millions of concurrent users."),
+        (1, 2, "That sounds fascinating! How do you handle data consistency?"),
+        (2, 1, "Great question! We use eventual consistency with conflict resolution strategies."),
+        (1, 2, "Do you use CRDTs at all?"),
+        (2, 1, "Yes! For certain use cases like watch lists and user preferences."),
+        (1, 2, "That's clever. How about for real-time features?"),
+        (2, 1, "WebSockets with fallback to SSE, plus Redis for pub/sub."),
+        (1, 2, "We're using a similar approach for Atria's chat features."),
+        (2, 1, "Nice! How are you handling message ordering?"),
+        (1, 2, "Timestamp-based with vector clocks for conflict resolution."),
+        (2, 1, "Smart. Have you had issues with clock drift?"),
+        (1, 2, "Some. We implemented NTP sync checks on the backend."),
+        (2, 1, "That's a good approach. What about message delivery guarantees?"),
+        (1, 2, "At-least-once delivery with idempotency keys."),
+        (2, 1, "Classic pattern. How's your database architecture?"),
+        (1, 2, "PostgreSQL primary with read replicas, Redis for caching."),
+        (2, 1, "Solid choice. Any sharding?"),
+        (1, 2, "Not yet, but we're designing for it. Considering Vitess."),
+        (2, 1, "Vitess is great. We use custom sharding at Netflix."),
+        (1, 2, "How do you handle cross-shard queries?"),
+        (2, 1, "Scatter-gather with async aggregation. It's complex but works."),
+        (1, 2, "I can imagine. What about your microservices communication?"),
+        (2, 1, "gRPC for internal, REST for external APIs."),
+        (1, 2, "Same here! Do you use service mesh?"),
+        (2, 1, "Yes, custom solution similar to Istio but optimized for our scale."),
+        (1, 2, "Interesting. How do you handle service discovery?"),
+        (2, 1, "Custom registry with health checking and load balancing."),
+        (1, 2, "We're using Consul. Working well so far."),
+        (2, 1, "Consul is solid. How about your deployment pipeline?"),
+        (1, 2, "GitOps with ArgoCD, rolling deployments with canary releases."),
+        (2, 1, "Nice! We do blue-green with automated rollback triggers."),
+        (1, 2, "What metrics trigger rollbacks?"),
+        (2, 1, "Error rates, latency P99, and business metrics like play starts."),
+        (1, 2, "Business metrics in deployment decisions - that's smart."),
+        (2, 1, "Critical at our scale. One bad deploy can cost millions."),
+        (1, 2, "I believe it. How do you test at that scale?"),
+        (2, 1, "Chaos engineering, load testing with production traffic replay."),
+        (1, 2, "Traffic replay is interesting. How do you handle PII?"),
+        (2, 1, "Automated scrubbing and tokenization before replay."),
+        (1, 2, "Makes sense. What about your monitoring stack?"),
+        (2, 1, "Custom metrics pipeline, but moving towards OpenTelemetry."),
+        (1, 2, "We're all-in on OpenTelemetry. Great decision."),
+        (2, 1, "How's the performance overhead?"),
+        (1, 2, "Minimal with sampling. About 1-2% CPU increase."),
+        (2, 1, "That's acceptable. What sampling rate?"),
+        (1, 2, "0.1% for normal traffic, 100% for errors."),
+        (2, 1, "Good strategy. How about your frontend architecture?"),
+        (1, 2, "React with Redux, moving to RTK Query for data fetching."),
+        (2, 1, "RTK Query is fantastic. Big improvement over plain Redux."),
+        (1, 2, "Agreed! The caching is so much better."),
+        (2, 1, "Have you looked at React Server Components?"),
+        (1, 2, "Experimenting with them. The DX is interesting."),
+        (2, 1, "We're going all-in. Initial results are promising."),
+        (1, 2, "What kind of performance improvements are you seeing?"),
+        (2, 1, "30-40% reduction in client bundle size, better INP scores."),
+        (1, 2, "Impressive! Any downsides?"),
+        (2, 1, "Complexity increase, harder mental model for developers."),
+        (1, 2, "That's our concern too. How's the migration going?"),
+        (2, 1, "Gradual. Route by route. Can't do big bang at our scale."),
+        (1, 2, "Smart approach. Speaking of scale, how many engineers?"),
+        (2, 1, "About 2000 in product engineering."),
+        (1, 2, "Wow! How do you coordinate at that scale?"),
+        (2, 1, "Strong platform teams, good tooling, clear interfaces."),
+        (1, 2, "Platform teams are crucial. We're building ours now."),
+        (2, 1, "Start with developer experience. It pays dividends."),
+        (1, 2, "Any specific tools you'd recommend?"),
+        (2, 1, "Backstage for developer portal, great for documentation."),
+        (1, 2, "We're looking at Backstage! How's your experience?"),
+        (2, 1, "Positive overall. Some customization needed but worth it."),
+        (1, 2, "Good to know. Thanks for all the insights!"),
+        (2, 1, "Happy to help! Let's catch up after my talk."),
+        (1, 2, "Definitely! Good luck with your session."),
+        (2, 1, "Thanks! See you there!"),
+    ]
+    
+    for sender, recipient, content in thread1_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 1,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ",
+        })
+        message_id += 1
+    
+    # Thread 2: Demo User <-> Marcus Rodriguez - Shorter conversation
+    thread2_messages = [
+        (3, 1, "Thanks for connecting! Excited about the conference."),
+        (1, 3, "Me too! Your Kubernetes workshop looks great."),
+        (3, 1, "We'll cover a lot of practical examples. Bring your laptop!"),
+        (1, 3, "Will do! Any prerequisites I should review?"),
+        (3, 1, "Basic Docker knowledge would be helpful, but we'll cover the fundamentals."),
+        (1, 3, "Perfect. I've been using Docker for a while."),
+        (3, 1, "Great! Then you'll be able to follow the advanced sections too."),
+        (1, 3, "Looking forward to the hands-on exercises."),
+        (3, 1, "They're the best part. Real clusters, real deployments."),
+        (1, 3, "Using cloud providers or local?"),
+        (3, 1, "Cloud. We have credits for everyone."),
+        (1, 3, "Excellent! See you at the workshop."),
+    ]
+    
+    for sender, recipient, content in thread2_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 2,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ",
+        })
+        message_id += 1
+    
+    # Thread 3: Demo User <-> Chris Martinez (Organizer)
+    thread3_messages = [
+        (8, 1, "Hey! Everything ready for your keynote?"),
+        (1, 8, "Yes! Just finished the final slides. Thanks for checking in."),
+        (8, 1, "Perfect. AV team will be ready 30 min early for setup."),
+        (1, 8, "Great, I'll be there. How's registration looking?"),
+        (8, 1, "We're at 380 in-person and 200+ virtual. Great turnout!"),
+        (1, 8, "That's amazing! This is going to be a great event."),
+        (8, 1, "Your keynote is highly anticipated. No pressure 😄"),
+        (1, 8, "Ha! I'll do my best. The topic resonates with many."),
+        (8, 1, "Future of software development - perfect opening."),
+        (1, 8, "I'm covering AI, quantum, and new paradigms."),
+        (8, 1, "The quantum section will be interesting!"),
+        (1, 8, "Trying to make it accessible without dumbing down."),
+        (8, 1, "That's the sweet spot. You'll nail it."),
+        (1, 8, "Thanks for the confidence boost!"),
+        (8, 1, "Anytime! Need anything else before tomorrow?"),
+        (1, 8, "All good. See you bright and early!"),
+    ]
+    
+    for sender, recipient, content in thread3_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 3,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ",
+        })
+        message_id += 1
+    
+    # Thread 4: Some unread messages
+    thread4_messages = [
+        (15, 1, "Hi! Quick question about the platform."),
+        (1, 15, "Sure, happy to help! What would you like to know?"),
+        (15, 1, "Is Atria open source or available for licensing?"),
+        (15, 1, "We're considering it for our internal events."),
+    ]
+    
+    for sender, recipient, content in thread4_messages:
+        messages.append({
+            "id": message_id,
+            "thread_id": 4,
+            "sender_id": sender,
+            "content": content,
+            "encrypted_content": None,
+            "status": "READ" if message_id < 100 else "SENT",
+        })
+        message_id += 1
+    
+    return messages


### PR DESCRIPTION
- Add 80 diverse users across major tech companies (Netflix, Google, Meta, etc.)
- Create 3 events with different scales (75, 20, and 8 attendees)
- Generate 54 sessions with full 3-day conference schedule
- Implement 281 chat messages including 188 in General Chat for pagination testing
- Add 108 direct messages with 76-message technical discussion thread
- Fix enum value mismatches (use UPPERCASE to match database)
- Implement incremental timestamps for proper message ordering
- Create modular seeder architecture with separate concern files
- Update init.sh to use comprehensive seeder on startup

This provides robust test data for:
- Pagination testing (50/100 messages per page)
- Permission-based chat rooms (GLOBAL, GREEN_ROOM, ADMIN)
- Realistic conference environment with speakers, attendees, organizers
- Direct messaging with long conversations
- Connection requests (pending/accepted/rejected states)

