### PR TITLE
feat: add change password functionality to Settings

### DIFF
--- a/backend/atria/api/api/routes/auth.py
+++ b/backend/atria/api/api/routes/auth.py
@@ -13,6 +13,7 @@ from api.api.schemas import (
     ResetPasswordSchema,
     ValidateResetTokenResponseSchema,
     VerifyPasswordSchema,
+    ChangePasswordSchema,
 )
 from api.services.auth import AuthService
 
@@ -327,3 +328,22 @@ class VerifyPasswordResource(MethodView):
             abort(401, message="Incorrect password")
         
         return {"message": "Password verified successfully"}
+
+
+@blp.route("/change-password")
+class ChangePasswordResource(MethodView):
+    @jwt_required()
+    @blp.arguments(ChangePasswordSchema)
+    @blp.response(200)
+    @blp.doc(
+        summary="Change user password",
+        description="Change the current user's password",
+        responses={
+            200: {"description": "Password changed successfully"},
+            400: {"description": "Invalid current password or new password requirements not met"},
+            401: {"description": "Not authenticated"},
+        },
+    )
+    def put(self, args):
+        """Change current user's password"""
+        return AuthService.change_password(args["current_password"], args["new_password"])

--- a/backend/atria/api/api/schemas/__init__.py
+++ b/backend/atria/api/api/schemas/__init__.py
@@ -78,6 +78,7 @@ from api.api.schemas.auth import (
     ResetPasswordSchema,
     ValidateResetTokenResponseSchema,
     VerifyPasswordSchema,
+    ChangePasswordSchema,
 )
 
 from api.api.schemas.chat import (
@@ -186,6 +187,7 @@ __all__ = [
     "ResetPasswordSchema",
     "ValidateResetTokenResponseSchema",
     "VerifyPasswordSchema",
+    "ChangePasswordSchema",
     # Networking schemas
     "ChatRoomSchema",
     "ChatRoomDetailSchema",

--- a/backend/atria/api/api/schemas/auth.py
+++ b/backend/atria/api/api/schemas/auth.py
@@ -100,6 +100,21 @@ class ValidateResetTokenResponseSchema(ma.Schema):
     email = ma.String(required=True)
 
 
+class ChangePasswordSchema(ma.Schema):
+    """Schema for changing password"""
+    
+    class Meta:
+        name = "ChangePassword"
+    
+    current_password = ma.String(required=True, load_only=True)
+    new_password = ma.String(required=True, load_only=True)
+    
+    @validates("new_password")
+    def validate_new_password(self, value, **kwargs):
+        if len(value) < 8:
+            raise ValidationError("Password must be at least 8 characters")
+
+
 class SignupResponseSchema(ma.Schema):
     """Response schema for signup"""
     

--- a/backend/atria/api/services/auth.py
+++ b/backend/atria/api/services/auth.py
@@ -125,3 +125,22 @@ class AuthService:
         )
         
         return {"token": socket_token}
+
+    @staticmethod
+    def change_password(current_password, new_password):
+        """Change user's password"""
+        from flask_smorest import abort
+        
+        # Get current user
+        user_id = int(get_jwt_identity())
+        user = User.query.get_or_404(user_id)
+        
+        # Verify current password
+        if not user.verify_password(current_password):
+            abort(400, message="Current password is incorrect")
+        
+        # Set new password (auto-hashes via property setter)
+        user.password = new_password
+        db.session.commit()
+        
+        return {"message": "Password changed successfully"}

--- a/frontend/src/app/features/auth/api.js
+++ b/frontend/src/app/features/auth/api.js
@@ -135,6 +135,15 @@ export const authApi = baseApi.injectEndpoints({
         body: { password },
       }),
     }),
+
+    changePassword: builder.mutation({
+      query: ({ current_password, new_password }) => ({
+        url: '/auth/change-password',
+        method: 'PUT',
+        body: { current_password, new_password },
+      }),
+      invalidatesTags: ['User'],
+    }),
   }),
 });
 
@@ -150,4 +159,5 @@ export const {
   useValidateResetTokenQuery,
   useResetPasswordMutation,
   useVerifyPasswordMutation,
+  useChangePasswordMutation,
 } = authApi;

