### PR TITLE
refactor(nav): update TopNav to use design tokens and improve respons…

### DIFF
--- a/frontend/src/app/router/layouts/AppLayout/index.jsx
+++ b/frontend/src/app/router/layouts/AppLayout/index.jsx
@@ -136,7 +136,7 @@ export const AppLayout = () => {
 
       {showEventNav && (
         <AppShell.Navbar>
-          <EventNav eventId={eventId} isAdmin={isAdmin} />
+          <EventNav eventId={eventId} isAdmin={isAdmin} onMobileNavClick={toggleMobile} />
         </AppShell.Navbar>
       )}
 

--- a/frontend/src/pages/Navigation/EventNav/EventNav.module.css
+++ b/frontend/src/pages/Navigation/EventNav/EventNav.module.css
@@ -9,11 +9,11 @@
   background: rgba(251, 250, 255, 0.1);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  box-shadow: 2px 0 8px rgba(139, 92, 246, 0.05);
+  box-shadow: 2px 0 8px var(--primary-alpha-4);
 }
 
 .container {
-  padding: 1.5rem;
+  padding: clamp(var(--space-md), 3vw, var(--space-xl));
   flex: 1;
   overflow: auto;
 }
@@ -27,42 +27,42 @@
 }
 
 .header {
-  padding: 0 1rem;
+  padding: 0 var(--space-md);
 }
 
 .header :global(.mantine-Text-root) {
-  color: #8b5cf6;
+  color: var(--color-primary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-size: 0.875rem;
+  font-size: clamp(var(--text-xs), 2.5vw, var(--text-sm));
 }
 
 .attribution {
   position: absolute;
-  bottom: 40px;
+  bottom: clamp(var(--space-lg), 5vw, 40px);
   left: 0;
   right: 0;
-  padding: 1rem;
+  padding: var(--space-md);
   text-align: center;
 }
 
 .attribution :global(.mantine-Text-root) {
-  color: #94a3b8;
-  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-size: clamp(10px, 2vw, var(--text-xs));
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
+  gap: var(--space-xs);
 }
 
 .heartIcon {
-  color: #8b5cf6;
-  fill: #8b5cf6;
+  color: var(--color-primary);
+  fill: var(--color-primary);
   vertical-align: middle;
 }
 
 .link {
-  color: #8b5cf6;
+  color: var(--color-primary);
   text-decoration: none;
   transition: opacity 0.2s ease;
 }
@@ -70,4 +70,45 @@
 .link:hover {
   opacity: 0.8;
   text-decoration: none;
+}
+
+/* Responsive adjustments for EventNav */
+@media (max-width: 480px) {
+  .container {
+    padding: var(--space-sm);
+  }
+  
+  .header {
+    padding: 0 var(--space-sm);
+  }
+  
+  .attribution {
+    display: none; /* Hide attribution on mobile for cleaner UX */
+  }
+}
+
+/* Laptop screens - expand width range and add height constraint */
+@media (min-width: 481px) and (max-width: 1600px) and (max-height: 1000px) {
+  .container {
+    padding: var(--space-sm); /* Tighter padding on laptops to prevent scroll */
+  }
+  
+  .header {
+    padding: 0 var(--space-md) !important; /* Match admin section padding */
+  }
+  
+  .attribution {
+    bottom: var(--space-sm); /* Reduce bottom space */
+    padding: var(--space-sm);
+  }
+}
+
+@media (min-width: 1281px) {
+  .container {
+    padding: var(--space-xl);
+  }
+  
+  .header {
+    padding: 0 var(--space-xl);
+  }
 }

--- a/frontend/src/pages/Navigation/EventNav/components/AdminSection/AdminSection.module.css
+++ b/frontend/src/pages/Navigation/EventNav/components/AdminSection/AdminSection.module.css
@@ -1,44 +1,92 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: clamp(var(--space-xs), 1.5vw, var(--space-sm));
+  margin-top: var(--space-md);
 }
 
 /* Admin section title */
 .container :global(.mantine-Text-root) {
-  color: #8B5CF6;
+  color: var(--color-primary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 0 1rem;
-  font-size: 0.875rem;
+  padding: 0 var(--space-md);
+  font-size: clamp(var(--text-xs), 2.5vw, var(--text-sm));
 }
 
 /* Divider styling */
 .container :global(.mantine-Divider-root) {
-  border-color: rgba(139, 92, 246, 0.08);
+  border-color: var(--primary-alpha-8);
 }
 
 /* Admin NavLink styling */
 .container :global(.mantine-NavLink-root) {
-  border-radius: 6px;
-  padding: 0.75rem 1rem;
-  color: #64748B;
-  font-size: 0.9rem;
+  border-radius: var(--radius-md);
+  padding: clamp(var(--space-sm), 2vw, 0.75rem) var(--space-md);
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-sm), 2.5vw, 0.9rem);
   font-weight: 500;
   transition: all 0.2s ease;
   border: 1px solid transparent;
 }
 
 .container :global(.mantine-NavLink-root):hover {
-  background: rgba(139, 92, 246, 0.04);
-  color: #8B5CF6;
+  background: var(--primary-alpha-4);
+  color: var(--color-primary);
   text-decoration: none;
 }
 
 .container :global(.mantine-NavLink-root[data-active]) {
-  background: rgba(139, 92, 246, 0.08);
-  color: #8B5CF6;
-  border: 1px solid rgba(139, 92, 246, 0.15);
+  background: var(--primary-alpha-8);
+  color: var(--color-primary);
+  border: 1px solid var(--primary-alpha-15);
   font-weight: 600;
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .container {
+    gap: var(--space-xs);
+    margin-top: var(--space-sm);
+  }
+  
+  .container :global(.mantine-Text-root) {
+    padding: 0 var(--space-sm);
+    font-size: var(--text-xs);
+  }
+  
+  .container :global(.mantine-NavLink-root) {
+    padding: var(--space-sm) var(--space-sm);
+    font-size: var(--text-sm);
+  }
+}
+
+/* Laptop screens - expand width range and add height constraint to catch MacBook Air */
+@media (min-width: 481px) and (max-width: 1600px) and (max-height: 1000px) {
+  .container {
+    gap: var(--space-xs) !important; /* Tighter gaps on laptops */
+    margin-top: var(--space-xs) !important; /* Reduce top margin */
+  }
+  
+  .container :global(.mantine-Text-root) {
+    padding: 0 var(--space-md) !important; /* Match event menu header padding */
+    font-size: clamp(var(--text-xs), 2.5vw, var(--text-sm)) !important; /* Match event menu title size */
+  }
+  
+  .container :global(.mantine-NavLink-root) {
+    padding: 6px var(--space-md) !important; /* A bit more breathing room on laptops */
+    font-size: var(--text-sm) !important; /* Slightly smaller text */
+    min-height: auto !important; /* Remove any min-height from Mantine */
+    line-height: 1.2 !important; /* Tighter line height for less vertical space */
+  }
+}
+
+@media (min-width: 1281px) {
+  .container :global(.mantine-Text-root) {
+    padding: 0 var(--space-xl);
+  }
+  
+  .container :global(.mantine-NavLink-root) {
+    padding: 0.75rem var(--space-xl);
+  }
 }

