### PR TITLE
fix(event-info): remove pointer cursor from info cards

### DIFF
--- a/frontend/src/pages/EventHome/EventInfo/styles/index.module.css
+++ b/frontend/src/pages/EventHome/EventInfo/styles/index.module.css
@@ -21,6 +21,7 @@
   align-items: flex-start;
   gap: clamp(var(--space-md), 3vw, var(--space-lg));
   transition: all 0.3s ease;
+  cursor: default;
 }
 
 .infoCard:hover {


### PR DESCRIPTION
- Set cursor to default for EventInfo cards to indicate they are not clickable
- Maintains hover effects while removing misleading cursor behavior