--- a/frontend/src/pages/Settings/components/SecuritySettings/index.jsx
+++ b/frontend/src/pages/Settings/components/SecuritySettings/index.jsx
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Stack,
+  Title,
+  Text,
+  Group,
+  PasswordInput,
+} from '@mantine/core';
+import { useForm, zodResolver } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { IconCheck, IconX, IconLock } from '@tabler/icons-react';
+import { useChangePasswordMutation } from '@/app/features/auth/api';
+import { Button } from '../../../../shared/components/buttons';
+import { securitySettingsSchema } from '../../schemas/securitySchema';
+import styles from './styles.module.css';
+
+const SecuritySettings = () => {
+  const currentUser = useSelector((state) => state.auth.user);
+  const [hasChanges, setHasChanges] = useState(false);
+  
+  // Change password mutation
+  const [changePassword, { isLoading: isSubmitting }] = useChangePasswordMutation();
+  
+  // Form setup
+  const form = useForm({
+    initialValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+    resolver: zodResolver(securitySettingsSchema),
+  });
+  
+  // Track changes
+  React.useEffect(() => {
+    const hasAnyValue = Object.values(form.values).some(value => value.trim() !== '');
+    setHasChanges(hasAnyValue);
+  }, [form.values]);
+  
+  const handleSubmit = async (values) => {
+    try {
+      await changePassword({
+        current_password: values.currentPassword,
+        new_password: values.newPassword,
+      }).unwrap();
+      
+      // Reset form after successful change
+      form.reset();
+      setHasChanges(false);
+      
+      notifications.show({
+        title: 'Success',
+        message: 'Password updated successfully',
+        color: 'green',
+        icon: <IconCheck />,
+      });
+    } catch (error) {
+      // Handle field errors
+      if (error.fieldErrors) {
+        Object.entries(error.fieldErrors).forEach(([field, errors]) => {
+          // Map backend field names to form field names
+          const fieldMap = {
+            current_password: 'currentPassword',
+            new_password: 'newPassword',
+          };
+          const formField = fieldMap[field] || field;
+          form.setFieldError(formField, errors[0]);
+        });
+      }
+      
+      notifications.show({
+        title: 'Error',
+        message: error.data?.message || 'Failed to update password',
+        color: 'red',
+        icon: <IconX />,
+      });
+    }
+  };
+  
+  const handleReset = () => {
+    form.reset();
+    setHasChanges(false);
+  };
+  
+  return (
+    <Stack gap="lg">
+      {/* Header Section - exactly like PrivacySettings */}
+      <div className={styles.headerSection}>
+        <Title order={3} className={styles.sectionTitle}>Security Settings</Title>
+        <Text size="sm" className={styles.description}>
+          Update your password to keep your account secure
+        </Text>
+      </div>
+      
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Stack gap="lg">
+          {/* Password Form Section */}
+          <div className={styles.formSection}>
+            <Text className={styles.sectionLabel}>Change Password</Text>
+            
+            <Stack gap="md">
+              <PasswordInput
+                className={styles.formInput}
+                label="Current Password"
+                placeholder="Enter your current password"
+                {...form.getInputProps('currentPassword')}
+                leftSection={<IconLock size={16} />}
+                size="md"
+              />
+              
+              <PasswordInput
+                className={styles.formInput}
+                label="New Password"
+                placeholder="Enter your new password"
+                {...form.getInputProps('newPassword')}
+                leftSection={<IconLock size={16} />}
+                size="md"
+              />
+              
+              <PasswordInput
+                className={styles.formInput}
+                label="Confirm New Password"
+                placeholder="Confirm your new password"
+                {...form.getInputProps('confirmPassword')}
+                leftSection={<IconLock size={16} />}
+                size="md"
+              />
+            </Stack>
+          </div>
+          
+          {/* Button Group - exactly like PrivacySettings */}
+          {hasChanges && (
+            <Group justify="flex-end" mt="md" className={styles.buttonGroup}>
+              <Button
+                variant="subtle"
+                onClick={handleReset}
+                disabled={isSubmitting}
+              >
+                <IconX size={16} />
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                loading={isSubmitting}
+              >
+                <IconCheck size={16} />
+                Update Password
+              </Button>
+            </Group>
+          )}
+        </Stack>
+      </form>
+    </Stack>
+  );
+};
+
+export default SecuritySettings;

--- a/frontend/src/pages/Settings/components/SecuritySettings/styles.module.css
+++ b/frontend/src/pages/Settings/components/SecuritySettings/styles.module.css
@@ -1,0 +1,57 @@
+/* Header Section - exact copy from PrivacySettings */
+.headerSection {
+  margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.description {
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* Form Section Styling - exact copy */
+.formSection {
+  padding: 1rem 0;
+}
+
+.sectionLabel {
+  font-weight: 500;
+  color: #1e293b;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+/* Form Input Styling - exact copy */
+.formInput input {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(139, 92, 246, 0.1);
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+}
+
+.formInput input:focus {
+  border-color: rgba(139, 92, 246, 0.3);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+/* Button Group - exact copy */
+.buttonGroup {
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(139, 92, 246, 0.04);
+  margin-top: 1.5rem;
+  background: rgba(251, 250, 255, 0.3);
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+  margin-bottom: -1.5rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-bottom: 1.5rem;
+}

--- a/frontend/src/pages/Settings/index.jsx
+++ b/frontend/src/pages/Settings/index.jsx
@@ -3,6 +3,7 @@ import { Text } from '@mantine/core';
 import { IconLock, IconUser, IconBell, IconShield } from '@tabler/icons-react';
 import { Tabs } from '@mantine/core';
 import PrivacySettings from './components/PrivacySettings';
+import SecuritySettings from './components/SecuritySettings';
 import styles from './styles/index.module.css';
 
 const Settings = () => {
@@ -49,8 +50,7 @@ const Settings = () => {
               <Tabs.Tab 
                 value="security" 
                 className={styles.tab}
-                leftSection={<IconShield size={16} />} 
-                disabled
+                leftSection={<IconShield size={16} />}
               >
                 Security
               </Tabs.Tab>
@@ -69,6 +69,10 @@ const Settings = () => {
                   </a>
                 </Text>
               </div>
+            </Tabs.Panel>
+            
+            <Tabs.Panel value="security" className={styles.tabPanel}>
+              <SecuritySettings />
             </Tabs.Panel>
           </Tabs>
         </section>

--- a/frontend/src/pages/Settings/schemas/securitySchema.js
+++ b/frontend/src/pages/Settings/schemas/securitySchema.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const securitySettingsSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z.string()
+    .min(8, 'Password must be at least 8 characters'),
+  confirmPassword: z.string()
+}).refine((data) => data.newPassword === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ["confirmPassword"],
+});


### PR DESCRIPTION
- Add SecuritySettings component with change password form
- Create ChangePasswordSchema with 8+ character validation
- Add PUT /api/auth/change-password endpoint
- Integrate SecuritySettings into Settings page Security tab
- Use shared Button component and follow design patterns
- Add form validation with current/new/confirm password fields

