### PR TITLE
fix: optimize BrandExperience section for MacBook Air

### DIFF
--- a/frontend/src/pages/Landing/BrandExperience/BrandExperience.module.css
+++ b/frontend/src/pages/Landing/BrandExperience/BrandExperience.module.css
@@ -39,6 +39,7 @@
   z-index: 2;
   opacity: 0.9;
   letter-spacing: 0.02em;
+  margin-bottom: 0 !important;
 }
 
 .showcaseWrapper {
@@ -322,10 +323,10 @@
   margin: 0;
 }
 
-
 /* Animations */
 @keyframes bounce {
-  0%, 100% {
+  0%,
+  100% {
     transform: translateY(0);
   }
   50% {
@@ -334,7 +335,8 @@
 }
 
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     transform: scale(1);
   }
   50% {
@@ -343,6 +345,22 @@
 }
 
 /* Mobile responsive */
+/* MacBook Air responsive - tighten spacing */
+@media (min-width: 1024px) and (max-width: 1680px) and (max-height: 1050px) {
+  .sectionSubtitle {
+    margin-bottom: 0 !important; /* Force remove all bottom margin */
+  }
+
+  .showcaseWrapper {
+    min-height: clamp(250px, 35vh, 400px); /* Much shorter showcase area */
+  }
+
+  /* Hide the "Complete Brand Customization" box on MacBook Air */
+  .comingSoonNote {
+    display: none;
+  }
+}
+
 @media (max-width: 767px) {
   /* Hide entire BrandExperience section on mobile */
   .brandExperience {

--- a/frontend/src/pages/Landing/BrandExperience/components/BrandHeader.module.css
+++ b/frontend/src/pages/Landing/BrandExperience/components/BrandHeader.module.css
@@ -20,10 +20,11 @@
   transform: translateX(-50%);
   width: 80px;
   height: 3px;
-  background: linear-gradient(90deg, 
-    transparent 0%, 
-    #14B8A6 20%,
-    #14B8A6 80%,
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    #14b8a6 20%,
+    #14b8a6 80%,
     transparent 100%
   );
   opacity: 0.8;
@@ -40,11 +41,21 @@
   opacity: 0.9;
 }
 
+/* MacBook Air responsive - remove bottom margin */
+@media (min-width: 1024px) and (max-width: 1680px) and (max-height: 1050px) {
+  p.sectionSubtitle {
+    margin-bottom: 10px !important; /* Small 10px gap instead of 64px */
+    margin: 0 auto !important; /* Reset all margins */
+    margin-top: var(--space-cozy) !important; /* Keep top margin only */
+    margin-bottom: 10px !important; /* Small gap to animation */
+  }
+}
+
 @media (max-width: 768px) {
   .sectionTitle {
     font-size: 2rem;
   }
-  
+
   .sectionSubtitle {
     font-size: 1.125rem;
   }

--- a/frontend/src/pages/Landing/BrandExperience/components/EventView.module.css
+++ b/frontend/src/pages/Landing/BrandExperience/components/EventView.module.css
@@ -1,5 +1,10 @@
 @import '../../_variables.css';
 
+/* Hide the yellow "Your brand front and center" badge completely */
+.brandHighlight {
+  display: none !important;
+}
+
 .mockInterface {
   width: 100%;
   max-width: 900px;
@@ -255,6 +260,22 @@
   }
   50% {
     transform: scale(1.1);
+  }
+}
+
+/* MacBook Air responsive - middle ground height */
+@media (min-width: 1024px) and (max-width: 1680px) and (max-height: 1050px) {
+  .contentWrapper {
+    height: 400px; /* Middle ground between 350px and 450px */
+  }
+  
+  .eventMain {
+    min-height: 400px; /* Middle ground height */
+  }
+  
+  /* Hide the yellow "Your brand front and center" badge completely */
+  .brandHighlight {
+    display: none;
   }
 }
 


### PR DESCRIPTION
- Remove excessive 64px bottom margin from subtitle (10px gap instead)
- Hide "Complete Brand Customization" box on MacBook Air for space
- Reduce showcase wrapper height and optimize EventView dimensions
- Set EventView to 400px height (middle ground) for better fit
- Hide yellow "Your brand front and center" badge completely
- Improve vertical spacing and component proportions

BrandExperience section now fits properly on MacBook Air screens while maintaining desktop functionality and visual hierarchy.

