### PR TITLE
fix: optimize CallToAction section positioning across devices

### DIFF
--- a/frontend/src/pages/Landing/CallToAction/CallToAction.module.css
+++ b/frontend/src/pages/Landing/CallToAction/CallToAction.module.css
@@ -27,7 +27,7 @@
 
 .drapeContent {
   position: absolute;
-  top: clamp(45%, 55%, 60%);
+  top: clamp(40%, 50%, 55%); /* Move content up on all devices */
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
@@ -135,14 +135,19 @@
 
 
 /* Mobile responsive */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .finalSection {
     height: auto;
     min-height: 100vh;
   }
   
   .drapeContent {
+    top: 50%; /* Center content in drape area on mobile */
     padding: 0 var(--space-tight);
+  }
+  
+  .footerWrapper {
+    height: clamp(25vh, 30vh, 35vh); /* More room for footer text on mobile */
   }
   
   .sectionTitle {
@@ -152,5 +157,16 @@
   .mainButton {
     font-size: var(--text-body) !important;
     padding: var(--space-tight) var(--space-cozy) !important;
+  }
+}
+
+/* MacBook Air responsive */
+@media (min-width: 1024px) and (max-width: 1680px) and (max-height: 1050px) {
+  .drapeContent {
+    top: 45%; /* Bring content up just a tiny touch on MacBook Air */
+  }
+  
+  .footerWrapper {
+    height: clamp(25vh, 28vh, 32vh); /* More room for AGPL3 Licensed text on MacBook Air */
   }
 }

--- a/frontend/src/pages/Landing/CallToAction/index.jsx
+++ b/frontend/src/pages/Landing/CallToAction/index.jsx
@@ -58,8 +58,13 @@ const CallToAction = () => {
         
         // Drape slides down to final position (stops just above footer)
         // Adjust final position based on screen size
-        const isMobile = window.innerWidth <= 768
-        const finalPosition = isMobile ? 10 : 5
+        const isMobile = window.innerWidth <= 767
+        const isMacBookAir = window.innerWidth >= 1024 && window.innerWidth <= 1680 && window.innerHeight <= 1050
+        
+        let finalPosition = 5 // Desktop default
+        if (isMobile) finalPosition = -2 // Bring drape up just a touch on mobile
+        else if (isMacBookAir) finalPosition = 0 // Bring drape up just barely on MacBook Air
+        
         const drapeY = gsap.utils.interpolate(-100, finalPosition, progress)
         gsap.set(drape, { y: `${drapeY}%`, force3D: true })
         

--- a/frontend/src/pages/Landing/Footer/Footer.module.css
+++ b/frontend/src/pages/Landing/Footer/Footer.module.css
@@ -15,8 +15,9 @@
 
 /* Social Section */
 .socialSection {
-  padding: var(--space-comfort) 0;
-  margin-bottom: var(--space-tight);
+  padding-top: var(--space-comfort);
+  padding-bottom: calc(var(--space-comfort) / 2); /* Half the bottom padding */
+  margin-bottom: var(--space-micro); /* Tighten gap to horizontal rule */
 }
 
 .socialLinks {


### PR DESCRIPTION
- Mobile: Center CTA content in drape area and increase footer space
- MacBook Air: Adjust drape and content positioning to prevent cutoffs
- Drape positioning: Mobile (-2%), MacBook Air (0%), Desktop (5%)
- Footer spacing: More room for "AGPL3 Licensed" text on mobile/laptop
- Tighten social icons gap to horizontal rule in footer

Ensures all footer text is visible and properly spaced on all devices while maintaining optimal drape positioning relative to footer icons.