--- a/frontend/src/pages/Navigation/EventNav/components/AdminSection/index.jsx
+++ b/frontend/src/pages/Navigation/EventNav/components/AdminSection/index.jsx
@@ -2,11 +2,18 @@ import { NavLink, Divider, Text } from '@mantine/core';
 import { NavLink as RouterNavLink, useLocation } from 'react-router-dom';
 import styles from './AdminSection.module.css';
 
-export const AdminSection = ({ eventId }) => {
+export const AdminSection = ({ eventId, onMobileNavClick }) => {
   const location = useLocation();
   
   const isActive = (path) => {
     return location.pathname.startsWith(path);
+  };
+
+  // Handle mobile nav click - close nav on mobile only
+  const handleNavClick = () => {
+    if (onMobileNavClick && window.innerWidth <= 480) {
+      onMobileNavClick();
+    }
   };
 
   return (
@@ -20,36 +27,42 @@ export const AdminSection = ({ eventId }) => {
         to={`/app/events/${eventId}/admin/sessions`}
         label="Sessions"
         active={isActive(`/app/events/${eventId}/admin/sessions`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/admin/attendees`}
         label="Attendees"
         active={isActive(`/app/events/${eventId}/admin/attendees`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/admin/speakers`}
         label="Speakers"
         active={isActive(`/app/events/${eventId}/admin/speakers`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/admin/sponsors`}
         label="Sponsors"
         active={isActive(`/app/events/${eventId}/admin/sponsors`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/admin/networking`}
         label="Networking"
         active={isActive(`/app/events/${eventId}/admin/networking`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/admin/settings`}
         label="Event Settings"
         active={isActive(`/app/events/${eventId}/admin/settings`)}
+        onClick={handleNavClick}
       />
     </div>
   );

--- a/frontend/src/pages/Navigation/EventNav/components/EventLinks/EventLinks.module.css
+++ b/frontend/src/pages/Navigation/EventNav/components/EventLinks/EventLinks.module.css
@@ -1,15 +1,15 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: clamp(var(--space-xs), 1.5vw, var(--space-sm));
 }
 
 /* Custom NavLink styling */
 .container :global(.mantine-NavLink-root) {
-  border-radius: 6px;
-  padding: 0.75rem 1rem;
-  color: #64748B;
-  font-size: 0.95rem;
+  border-radius: var(--radius-md);
+  padding: clamp(var(--space-sm), 2vw, 0.75rem) var(--space-md);
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-sm), 2.5vw, 0.95rem);
   font-weight: 500;
   transition: all 0.2s ease;
   border: 1px solid transparent;
@@ -22,14 +22,46 @@
 }
 
 .container :global(.mantine-NavLink-root):hover {
-  background: rgba(139, 92, 246, 0.04);
-  color: #8B5CF6;
+  background: var(--primary-alpha-4);
+  color: var(--color-primary);
   text-decoration: none;
 }
 
 .container :global(.mantine-NavLink-root[data-active]) {
-  background: rgba(139, 92, 246, 0.08);
-  color: #8B5CF6;
-  border: 1px solid rgba(139, 92, 246, 0.15);
+  background: var(--primary-alpha-8);
+  color: var(--color-primary);
+  border: 1px solid var(--primary-alpha-15);
   font-weight: 600;
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .container {
+    gap: var(--space-xs);
+  }
+  
+  .container :global(.mantine-NavLink-root) {
+    padding: var(--space-sm) var(--space-sm);
+    font-size: var(--text-sm);
+  }
+}
+
+/* Laptop screens - expand width range and add height constraint to catch MacBook Air */
+@media (min-width: 481px) and (max-width: 1600px) and (max-height: 1000px) {
+  .container {
+    gap: var(--space-xs) !important; /* Tighter gaps on laptops */
+  }
+  
+  .container :global(.mantine-NavLink-root) {
+    padding: 6px var(--space-md) !important; /* A bit more breathing room on laptops */
+    font-size: var(--text-sm) !important; /* Slightly smaller text */
+    min-height: auto !important; /* Remove any min-height from Mantine */
+    line-height: 1.2 !important; /* Tighter line height for less vertical space */
+  }
+}
+
+@media (min-width: 1281px) {
+  .container :global(.mantine-NavLink-root) {
+    padding: 0.75rem var(--space-xl);
+  }
 }

--- a/frontend/src/pages/Navigation/EventNav/components/EventLinks/index.jsx
+++ b/frontend/src/pages/Navigation/EventNav/components/EventLinks/index.jsx
@@ -2,7 +2,7 @@ import { NavLink } from '@mantine/core';
 import { NavLink as RouterNavLink, useLocation } from 'react-router-dom';
 import styles from './EventLinks.module.css';
 
-export const EventLinks = ({ eventId }) => {
+export const EventLinks = ({ eventId, onMobileNavClick }) => {
   const location = useLocation();
   
   const isActive = (path) => {
@@ -14,6 +14,13 @@ export const EventLinks = ({ eventId }) => {
     return location.pathname.startsWith(path);
   };
 
+  // Handle mobile nav click - close nav on mobile only
+  const handleNavClick = () => {
+    if (onMobileNavClick && window.innerWidth <= 480) {
+      onMobileNavClick();
+    }
+  };
+
   return (
     <div className={styles.container}>
       <NavLink
@@ -21,30 +28,35 @@ export const EventLinks = ({ eventId }) => {
         to={`/app/events/${eventId}`}
         label="Event Home"
         active={isActive(`/app/events/${eventId}`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/agenda`}
         label="Agenda"
         active={isActive(`/app/events/${eventId}/agenda`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/speakers`}
         label="Speakers"
         active={isActive(`/app/events/${eventId}/speakers`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/networking`}
         label="Networking"
         active={isActive(`/app/events/${eventId}/networking`)}
+        onClick={handleNavClick}
       />
       <NavLink
         component={RouterNavLink}
         to={`/app/events/${eventId}/sponsors`}
         label="Sponsors"
         active={isActive(`/app/events/${eventId}/sponsors`)}
+        onClick={handleNavClick}
       />
     </div>
   );

--- a/frontend/src/pages/Navigation/EventNav/index.jsx
+++ b/frontend/src/pages/Navigation/EventNav/index.jsx
@@ -5,7 +5,7 @@ import styles from './EventNav.module.css';
 import { EventLinks } from './components/EventLinks';
 import { AdminSection } from './components/AdminSection';
 
-const EventNavComponent = ({ eventId, isAdmin }) => {
+const EventNavComponent = ({ eventId, isAdmin, onMobileNavClick }) => {
   return (
     <div className={styles.navWrapper}>
       <ScrollArea className={styles.container}>
@@ -15,8 +15,8 @@ const EventNavComponent = ({ eventId, isAdmin }) => {
               Event Menu
             </Text>
           </div>
-          <EventLinks eventId={eventId} />
-          {isAdmin && <AdminSection eventId={eventId} />}
+          <EventLinks eventId={eventId} onMobileNavClick={onMobileNavClick} />
+          {isAdmin && <AdminSection eventId={eventId} onMobileNavClick={onMobileNavClick} />}
         </Stack>
       </ScrollArea>
       

--- a/frontend/src/pages/Navigation/TopNav/TopNav.module.css
+++ b/frontend/src/pages/Navigation/TopNav/TopNav.module.css
@@ -4,7 +4,7 @@
 .navbar {
   width: 100%;
   height: 60px; /* Match AppShell header height */
-  background: rgba(139, 92, 246, 0.9); /* Using our brand purple #8B5CF6 */
+  background: rgba(139, 92, 246, 0.9); /* Using our brand purple - will replace with design token */
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -21,7 +21,7 @@
   align-items: center;
   width: 100%;
   height: 100%;
-  padding: 0 2rem;
+  padding: 0 clamp(var(--space-md), 4vw, var(--space-xl));
 }
 
 .navLeft {
@@ -35,7 +35,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-md);
 }
 
 .atriaTitle {
@@ -44,7 +44,7 @@
     system-ui,
     -apple-system,
     sans-serif;
-  font-size: 1.75rem;
+  font-size: clamp(var(--text-lg), 3.5vw, 1.75rem);
   font-weight: 300;
   color: #ffffff;
   letter-spacing: -0.02em;
@@ -60,14 +60,14 @@
 /* Burger menu wrapper */
 .burgerWrapper {
   position: fixed;
-  left: 2rem;
+  left: clamp(var(--space-md), 4vw, var(--space-xl));
   z-index: 101;
 }
 
 /* Special case for navbar with burger in event */
 .navbarWithBurger .navContent {
   max-width: none; /* Remove max-width constraint */
-  padding: 0 2rem;
+  padding: 0 clamp(var(--space-md), 4vw, var(--space-xl));
 }
 
 /* Style the burger button to be white */
@@ -75,18 +75,55 @@
   color: #ffffff;
 }
 
-/* Media query for mobile */
-@media (max-width: 768px) {
+/* Responsive breakpoints */
+/* Mobile (iPhone SE: 375px, iPhone 15 Pro: 393px) */
+@media (max-width: 480px) {
   .navContent {
-    padding: 0 1rem;
+    padding: 0 var(--space-md);
   }
 
   .burgerWrapper {
-    left: 1rem;
+    left: var(--space-md);
   }
 
   .navbarWithBurger .navContent {
-    max-width: none; /* Remove max-width constraint on mobile too */
-    padding: 0 1rem;
+    max-width: none;
+    padding: 0 var(--space-md);
+  }
+
+  .atriaTitle {
+    font-size: var(--text-lg); /* Bigger on mobile for better readability */
+  }
+}
+
+/* Laptop (MacBook Air M1: ~1440px width, but we'll target smaller laptop sizes) */
+@media (min-width: 481px) and (max-width: 1280px) {
+  .navContent {
+    padding: 0 var(--space-lg);
+  }
+
+  .burgerWrapper {
+    left: var(--space-lg);
+  }
+
+  .navbarWithBurger .navContent {
+    max-width: none;
+    padding: 0 var(--space-lg);
+  }
+}
+
+/* Desktop */
+@media (min-width: 1281px) {
+  .navContent {
+    padding: 0 var(--space-xl);
+  }
+
+  .burgerWrapper {
+    left: var(--space-xl);
+  }
+
+  .navbarWithBurger .navContent {
+    max-width: none;
+    padding: 0 var(--space-xl);
   }
 }

--- a/frontend/src/pages/Navigation/TopNav/components/CenterContent/CenterContent.module.css
+++ b/frontend/src/pages/Navigation/TopNav/components/CenterContent/CenterContent.module.css
@@ -2,24 +2,55 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0 1rem;
+  padding: 0 var(--space-md);
 }
 
 .title {
   font-family: 'M Plus 2', system-ui, -apple-system, sans-serif;
-  font-size: 1.5rem;
+  font-size: clamp(var(--text-lg), 4vw, var(--text-2xl));
   font-weight: 300;
   color: #FFFFFF;
   letter-spacing: -0.02em;
   margin: 0;
+  text-align: center;
+  line-height: 1.2;
 }
 
 .titleContainer {
   text-align: center;
+  max-width: 100%;
 }
 
 .subtitle {
-  font-size: 0.875rem;
+  font-size: clamp(var(--text-xs), 2.5vw, var(--text-sm));
   color: rgba(255, 255, 255, 0.8);
-  margin-top: 0.25rem;
+  margin-top: var(--space-xs);
+  line-height: 1.3;
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .centerContent {
+    padding: 0 var(--space-md);
+  }
+  
+  .title {
+    font-size: var(--text-lg); /* Bigger on mobile for better readability */
+  }
+  
+  .subtitle {
+    font-size: var(--text-sm); /* Bigger on mobile for better readability */
+  }
+}
+
+@media (min-width: 481px) and (max-width: 1280px) {
+  .centerContent {
+    padding: 0 var(--space-lg);
+  }
+}
+
+@media (min-width: 1281px) {
+  .centerContent {
+    padding: 0 var(--space-xl);
+  }
 }

--- a/frontend/src/pages/Navigation/TopNav/components/MenuButton/MenuButton.module.css
+++ b/frontend/src/pages/Navigation/TopNav/components/MenuButton/MenuButton.module.css
@@ -5,15 +5,15 @@
   align-items: center;
   justify-content: center;
   /* Fix for CSS reset affecting button size */
-  width: 40px !important;
-  height: 40px !important;
-  min-width: 40px !important;
-  min-height: 40px !important;
-  padding: 8px !important;
+  width: clamp(40px, 8vw, 44px) !important;
+  height: clamp(40px, 8vw, 44px) !important;
+  min-width: clamp(40px, 8vw, 44px) !important;
+  min-height: clamp(40px, 8vw, 44px) !important;
+  padding: var(--space-sm) !important;
   background: transparent !important;
   border: none !important;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15) !important;
-  border-radius: 6px !important;
+  border-radius: var(--radius-md) !important;
   transition: all 0.2s ease !important;
 }
 
@@ -24,10 +24,10 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(45deg, rgba(139, 92, 246, 0.1), rgba(168, 85, 247, 0.1));
+  background: linear-gradient(45deg, var(--primary-alpha-10), var(--primary-alpha-15));
   opacity: 0;
   transition: opacity 0.3s ease;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   pointer-events: none;
   z-index: 1;
 }
@@ -43,69 +43,87 @@
 .menuIcon {
   position: relative;
   z-index: 1;
-  filter: drop-shadow(0 1px 2px rgba(139, 92, 246, 0.1));
+  filter: drop-shadow(0 1px 2px var(--primary-alpha-10));
   display: block;
-  width: 24px;
-  height: 24px;
+  width: clamp(24px, 5vw, 28px);
+  height: clamp(24px, 5vw, 28px);
   object-fit: contain;
 }
 
 /* Menu Dropdown Styles */
 .menuDropdown {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--color-background-glass);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.95);
-  box-shadow: 0 8px 32px rgba(139, 92, 246, 0.08);
-  padding: 6px;
-  min-width: 200px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-xl);
+  padding: var(--space-sm);
+  min-width: clamp(180px, 40vw, 200px);
 }
 
 .menuArrow {
-  border: 1px solid rgba(255, 255, 255, 0.95);
-  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--glass-border);
+  background: var(--color-background-glass);
 }
 
 .menuItem {
-  font-size: 13px;
-  padding: 8px 10px;
-  border-radius: 6px;
-  color: #1E293B;
+  font-size: clamp(var(--text-xs), 3vw, var(--text-sm));
+  padding: var(--space-sm) var(--space-sm);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
   font-weight: 500;
   transition: all 0.2s ease;
   line-height: 1.4;
 }
 
 .menuItem[data-hovered] {
-  background-color: rgba(139, 92, 246, 0.08);
-  color: #8B5CF6;
+  background-color: var(--primary-alpha-8);
+  color: var(--color-primary);
   transform: translateX(2px);
 }
 
 .menuLabel {
-  font-size: 11px;
+  font-size: clamp(10px, 2.5vw, 11px);
   font-weight: 600;
-  color: #94A3B8;
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 6px 10px;
+  padding: var(--space-sm) var(--space-sm);
 }
 
 .menuDivider {
-  border-color: rgba(139, 92, 246, 0.08);
-  margin: 6px 0;
+  border-color: var(--primary-alpha-8);
+  margin: var(--space-sm) 0;
 }
 
 .logoutItem {
-  color: #DC2626 !important;
+  color: var(--color-error) !important;
 }
 
 .logoutItem svg {
-  color: #DC2626 !important;
+  color: var(--color-error) !important;
 }
 
 .logoutItem:hover {
   background-color: rgba(220, 38, 38, 0.08) !important;
   color: #B91C1C !important;
+}
+
+/* Responsive menu adjustments */
+@media (max-width: 480px) {
+  .menuDropdown {
+    min-width: 180px; /* Slightly bigger on mobile */
+    padding: var(--space-sm);
+  }
+  
+  .menuItem {
+    font-size: var(--text-sm); /* Bigger text on mobile for better touch targets */
+    padding: var(--space-sm) var(--space-md); /* More padding for better touch targets */
+  }
+  
+  .menuLabel {
+    font-size: 11px; /* Slightly bigger */
+    padding: var(--space-sm) var(--space-md);
+  }
 }

--- a/frontend/src/pages/Navigation/TopNav/components/MenuButton/index.jsx
+++ b/frontend/src/pages/Navigation/TopNav/components/MenuButton/index.jsx
@@ -63,7 +63,7 @@ export const MenuButton = () => {
         <Menu.Item
           leftSection={
             <IconLayoutDashboard
-              style={{ width: rem(14), height: rem(14), color: '#8B5CF6' }}
+              style={{ width: rem(14), height: rem(14), color: 'var(--color-primary)' }}
             />
           }
           onClick={() => navigate('/app/dashboard')}
@@ -74,7 +74,7 @@ export const MenuButton = () => {
         <Menu.Item
           leftSection={
             <IconUser
-              style={{ width: rem(14), height: rem(14), color: '#8B5CF6' }}
+              style={{ width: rem(14), height: rem(14), color: 'var(--color-primary)' }}
             />
           }
           onClick={() => navigate('/app/profile')}
@@ -85,7 +85,7 @@ export const MenuButton = () => {
         <Menu.Item
           leftSection={
             <IconUsers
-              style={{ width: rem(14), height: rem(14), color: '#8B5CF6' }}
+              style={{ width: rem(14), height: rem(14), color: 'var(--color-primary)' }}
             />
           }
           onClick={() => navigate('/app/network')}
@@ -96,7 +96,7 @@ export const MenuButton = () => {
         <Menu.Item
           leftSection={
             <IconCalendarEvent
-              style={{ width: rem(14), height: rem(14), color: '#8B5CF6' }}
+              style={{ width: rem(14), height: rem(14), color: 'var(--color-primary)' }}
             />
           }
           onClick={() => navigate('/app/events')}
@@ -107,7 +107,7 @@ export const MenuButton = () => {
         <Menu.Item
           leftSection={
             <IconSettings
-              style={{ width: rem(14), height: rem(14), color: '#8B5CF6' }}
+              style={{ width: rem(14), height: rem(14), color: 'var(--color-primary)' }}
             />
           }
           onClick={() => navigate('/app/settings')}


### PR DESCRIPTION
…iveness

- Convert TopNav.module.css to use design tokens for spacing and typography
- Add responsive breakpoints for mobile (480px), laptop (1280px), and desktop
- Update CenterContent to use clamp() for fluid typography scaling
- Refactor MenuButton to use design tokens while maintaining subtle styling
- Improve mobile touch targets with larger sizes and better spacing
- Replace hardcoded colors with CSS custom properties for consistency
- Maintain original subtle button appearance with black shadow

Changes support iPhone SE/15 Pro, MacBook Air M1, and desktop layouts