### PR TITLE
fix: pass event icebreakers to admin connect modal

### DIFF
--- a/frontend/src/pages/EventAdmin/AttendeesManager/AttendeeRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/AttendeeRow/index.jsx
@@ -40,6 +40,7 @@ const AttendeeRow = ({
   currentUserRole,
   currentUserId,
   adminCount,
+  eventIcebreakers,
 }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -514,7 +515,7 @@ const AttendeeRow = ({
           company: attendee.company_name,
           avatarUrl: attendee.image_url,
         }}
-        eventIcebreakers={[]} // Could fetch from event data if needed
+        eventIcebreakers={eventIcebreakers || []}
         onSend={handleSendConnectionRequest}
         isLoading={false}
       />

--- a/frontend/src/pages/EventAdmin/AttendeesManager/AttendeesList/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/AttendeesList/index.jsx
@@ -8,6 +8,7 @@ const AttendeesList = ({
   currentUserRole,
   currentUserId,
   adminCount,
+  eventIcebreakers,
   onUpdateRole,
   onSort,
   sortBy,
@@ -79,6 +80,7 @@ const AttendeesList = ({
               currentUserRole={currentUserRole}
               currentUserId={currentUserId}
               adminCount={adminCount}
+              eventIcebreakers={eventIcebreakers}
             />
           ))}
         </Table.Tbody>

--- a/frontend/src/pages/EventAdmin/AttendeesManager/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/index.jsx
@@ -341,6 +341,7 @@ const AttendeesManager = () => {
                 currentUserRole={currentUserRole}
                 currentUserId={currentUserId}
                 adminCount={attendeesData?.role_counts?.admins || attendeesData?.event_users?.filter(u => u.role === 'ADMIN').length || 1}
+                eventIcebreakers={eventData?.icebreakers || []}
                 onUpdateRole={(user) => {
                   setRoleUpdateModal({ open: true, user });
                 }}


### PR DESCRIPTION
- Fix issue where admin/organizer connect modal showed no icebreakers
- Pass eventIcebreakers prop through component chain from AttendeesManager to AttendeeRow
- Ensures consistent icebreaker experience between networking and admin areas
- Admin users can now properly send connection requests with icebreaker messages in the attendee management context

Fixes connection flow parity between networking page and admin attendee management.
