### PR TITLE
refactor(sponsors): align page with design system and improve visual …

### DIFF
--- a/frontend/src/pages/Sponsors/Sponsors.module.css
+++ b/frontend/src/pages/Sponsors/Sponsors.module.css
@@ -19,18 +19,22 @@
 }
 
 .pageTitle {
-  composes: section-title from '../../styles/design-tokens.css';
+  font-size: clamp(2rem, 5vw, 2.5rem);
   font-weight: 300;
   color: var(--color-primary);
   letter-spacing: -0.02em;
-  margin: 0 0 0.5rem 0;
+  margin: 0 0 clamp(var(--space-sm), 2vw, var(--space-md)) 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 .pageSubtitle {
-  font-size: clamp(var(--text-base), 2.5vw, var(--text-lg));
+  font-size: clamp(var(--text-base), 2.5vw, 1.125rem);
   color: var(--color-text-secondary);
   font-weight: 400;
   margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  letter-spacing: 0.02em;
+  opacity: 0.9;
 }
 
 /* Background shapes */
@@ -119,6 +123,10 @@
 
 /* Responsive */
 @media (max-width: 768px) {
+  .contentWrapper {
+    padding-bottom: 50px; /* Extra space for messaging tab */
+  }
+  
   .bgShape1,
   .bgShape2,
   .bgShape3 {

--- a/frontend/src/pages/Sponsors/SponsorsList/styles/index.module.css
+++ b/frontend/src/pages/Sponsors/SponsorsList/styles/index.module.css
@@ -21,10 +21,12 @@
 }
 
 .tierTitle {
-  font-size: clamp(var(--text-lg), 3vw, var(--text-2xl));
-  font-weight: 600;
-  color: var(--color-text-primary);
+  font-size: clamp(var(--text-lg), 3vw, var(--text-2xl)) !important;
+  font-weight: 600 !important;
+  color: var(--color-text-primary) !important;
   letter-spacing: -0.02em;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  margin: 0 !important;
 }
 
 .sponsorGrid {

--- a/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
+++ b/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
@@ -6,11 +6,18 @@
   flex-direction: column;
   overflow: hidden;
   cursor: pointer;
+  background: linear-gradient(180deg, 
+    rgba(255, 255, 255, 0.95) 0%, 
+    rgba(251, 250, 255, 0.9) 100%);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .card:hover {
-  box-shadow: var(--shadow-lg) !important;
-  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 8px 28px rgba(139, 92, 246, 0.12) !important;
+  background: linear-gradient(180deg, 
+    rgba(255, 255, 255, 1) 0%, 
+    rgba(251, 250, 255, 0.95) 100%);
+  transform: translateY(-2px) scale(1.01);
 }
 
 /* Featured card special styling */
@@ -45,14 +52,15 @@
 }
 
 .tierText {
-  font-size: clamp(0.625rem, 1.5vw, 0.7rem);
-  font-weight: 600;
+  font-size: clamp(0.625rem, 1.5vw, 0.7rem) !important;
+  font-weight: 700 !important;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.05em !important;
   position: relative;
   z-index: 1;
-  color: inherit;
+  color: inherit !important;
   white-space: nowrap;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
 }
 
 /* Logo section */
@@ -108,8 +116,10 @@
 }
 
 .placeholderText {
-  color: var(--color-primary);
+  color: var(--color-primary) !important;
   line-height: 1;
+  font-weight: 700 !important;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
 }
 
 /* Content section */
@@ -121,20 +131,24 @@
 }
 
 .sponsorName {
-  font-size: clamp(var(--text-base), 2.5vw, var(--text-xl));
-  font-weight: 600;
-  color: var(--color-text-primary);
-  margin-bottom: var(--space-sm);
-  letter-spacing: -0.01em;
-  line-height: 1.3;
+  font-size: clamp(1.1rem, 2.5vw, 1.25rem) !important;
+  font-weight: 600 !important;
+  color: var(--color-text-secondary) !important;
+  margin-bottom: var(--space-sm) !important;
+  letter-spacing: -0.01em !important;
+  line-height: 1.3 !important;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
 }
 
 .description {
-  font-size: clamp(var(--text-sm), 2vw, 0.9rem);
-  color: var(--color-text-secondary);
-  line-height: 1.5;
-  margin-bottom: var(--space-md);
+  font-size: clamp(var(--text-sm), 2vw, 0.925rem) !important;
+  color: var(--color-text-secondary) !important;
+  line-height: 1.6 !important;
+  margin-bottom: var(--space-md) !important;
   flex: 1;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  letter-spacing: 0.01em;
+  opacity: 0.95;
 }
 
 /* Footer section */
@@ -149,18 +163,20 @@
 }
 
 .websiteLink {
-  display: flex;
+  display: inline-flex !important;
   align-items: center;
   gap: var(--space-xs);
-  color: var(--color-primary);
-  font-size: clamp(var(--text-xs), 2vw, var(--text-sm));
-  font-weight: 500;
-  text-decoration: none;
+  color: var(--color-primary) !important;
+  font-size: clamp(var(--text-xs), 2vw, var(--text-sm)) !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
   transition: all 0.2s ease;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  letter-spacing: 0.01em;
 }
 
 .websiteLink:hover {
-  color: var(--color-primary-hover);
+  color: var(--color-primary-hover) !important;
   transform: translateX(2px);
 }
 
@@ -170,14 +186,14 @@
 }
 
 .socialIcon {
-  color: var(--color-text-muted);
+  color: var(--color-text-muted) !important;
   transition: all 0.2s ease;
-  background: transparent;
+  background: transparent !important;
 }
 
 .socialIcon:hover {
-  color: var(--color-primary);
-  background: rgba(139, 92, 246, 0.08);
+  color: var(--color-primary) !important;
+  background: rgba(139, 92, 246, 0.08) !important;
   transform: translateY(-2px);
 }
 
@@ -224,3 +240,30 @@
 }
 
 /* Remove shimmer animation for cleaner look */
+
+/* Hover effect for sponsor name */
+.card:hover .sponsorName {
+  color: var(--color-text-primary) !important;
+}
+
+/* Override Mantine components inside card */
+.card :global(.mantine-Text-root) {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+  letter-spacing: 0.01em;
+}
+
+.card :global(.mantine-Anchor-root) {
+  color: var(--gradient-purple-medium) !important;
+  text-decoration: none !important;
+}
+
+/* Icon color fixes */
+.websiteLink svg {
+  stroke: var(--color-primary) !important;
+  opacity: 0.9;
+}
+
+.websiteLink:hover svg {
+  stroke: var(--color-primary-hover) !important;
+  opacity: 1;
+}


### PR DESCRIPTION
…consistency

- Match page title style with Speakers page (simple purple, no gradient)
- Use black text for tier labels instead of gradient for better readability
- Change sponsor names to gray for consistent hierarchy
- Simplify website links to use light purple instead of gradient
- Tone down social icons to muted gray with purple hover
- Add 50px bottom padding on mobile for messaging tab clearance
- Remove excessive gradient effects for cleaner, professional look
- Improve typography with proper font family and letter spacing
- Maintain consistent design language across Speakers and Sponsors pages

