### PR TITLE
feat: implement comprehensive event role permission system

### DIFF
--- a/backend/atria/api/api/routes/event_users.py
+++ b/backend/atria/api/api/routes/event_users.py
@@ -20,6 +20,8 @@ from api.commons.decorators import (
     event_member_required,
     event_organizer_required,
     event_admin_required,
+    event_organizer_or_org_owner_required,
+    event_admin_or_org_owner_required,
 )
 from api.services.event_user import EventUserService
 
@@ -145,7 +147,7 @@ class EventUserDetail(MethodView):
         },
     )
     @jwt_required()
-    @event_organizer_required()
+    @event_organizer_or_org_owner_required()
     def put(self, update_data, event_id, user_id):
         """Update user's role or info in event"""
         return EventUserService.update_user_role(
@@ -170,7 +172,7 @@ class EventUserDetail(MethodView):
         },
     )
     @jwt_required()
-    @event_admin_required()
+    @event_admin_or_org_owner_required()
     def delete(self, event_id, user_id):
         """Remove user from event"""
         try:

--- a/frontend/src/pages/EventAdmin/AttendeesManager/AttendeesList/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/AttendeesList/index.jsx
@@ -6,6 +6,8 @@ import styles from './styles.module.css';
 const AttendeesList = ({
   attendees,
   currentUserRole,
+  currentUserId,
+  adminCount,
   onUpdateRole,
   onSort,
   sortBy,
@@ -75,6 +77,8 @@ const AttendeesList = ({
               attendee={attendee}
               onUpdateRole={onUpdateRole}
               currentUserRole={currentUserRole}
+              currentUserId={currentUserId}
+              adminCount={adminCount}
             />
           ))}
         </Table.Tbody>

--- a/frontend/src/pages/EventAdmin/AttendeesManager/InviteModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/InviteModal/index.jsx
@@ -20,7 +20,7 @@ import {
 import { Button } from '../../../../shared/components/buttons';
 import styles from './styles.module.css';
 
-const InviteModal = ({ opened, onClose, eventId, onSuccess }) => {
+const InviteModal = ({ opened, onClose, eventId, currentUserRole, onSuccess }) => {
   const [activeTab, setActiveTab] = useState('single');
   const [bulkEmails, setBulkEmails] = useState('');
   const [sendInvitation, { isLoading: isSending }] = useSendEventInvitationMutation();
@@ -159,12 +159,23 @@ const InviteModal = ({ opened, onClose, eventId, onSuccess }) => {
     onClose();
   };
 
-  const roleOptions = [
-    { value: 'ATTENDEE', label: getRoleDisplayName('ATTENDEE') },
-    { value: 'SPEAKER', label: getRoleDisplayName('SPEAKER') },
-    { value: 'ORGANIZER', label: getRoleDisplayName('ORGANIZER') },
-    { value: 'ADMIN', label: getRoleDisplayName('ADMIN') },
-  ];
+  // Filter role options based on current user's role
+  const roleOptions = (() => {
+    const allRoles = [
+      { value: 'ATTENDEE', label: getRoleDisplayName('ATTENDEE') },
+      { value: 'SPEAKER', label: getRoleDisplayName('SPEAKER') },
+      { value: 'ORGANIZER', label: getRoleDisplayName('ORGANIZER') },
+      { value: 'ADMIN', label: getRoleDisplayName('ADMIN') },
+    ];
+    
+    if (currentUserRole === 'ORGANIZER') {
+      // Organizers can only invite ATTENDEE and SPEAKER
+      return allRoles.filter(role => ['ATTENDEE', 'SPEAKER'].includes(role.value));
+    }
+    
+    // Admins can invite any role
+    return allRoles;
+  })();
 
   return (
     <Modal


### PR DESCRIPTION
- Add hierarchical role change permissions:
  - Organizers can only change between ATTENDEE ↔ SPEAKER roles
  - Admins can change any role except cannot remove last admin
  - Organization owners have full admin privileges even if not event members
  - Users cannot change their own roles

- Implement invitation role restrictions:
  - Organizers can only invite as ATTENDEE or SPEAKER
  - Admins can invite with any role
  - Organization owners bypass all invitation restrictions

- Add backend validation and permission checks:
  - New decorators for org owner permissions
  - Service layer validation for role changes and invitations
  - Protection against removing last event admin

- Update frontend with proper permission checks:
  - Role change UI disabled based on user permissions
  - Invitation modal filters role options by user role
  - Accurate role counts displayed regardless of pagination

- Fix role count display to show total counts from backend instead of just current page counts

