### PR TITLE
feat(speakers): implement responsive mobile design with cards

### DIFF
--- a/frontend/src/pages/EventAdmin/SpeakersManager/AddSpeakerModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/AddSpeakerModal/index.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Modal, Select, Group, Stack, Text, Alert, Loader, Box } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { 
   useGetEventUsersAdminQuery,
@@ -12,6 +13,7 @@ import styles from './styles.module.css';
 const AddSpeakerModal = ({ opened, onClose, eventId, onSuccess }) => {
   const [selectedUserId, setSelectedUserId] = useState(null);
   const [updateUser, { isLoading: isUpdating }] = useUpdateEventUserMutation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   // Fetch non-speaker users
   const { data: usersData, isLoading } = useGetEventUsersAdminQuery(
@@ -78,17 +80,27 @@ const AddSpeakerModal = ({ opened, onClose, eventId, onSuccess }) => {
       onClose={handleClose}
       title="Add Speaker"
       size="md"
+      centered
       lockScroll={false}
       classNames={{
         content: styles.modalContent,
         header: styles.modalHeader,
+        body: styles.modalBody,
       }}
     >
-      <Stack p="lg">
-        <Alert icon={<IconInfoCircle size={16} />} color="blue" className={styles.infoAlert}>
-          <Text size="sm">
-            Select an existing attendee or organizer to make them a speaker.
-            You can customize their speaker title and bio after adding them.
+      <Stack className={styles.formStack}>
+        <Alert 
+          icon={<IconInfoCircle size={14} />} 
+          color="blue" 
+          className={styles.infoAlert}
+          styles={{
+            root: { padding: 'var(--space-sm) !important' },
+            message: { fontSize: 'var(--text-xs) !important' }
+          }}
+        >
+          <Text size="xs">
+            Select an attendee to make them a speaker.
+            {!isMobile && ' Customize their info after adding.'}
           </Text>
         </Alert>
 
@@ -116,13 +128,14 @@ const AddSpeakerModal = ({ opened, onClose, eventId, onSuccess }) => {
               required
               leftSection={<IconUserPlus size={16} />}
               className={styles.selectInput}
+              size="sm"
               classNames={{
                 dropdown: styles.selectDropdown,
               }}
               renderOption={({ option }) => (
                 <Group justify="space-between" wrap="nowrap">
                   <div>
-                    <Text size="sm">{option.label}</Text>
+                    <Text size="xs">{option.label}</Text>
                     <Text size="xs" c="dimmed">{option.email}</Text>
                   </div>
                 </Group>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/AddSpeakerModal/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/AddSpeakerModal/styles.module.css
@@ -4,61 +4,87 @@
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   padding: 0;
+  max-height: clamp(350px, 70vh, 600px);
+  display: flex;
+  flex-direction: column;
 }
 
 /* Modal Header */
 .modalHeader {
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 2vw, 1.125rem);
   font-weight: 600;
-  color: #1E293B;
-  padding: 1.5rem;
-  border-bottom: 1px solid rgba(139, 92, 246, 0.04);
+  color: var(--color-text-primary);
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-bottom: 1px solid var(--primary-alpha-4);
+  flex-shrink: 0;
+}
+
+/* Modal Body */
+.modalBody {
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* Form Stack */
+.formStack {
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  gap: clamp(0.5rem, 1.5vw, 1rem);
 }
 
 /* Alert Styling */
 .infoAlert {
-  background: rgba(139, 92, 246, 0.04);
-  border: 1px solid rgba(139, 92, 246, 0.1);
-  border-radius: 6px;
+  background: var(--primary-alpha-4) !important;
+  border: 1px solid var(--primary-alpha-10) !important;
+  border-radius: var(--radius-md) !important;
 }
 
 .warningAlert {
-  background: rgba(245, 158, 11, 0.04);
-  border: 1px solid rgba(245, 158, 11, 0.1);
-  border-radius: 6px;
+  background: rgba(245, 158, 11, 0.04) !important;
+  border: 1px solid rgba(245, 158, 11, 0.1) !important;
+  border-radius: var(--radius-md) !important;
 }
 
 /* Form Elements */
 .selectInput input {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(139, 92, 246, 0.1);
-  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid var(--primary-alpha-10) !important;
+  transition: all 0.2s ease !important;
+  font-size: clamp(var(--text-sm), 2.5vw, var(--text-base)) !important;
 }
 
 .selectInput input:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
+  border-color: var(--primary-alpha-30) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Dropdown Styling */
 .selectDropdown {
-  background: rgba(255, 255, 255, 1);
+  background: rgba(255, 255, 255, 0.95) !important;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.08);
-  border-radius: 6px;
+  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-md);
 }
 
 /* Button Group */
 .buttonGroup {
-  padding: 1.5rem;
-  border-top: 1px solid rgba(139, 92, 246, 0.04);
-  margin-top: 1.5rem;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-top: 1px solid var(--primary-alpha-4);
+  margin-top: 0;
   background: rgba(251, 250, 255, 0.5);
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: clamp(0.5rem, 1.5vw, 0.75rem);
+  flex-shrink: 0;
+}
+
+/* Mobile Responsive - only iOS zoom prevention */
+@media (max-width: 768px) {
+  .selectInput input {
+    font-size: 16px !important; /* Prevents zoom on iOS */
+  }
 }
 
 /* Override Mantine Modal Styles */

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
@@ -1,4 +1,4 @@
-import { Group, Text, Avatar, Menu, ActionIcon, Badge, Tooltip, Stack, Alert } from '@mantine/core';
+import { Group, Text, Avatar, Menu, ActionIcon, Badge, Tooltip, Stack, Alert, Collapse } from '@mantine/core';
 import {
   IconDots,
   IconUserCircle,
@@ -7,7 +7,10 @@ import {
   IconTrash,
   IconMessage,
   IconAlertCircle,
+  IconChevronDown,
+  IconChevronUp,
 } from '@tabler/icons-react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
@@ -22,6 +25,7 @@ const SpeakerCard = ({
 }) => {
   const navigate = useNavigate();
   const [updateUser] = useUpdateEventUserMutation();
+  const [sessionsExpanded, setSessionsExpanded] = useState(false);
 
   const formatTime = (timeStr) => {
     if (!timeStr) return '';
@@ -215,38 +219,19 @@ const SpeakerCard = ({
           Sessions
         </Text>
         {speaker.session_count > 0 ? (
-          <Tooltip
-            label={
-              <Stack gap="xs">
-                {speaker.sessions?.map((session) => (
-                  <div key={session.id}>
-                    <Text size="sm" fw={500}>{session.title}</Text>
-                    <Text size="xs" c="dimmed">
-                      {session.day_number ? `Day ${session.day_number}` : 'Day TBD'}
-                      {session.start_time && session.end_time && (
-                        <> • {formatTime(session.start_time)} - {formatTime(session.end_time)}</>
-                      )}
-                      {session.session_type && <> • {capitalizeWords(session.session_type)}</>}
-                      {session.role && <> • {capitalizeWords(session.role)}</>}
-                    </Text>
-                  </div>
-                ))}
-              </Stack>
+          <Badge 
+            variant="light" 
+            color="green" 
+            radius="sm" 
+            className={styles.sessionBadge}
+            style={{ cursor: 'pointer' }}
+            onClick={() => setSessionsExpanded(!sessionsExpanded)}
+            rightSection={
+              sessionsExpanded ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />
             }
-            multiline
-            maw={400}
-            withArrow
           >
-            <Badge 
-              variant="light" 
-              color="green" 
-              radius="sm" 
-              className={styles.sessionBadge}
-              style={{ cursor: 'pointer' }}
-            >
-              {speaker.session_count} Session{speaker.session_count > 1 ? 's' : ''}
-            </Badge>
-          </Tooltip>
+            {speaker.session_count} Session{speaker.session_count > 1 ? 's' : ''}
+          </Badge>
         ) : (
           <Badge 
             variant="light" 
@@ -258,6 +243,29 @@ const SpeakerCard = ({
           </Badge>
         )}
       </div>
+
+      {/* Expandable Sessions List */}
+      {speaker.session_count > 0 && (
+        <Collapse in={sessionsExpanded}>
+          <div className={styles.sessionsList}>
+            {speaker.sessions?.map((session) => (
+              <div key={session.id} className={styles.sessionItem}>
+                <Text size="sm" fw={500} className={styles.sessionTitle}>
+                  {session.title}
+                </Text>
+                <Text size="xs" c="dimmed" className={styles.sessionDetails}>
+                  {session.day_number ? `Day ${session.day_number}` : 'Day TBD'}
+                  {session.start_time && session.end_time && (
+                    <> • {formatTime(session.start_time)} - {formatTime(session.end_time)}</>
+                  )}
+                  {session.session_type && <> • {capitalizeWords(session.session_type)}</>}
+                  {session.role && <> • {capitalizeWords(session.role)}</>}
+                </Text>
+              </div>
+            ))}
+          </div>
+        </Collapse>
+      )}
 
       {/* Bio Section */}
       {displayBio && (

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
 import { useUpdateEventUserMutation } from '@/app/features/events/api';
+import { formatTime, capitalizeWords, truncateBio } from '@/shared/utils/formatting';
 import styles from './styles.module.css';
 
 const SpeakerCard = ({
@@ -26,22 +27,6 @@ const SpeakerCard = ({
   const navigate = useNavigate();
   const [updateUser] = useUpdateEventUserMutation();
   const [sessionsExpanded, setSessionsExpanded] = useState(false);
-
-  const formatTime = (timeStr) => {
-    if (!timeStr) return '';
-    const [hours, minutes] = timeStr.split(':');
-    const hour = parseInt(hours);
-    const ampm = hour >= 12 ? 'PM' : 'AM';
-    const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
-    return `${displayHour}:${minutes} ${ampm}`;
-  };
-
-  const capitalizeWords = (str) => {
-    if (!str) return '';
-    return str.split('_').map(word => 
-      word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-    ).join(' ');
-  };
 
   const handleRemoveSpeaker = () => {
     openConfirmationModal({
@@ -93,12 +78,6 @@ const SpeakerCard = ({
         }
       },
     });
-  };
-
-  const truncateBio = (bio, maxLength = 80) => {
-    if (!bio) return 'No bio provided';
-    if (bio.length <= maxLength) return bio;
-    return bio.substring(0, maxLength) + '...';
   };
 
   const canManage = ['ADMIN', 'ORGANIZER'].includes(currentUserRole);

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/styles.module.css
@@ -1,0 +1,260 @@
+/* Mobile Speaker Card - Enhanced glassmorphism and refined polish */
+.card {
+  composes: card-base from '../../../../styles/design-tokens.css';
+  margin-bottom: clamp(0.75rem, 2vw, var(--space-md));
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(251, 250, 255, 0.9) 100%
+  );
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 
+    0 2px 8px rgba(139, 92, 246, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.card:hover {
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(251, 250, 255, 0.95) 100%
+  );
+  box-shadow: 
+    0 8px 24px rgba(139, 92, 246, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  transform: translateY(-2px) scale(1.01);
+  border-color: rgba(139, 92, 246, 0.1);
+}
+
+/* Subtle gradient accent for visual interest */
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--gradient-purple-light),
+    var(--gradient-purple-medium),
+    var(--gradient-purple-light)
+  );
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover::before {
+  opacity: 0.6;
+}
+
+.card:last-child {
+  margin-bottom: 0;
+}
+
+/* Card Actions - Top right corner */
+.cardActions {
+  position: absolute;
+  top: clamp(var(--space-sm), 2vw, var(--space-md));
+  right: clamp(var(--space-sm), 2vw, var(--space-md));
+  z-index: 1;
+}
+
+/* Action Button - Glass effect */
+.actionButton {
+  color: var(--color-text-muted) !important;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1) !important;
+  background: rgba(255, 255, 255, 0.5) !important;
+  backdrop-filter: blur(8px) !important;
+  -webkit-backdrop-filter: blur(8px) !important;
+  width: 32px !important;
+  height: 32px !important;
+  border: 1px solid rgba(139, 92, 246, 0.08) !important;
+  border-radius: var(--radius-md) !important;
+}
+
+.actionButton:hover {
+  color: var(--color-primary) !important;
+  background: rgba(139, 92, 246, 0.08) !important;
+  border-color: rgba(139, 92, 246, 0.15) !important;
+  transform: scale(1.05) !important;
+  box-shadow: 0 2px 8px rgba(139, 92, 246, 0.15) !important;
+}
+
+/* User Info Section */
+.userInfo {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.75rem, 2vw, var(--space-md));
+  margin-bottom: clamp(var(--space-md), 3vw, var(--space-lg));
+  padding-right: 40px; /* Space for action button */
+}
+
+.avatar {
+  flex-shrink: 0;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 
+    0 2px 8px rgba(139, 92, 246, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  background: linear-gradient(
+    135deg, 
+    var(--gradient-purple-light), 
+    var(--gradient-purple-medium)
+  );
+  position: relative;
+  transition: all 0.3s ease;
+}
+
+.card:hover .avatar {
+  transform: scale(1.05);
+  box-shadow: 
+    0 4px 12px rgba(139, 92, 246, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.userDetails {
+  flex: 1;
+  min-width: 0; /* Allow text truncation */
+}
+
+.userName {
+  composes: card-title from '../../../../styles/design-tokens.css';
+  margin-bottom: clamp(0.1rem, 0.5vw, 0.25rem);
+}
+
+.userEmail {
+  color: var(--color-text-secondary) !important;
+  font-size: clamp(var(--text-xs), 2vw, var(--text-sm)) !important;
+  word-break: break-word;
+}
+
+/* Professional Info Section - Enhanced divider */
+.professionalInfo {
+  margin-bottom: clamp(var(--space-sm), 2vw, var(--space-md));
+  padding-bottom: clamp(var(--space-sm), 2vw, var(--space-md));
+  border-bottom: 1px solid transparent;
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    rgba(139, 92, 246, 0.1) 20%,
+    rgba(139, 92, 246, 0.1) 80%,
+    transparent
+  );
+  background-position: 0 100%;
+  background-size: 100% 1px;
+  background-repeat: no-repeat;
+}
+
+.titleText {
+  color: var(--color-text-primary);
+  font-weight: 500;
+  font-size: clamp(var(--text-sm), 2.5vw, var(--text-base));
+}
+
+.companyText {
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-xs), 2vw, var(--text-sm));
+  margin-top: clamp(0.25rem, 1vw, 0.5rem);
+}
+
+.customBadge {
+  font-weight: 500 !important;
+  font-size: 11px !important;
+  padding: 3px 8px !important;
+  height: auto !important;
+  text-transform: none !important;
+  background: linear-gradient(
+    135deg,
+    rgba(139, 92, 246, 0.08),
+    rgba(168, 85, 247, 0.08)
+  ) !important;
+  border: 1px solid rgba(139, 92, 246, 0.15) !important;
+  color: var(--color-primary) !important;
+  backdrop-filter: blur(4px) !important;
+  -webkit-backdrop-filter: blur(4px) !important;
+}
+
+/* Sessions Section */
+.sessionsSection {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: clamp(var(--space-sm), 2vw, var(--space-md));
+}
+
+.sessionLabel {
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-xs), 2vw, var(--text-sm));
+}
+
+.sessionBadge {
+  font-weight: 600 !important;
+  font-size: clamp(11px, 1.8vw, var(--text-xs)) !important;
+  transition: all 0.2s ease !important;
+  backdrop-filter: blur(4px) !important;
+  -webkit-backdrop-filter: blur(4px) !important;
+}
+
+.sessionBadge[data-status="active"] {
+  background: linear-gradient(
+    135deg,
+    rgba(34, 197, 94, 0.1),
+    rgba(16, 185, 129, 0.1)
+  ) !important;
+  border: 1px solid rgba(34, 197, 94, 0.2) !important;
+  color: var(--color-success) !important;
+}
+
+.sessionBadge:hover {
+  transform: scale(1.05);
+  box-shadow: 0 2px 8px rgba(139, 92, 246, 0.15);
+}
+
+/* Bio Section - Enhanced with glass effect */
+.bioSection {
+  padding-top: clamp(var(--space-sm), 2vw, var(--space-md));
+  margin-top: clamp(var(--space-sm), 2vw, var(--space-md));
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(139, 92, 246, 0.02)
+  );
+  border-top: 1px solid transparent;
+  background-image: linear-gradient(
+    90deg,
+    transparent,
+    rgba(139, 92, 246, 0.08) 20%,
+    rgba(139, 92, 246, 0.08) 80%,
+    transparent
+  );
+  background-position: 0 0;
+  background-size: 100% 1px;
+  background-repeat: no-repeat;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  position: relative;
+}
+
+.bioText {
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-xs), 2vw, var(--text-sm));
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: 0.01em;
+  opacity: 0.9;
+  transition: opacity 0.2s ease;
+}
+
+.card:hover .bioText {
+  opacity: 1;
+}
+
+/* Removed organic shape decoration - keeping cards clean */

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/styles.module.css
@@ -198,6 +198,9 @@
   transition: all 0.2s ease !important;
   backdrop-filter: blur(4px) !important;
   -webkit-backdrop-filter: blur(4px) !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 4px !important;
 }
 
 .sessionBadge[data-status="active"] {
@@ -213,6 +216,40 @@
 .sessionBadge:hover {
   transform: scale(1.05);
   box-shadow: 0 2px 8px rgba(139, 92, 246, 0.15);
+}
+
+/* Expandable Sessions List */
+.sessionsList {
+  margin-top: clamp(var(--space-sm), 2vw, var(--space-md));
+  padding: clamp(var(--space-sm), 2vw, var(--space-md));
+  background: rgba(139, 92, 246, 0.02);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(139, 92, 246, 0.06);
+}
+
+.sessionItem {
+  padding: clamp(0.5rem, 1.5vw, 0.75rem) 0;
+  border-bottom: 1px solid rgba(139, 92, 246, 0.04);
+}
+
+.sessionItem:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.sessionItem:first-child {
+  padding-top: 0;
+}
+
+.sessionTitle {
+  color: var(--color-text-primary);
+  margin-bottom: 0.25rem;
+  line-height: 1.4;
+}
+
+.sessionDetails {
+  line-height: 1.5;
+  color: var(--color-text-muted) !important;
 }
 
 /* Bio Section - Enhanced with glass effect */

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerEditModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerEditModal/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Modal, TextInput, Textarea, Group, Stack, Text, Avatar, Alert } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
+import { useMediaQuery } from '@mantine/hooks';
 import { IconInfoCircle } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { speakerInfoSchema } from '../schemas/speakerSchemas';
@@ -10,6 +11,7 @@ import styles from './styles.module.css';
 
 const SpeakerEditModal = ({ opened, onClose, speaker, eventId, onSuccess }) => {
   const [updateSpeakerInfo, { isLoading }] = useUpdateEventSpeakerInfoMutation();
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const form = useForm({
     resolver: zodResolver(speakerInfoSchema),
@@ -62,67 +64,87 @@ const SpeakerEditModal = ({ opened, onClose, speaker, eventId, onSuccess }) => {
     <Modal
       opened={opened}
       onClose={onClose}
-      title="Edit Speaker Information"
+      title="Edit Speaker Info"
       size="lg"
+      centered
       lockScroll={false}
       classNames={{
         content: styles.modalContent,
         header: styles.modalHeader,
+        body: styles.modalBody,
       }}
     >
       <form onSubmit={form.onSubmit(handleSubmit)}>
-        <Stack p="lg">
+        <Stack className={styles.formStack}>
           <Group className={styles.userInfo}>
             <Avatar
               src={speaker.image_url}
               alt={speaker.full_name}
               radius="xl"
-              size="lg"
+              size={isMobile ? 'md' : 'lg'}
               className={styles.userAvatar}
             >
               {speaker.first_name?.[0]}{speaker.last_name?.[0]}
             </Avatar>
-            <div>
-              <Text fw={500}>{speaker.full_name}</Text>
-              <Text size="sm" c="dimmed">{speaker.email}</Text>
+            <div className={styles.userDetails}>
+              <Text fw={500} size={isMobile ? 'sm' : 'md'}>{speaker.full_name}</Text>
+              <Text size={isMobile ? 'xs' : 'sm'} c="dimmed">{speaker.email}</Text>
             </div>
           </Group>
 
-          <Alert icon={<IconInfoCircle size={16} />} color="blue" className={styles.infoAlert}>
-            <Text size="sm">
-              These fields override the speaker's profile information for this event only.
-              Leave blank to use their default profile information.
+          <Alert 
+            icon={<IconInfoCircle size={14} />} 
+            color="blue" 
+            className={styles.infoAlert}
+            styles={{
+              root: { padding: 'var(--space-sm) !important' },
+              message: { fontSize: 'var(--text-xs) !important' }
+            }}
+          >
+            <Text size="xs">
+              Override speaker's profile info for this event only.
+              Leave blank to use defaults.
             </Text>
           </Alert>
 
           <TextInput
             label="Speaker Title"
-            placeholder={speaker.title || "Enter speaker's title for this event"}
-            description="How they should be introduced (e.g., 'CEO @ Atria'). This overrides their profile title and company."
+            placeholder={speaker.title || "Enter title for this event"}
+            description={!isMobile && "How they should be introduced (e.g., 'CEO @ Atria')"}
             className={styles.formInput}
+            size="sm"
             {...form.getInputProps('speaker_title')}
           />
 
           <Textarea
             label="Speaker Bio"
-            placeholder={speaker.bio || "Enter speaker's bio for this event"}
-            description="Biography to display on the speakers page"
-            rows={6}
+            placeholder={speaker.bio || "Enter bio for this event"}
+            description={!isMobile && "Biography to display on the speakers page"}
+            rows={isMobile ? 3 : 4}
             className={styles.formTextarea}
+            size="sm"
             {...form.getInputProps('speaker_bio')}
           />
 
-          {(speaker.title || speaker.bio) && (
-            <Alert color="gray" variant="light" className={styles.grayAlert}>
-              <Stack gap="xs">
-                <Text size="sm" fw={500}>Profile Information:</Text>
+          {!isMobile && (speaker.title || speaker.bio) && (
+            <Alert 
+              color="gray" 
+              variant="light" 
+              className={styles.grayAlert}
+              styles={{
+                root: { padding: 'var(--space-sm) !important' },
+                message: { fontSize: 'var(--text-xs) !important' }
+              }}
+            >
+              <Stack gap={4}>
+                <Text size="xs" fw={500}>Current Profile:</Text>
                 {speaker.title && (
-                  <Text size="sm">
+                  <Text size="xs" lineClamp={1}>
                     <strong>Title:</strong> {speaker.title}
                   </Text>
                 )}
                 {speaker.bio && (
-                  <Text size="sm">
+                  <Text size="xs" lineClamp={2}>
                     <strong>Bio:</strong> {speaker.bio}
                   </Text>
                 )}

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerEditModal/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerEditModal/styles.module.css
@@ -4,67 +4,101 @@
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   padding: 0;
+  max-height: clamp(400px, 80vh, 700px);
+  display: flex;
+  flex-direction: column;
 }
 
 /* Modal Header */
 .modalHeader {
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 2vw, 1.125rem);
   font-weight: 600;
-  color: #1E293B;
-  padding: 1.5rem;
-  border-bottom: 1px solid rgba(139, 92, 246, 0.04);
+  color: var(--color-text-primary);
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-bottom: 1px solid var(--primary-alpha-4);
+  flex-shrink: 0;
+}
+
+/* Modal Body */
+.modalBody {
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* Form Stack */
+.formStack {
+  padding: clamp(0.75rem, 2vw, 1.25rem);
+  gap: clamp(0.5rem, 1.5vw, 1rem);
 }
 
 /* User Info Section */
 .userInfo {
-  background: rgba(139, 92, 246, 0.04);
-  padding: 1rem;
-  border-radius: 6px;
-  border: 1px solid rgba(139, 92, 246, 0.08);
+  background: var(--primary-alpha-4);
+  padding: clamp(0.5rem, 1.5vw, 0.75rem);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--primary-alpha-8);
+  gap: clamp(0.5rem, 1.5vw, 0.75rem);
+}
+
+.userDetails {
+  flex: 1;
+  min-width: 0;
 }
 
 /* Alert Styling */
 .infoAlert {
-  background: rgba(139, 92, 246, 0.04);
-  border: 1px solid rgba(139, 92, 246, 0.1);
-  border-radius: 6px;
+  background: var(--primary-alpha-4) !important;
+  border: 1px solid var(--primary-alpha-10) !important;
+  border-radius: var(--radius-md) !important;
 }
 
 .grayAlert {
-  background: rgba(107, 114, 128, 0.04);
-  border: 1px solid rgba(107, 114, 128, 0.1);
-  border-radius: 6px;
+  background: rgba(107, 114, 128, 0.04) !important;
+  border: 1px solid rgba(107, 114, 128, 0.1) !important;
+  border-radius: var(--radius-md) !important;
 }
 
 /* Form Elements */
 .formInput input,
 .formTextarea textarea {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(139, 92, 246, 0.1);
-  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid var(--primary-alpha-10) !important;
+  transition: all 0.2s ease !important;
+  font-size: clamp(var(--text-sm), 2.5vw, var(--text-base)) !important;
 }
 
 .formInput input:focus,
 .formTextarea textarea:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
+  border-color: var(--primary-alpha-30) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Avatar Styling */
 .userAvatar {
   border: 2px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
+  flex-shrink: 0;
 }
 
 /* Button Group */
 .buttonGroup {
-  padding: 1.5rem;
-  border-top: 1px solid rgba(139, 92, 246, 0.04);
-  margin-top: 1.5rem;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-top: 1px solid var(--primary-alpha-4);
+  margin-top: 0;
   background: rgba(251, 250, 255, 0.5);
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: clamp(0.5rem, 1.5vw, 0.75rem);
+  flex-shrink: 0;
+}
+
+/* Mobile Responsive - only iOS zoom prevention */
+@media (max-width: 768px) {
+  .formInput input,
+  .formTextarea textarea {
+    font-size: 16px !important; /* Prevents zoom on iOS */
+  }
 }
 
 /* Override Mantine Modal Styles */

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.jsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
 import { useUpdateEventUserMutation } from '@/app/features/events/api';
+import { formatTime, capitalizeWords, truncateText } from '@/shared/utils/formatting';
 import styles from './styles.module.css';
 
 const SpeakerRow = ({
@@ -23,24 +24,6 @@ const SpeakerRow = ({
   const navigate = useNavigate();
   const [updateUser] = useUpdateEventUserMutation();
   
-  // Format time from 24hr to 12hr with AM/PM
-  const formatTime = (timeStr) => {
-    if (!timeStr) return '';
-    const [hours, minutes] = timeStr.split(':');
-    const hour = parseInt(hours);
-    const ampm = hour >= 12 ? 'PM' : 'AM';
-    const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
-    return `${displayHour}:${minutes} ${ampm}`;
-  };
-
-  // Capitalize first letter of each word
-  const capitalizeWords = (str) => {
-    if (!str) return '';
-    return str.split('_').map(word => 
-      word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-    ).join(' ');
-  };
-
   const handleRemoveSpeaker = () => {
     openConfirmationModal({
       title: 'Remove Speaker Role',
@@ -91,13 +74,6 @@ const SpeakerRow = ({
         }
       },
     });
-  };
-
-  // Truncate bio for display
-  const truncateBio = (bio, maxLength = 100) => {
-    if (!bio) return 'No bio provided';
-    if (bio.length <= maxLength) return bio;
-    return bio.substring(0, maxLength) + '...';
   };
 
   const canManage = ['ADMIN', 'ORGANIZER'].includes(currentUserRole);
@@ -203,7 +179,7 @@ const SpeakerRow = ({
       <Table.Td>
         <Tooltip label={displayBio} multiline maw={300}>
           <Text size="sm" lineClamp={2} className={styles.bioText}>
-            {truncateBio(displayBio)}
+            {truncateText(displayBio, { maxLength: 100, fallback: 'No bio provided', wordBoundary: true })}
           </Text>
         </Tooltip>
       </Table.Td>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/styles.module.css
@@ -1,36 +1,38 @@
 /* Speaker Info Styles */
 .titleText {
   display: inline-block;
-  margin-right: 0.5rem;
-  color: #1E293B;
+  margin-right: clamp(0.25rem, 1vw, 0.5rem);
+  color: var(--color-text-primary);
   font-weight: 500;
+  font-size: clamp(var(--text-sm), 1.5vw, var(--text-base));
 }
 
 /* Avatar Styling */
 .userAvatar {
   border: 2px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-sm);
+  background: linear-gradient(45deg, var(--gradient-purple-light), var(--gradient-purple-medium));
 }
 
 /* Badge Styling */
 .sessionBadge {
-  background: rgba(34, 197, 94, 0.08);
-  color: #16A34A;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.75rem;
+  background: rgba(34, 197, 94, 0.08) !important;
+  color: var(--color-success) !important;
+  font-weight: 500 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.05em !important;
+  font-size: clamp(11px, 1.2vw, var(--text-xs)) !important;
 }
 
 .sessionBadge.unassigned {
-  background: rgba(107, 114, 128, 0.08);
-  color: #6B7280;
+  background: rgba(107, 114, 128, 0.08) !important;
+  color: var(--color-text-muted) !important;
 }
 
 /* Bio Text */
 .bioText {
-  color: #64748B;
-  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-xs), 1.3vw, 0.85rem);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -42,16 +44,17 @@
 /* Action Button */
 .actionButton {
   transition: all 0.2s ease;
+  color: var(--color-text-muted) !important;
 }
 
 .actionButton:hover {
-  background: rgba(139, 92, 246, 0.08);
-  color: #8B5CF6;
+  background: var(--primary-alpha-8) !important;
+  color: var(--color-primary) !important;
 }
 
-/* Initials Avatar */
+/* Initials Avatar - fallback when no image */
 .initialsAvatar {
-  background: linear-gradient(45deg, #8B5CF6, #A855F7);
+  background: linear-gradient(45deg, var(--gradient-purple-light), var(--gradient-purple-medium));
   color: white;
   font-weight: 600;
   text-transform: uppercase;

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
@@ -1,6 +1,6 @@
-import { Table, Group, Text, ActionIcon, UnstyledButton, Badge, Select } from '@mantine/core';
+import { Table, Group, Text, ActionIcon, UnstyledButton, Select } from '@mantine/core';
 import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
-import { useState, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useMediaQuery } from '@mantine/hooks';
 import SpeakerRow from '../SpeakerRow';
 import SpeakerCard from '../SpeakerCard';
@@ -26,7 +26,8 @@ const SpeakersList = ({
     }
   };
 
-  const sortedSpeakers = [...speakers].sort((a, b) => {
+  const sortedSpeakers = useMemo(() => {
+    return [...speakers].sort((a, b) => {
     let aVal, bVal;
     switch (sortBy) {
       case 'name':
@@ -64,7 +65,8 @@ const SpeakersList = ({
     } else {
       return aVal < bVal ? 1 : -1;
     }
-  });
+    });
+  }, [speakers, sortBy, sortOrder]);
 
   const SortHeader = ({ field, children }) => (
     <UnstyledButton

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
@@ -1,7 +1,9 @@
-import { Table, Group, Text, ActionIcon, UnstyledButton, Badge } from '@mantine/core';
+import { Table, Group, Text, ActionIcon, UnstyledButton, Badge, Select } from '@mantine/core';
 import { IconChevronUp, IconChevronDown } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useMediaQuery } from '@mantine/hooks';
 import SpeakerRow from '../SpeakerRow';
+import SpeakerCard from '../SpeakerCard';
 import { getNameSortValue } from '../../../../shared/utils/sorting';
 import styles from './styles.module.css';
 
@@ -13,6 +15,7 @@ const SpeakersList = ({
 }) => {
   const [sortBy, setSortBy] = useState('name');
   const [sortOrder, setSortOrder] = useState('asc');
+  const isMobile = useMediaQuery('(max-width: 768px)');
 
   const handleSort = (field) => {
     if (sortBy === field) {
@@ -96,25 +99,67 @@ const SpeakersList = ({
     );
   }
 
+  // Mobile: Card layout with sorting dropdown
+  if (isMobile) {
+    return (
+      <div className={styles.mobileContainer}>
+        <div className={styles.mobileSortControls}>
+          <Select
+            label="Sort by"
+            value={`${sortBy}-${sortOrder}`}
+            onChange={(value) => {
+              const [field, order] = value.split('-');
+              setSortBy(field);
+              setSortOrder(order);
+            }}
+            data={[
+              { value: 'name-asc', label: 'Name (A-Z)' },
+              { value: 'name-desc', label: 'Name (Z-A)' },
+              { value: 'title-asc', label: 'Title (A-Z)' },
+              { value: 'title-desc', label: 'Title (Z-A)' },
+              { value: 'company-asc', label: 'Company (A-Z)' },
+              { value: 'company-desc', label: 'Company (Z-A)' },
+              { value: 'sessions-desc', label: 'Most Sessions' },
+              { value: 'sessions-asc', label: 'Least Sessions' },
+            ]}
+            className={styles.sortSelect}
+          />
+        </div>
+        <div className={styles.cardList}>
+          {sortedSpeakers.map((speaker) => (
+            <SpeakerCard
+              key={speaker.user_id}
+              speaker={speaker}
+              onEditSpeaker={onEditSpeaker}
+              currentUserRole={currentUserRole}
+              organizationId={organizationId}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Desktop: Table layout
   return (
     <div className={styles.tableContainer}>
       <Table horizontalSpacing="md" verticalSpacing="sm" striped highlightOnHover>
         <Table.Thead>
           <Table.Tr>
-            <Table.Th>
+            <Table.Th style={{ minWidth: '200px', maxWidth: '300px' }}>
               <SortHeader field="name">Speaker</SortHeader>
             </Table.Th>
-            <Table.Th>
+            <Table.Th style={{ minWidth: '150px' }}>
               <SortHeader field="title">Title</SortHeader>
             </Table.Th>
-            <Table.Th>
+            <Table.Th style={{ minWidth: '120px' }}>
               <SortHeader field="company">Company</SortHeader>
             </Table.Th>
-            <Table.Th style={{ textAlign: 'center' }}>
+            <Table.Th style={{ textAlign: 'center', width: '100px' }}>
               <SortHeader field="sessions">Sessions</SortHeader>
             </Table.Th>
-            <Table.Th>Bio</Table.Th>
-            <Table.Th width={100} style={{ textAlign: 'center' }}>Actions</Table.Th>
+            <Table.Th style={{ minWidth: '150px' }}>Bio</Table.Th>
+            <Table.Th width={80} style={{ textAlign: 'center' }}>Actions</Table.Th>
           </Table.Tr>
         </Table.Thead>
         <Table.Tbody>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/styles.module.css
@@ -101,6 +101,7 @@
   display: flex;
   flex-direction: column;
   gap: 0; /* Gap handled by card margins */
+  padding-bottom: 50px; /* Space for mobile messaging bar */
 }
 
 /* Responsive Styles */

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/styles.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/styles.module.css
@@ -1,37 +1,37 @@
-/* Table Container - Glass Card Style */
+/* Table Container - Glass Card Style (Desktop) */
 .tableContainer {
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.9);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(139, 92, 246, 0.03);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Table Header */
 .tableContainer thead tr {
-  background: rgba(139, 92, 246, 0.04);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.08);
+  background: var(--primary-alpha-4);
+  border-bottom: 1px solid var(--primary-alpha-8);
 }
 
 .tableContainer th {
   font-weight: 500;
-  color: #64748B;
-  padding: 1rem;
-  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  padding: clamp(0.75rem, 2vw, 1rem);
+  font-size: clamp(var(--text-xs), 1.5vw, 0.85rem);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 /* Table Body */
 .tableContainer tbody tr {
-  border-bottom: 1px solid rgba(139, 92, 246, 0.04);
+  border-bottom: 1px solid var(--primary-alpha-4);
   transition: background-color 0.2s ease;
 }
 
 .tableContainer tbody tr:hover {
-  background: rgba(139, 92, 246, 0.02);
+  background: var(--primary-alpha-2);
 }
 
 .tableContainer tbody tr:last-child {
@@ -39,16 +39,16 @@
 }
 
 .tableContainer td {
-  padding: 1rem;
-  color: #1E293B;
-  font-size: 0.9rem;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  color: var(--color-text-primary);
+  font-size: clamp(var(--text-sm), 1.5vw, 0.9rem);
 }
 
 /* Empty State */
 .emptyState {
-  padding: 4rem 2rem;
+  padding: clamp(var(--space-2xl), 5vw, 4rem) clamp(var(--space-lg), 4vw, var(--space-xl));
   text-align: center;
-  color: #64748B;
+  color: var(--color-text-secondary);
 }
 
 /* Sort Header */
@@ -68,6 +68,59 @@
 }
 
 .sortHeader:hover {
-  color: #8B5CF6;
+  color: var(--color-primary);
   background: rgba(139, 92, 246, 0.02);
+}
+
+/* Mobile Container */
+.mobileContainer {
+  display: none;
+}
+
+/* Mobile Sort Controls */
+.mobileSortControls {
+  margin-bottom: clamp(var(--space-md), 3vw, var(--space-lg));
+}
+
+.sortSelect {
+  width: 100%;
+}
+
+.sortSelect input {
+  background: rgba(255, 255, 255, 0.8) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
+  font-size: clamp(var(--text-sm), 2.5vw, var(--text-base)) !important;
+}
+
+.sortSelect input:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+}
+
+/* Card List for Mobile */
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: 0; /* Gap handled by card margins */
+}
+
+/* Responsive Styles */
+@media (max-width: 768px) {
+  /* Hide desktop table on mobile */
+  .tableContainer {
+    display: none;
+  }
+  
+  /* Show mobile container */
+  .mobileContainer {
+    display: block;
+  }
+}
+
+/* Tablet adjustments for better table readability */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .tableContainer th,
+  .tableContainer td {
+    padding: clamp(0.5rem, 1.5vw, 1rem);
+    font-size: clamp(var(--text-xs), 1.5vw, var(--text-sm));
+  }
 }

--- a/frontend/src/pages/EventAdmin/SpeakersManager/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/index.jsx
@@ -122,22 +122,22 @@ const SpeakersManager = () => {
       <div className={styles.contentWrapper}>
         {/* Header Section */}
         <section className={styles.headerSection}>
-          <Group justify="space-between" align="flex-start">
-            <div>
+          <div className={styles.headerContent}>
+            <div className={styles.headerLeft}>
               <h2 className={styles.pageTitle}>Speakers Management</h2>
               <div className={styles.badgeGroup}>
-                <Badge className={styles.statsBadge} size="lg" variant="light" radius="sm">
+                <Badge className={styles.statsBadge} size="md" variant="light" radius="sm">
                   {speakerCounts.total} Total
                 </Badge>
-                <Badge size="lg" variant="light" color="green" radius="sm">
+                <Badge className={styles.statsBadge} size="md" variant="light" color="green" radius="sm">
                   {speakerCounts.withSessions} Assigned
                 </Badge>
-                <Badge size="lg" variant="light" color="gray" radius="sm">
+                <Badge className={styles.statsBadge} size="md" variant="light" color="gray" radius="sm">
                   {speakerCounts.withoutSessions} Unassigned
                 </Badge>
               </div>
             </div>
-            <Group>
+            <div className={styles.headerRight}>
               {/* CSV Export - Commented out for post-launch implementation
               <Menu shadow="md" width={200}>
                 <Menu.Target>
@@ -166,12 +166,13 @@ const SpeakersManager = () => {
               <Button
                 variant="primary"
                 onClick={handleAddSpeaker}
+                className={styles.addButton}
               >
                 <IconPlus size={18} />
                 Add Speaker
               </Button>
-            </Group>
-          </Group>
+            </div>
+          </div>
         </section>
 
         {/* Main Content Section */}

--- a/frontend/src/pages/EventAdmin/SpeakersManager/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/styles/index.module.css
@@ -62,37 +62,64 @@
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border-radius: 8px;
-  padding: 2rem;
+  border-radius: var(--radius-lg);
+  padding: clamp(1.25rem, 3vw, 2rem);
   border: 1px solid rgba(255, 255, 255, 0.8);
   box-shadow: 0 4px 20px rgba(139, 92, 246, 0.04);
-  margin-bottom: 2rem;
+  margin-bottom: clamp(1rem, 3vw, 2rem);
+}
+
+/* Header Content Layout */
+.headerContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(1rem, 3vw, 2rem);
+  flex-wrap: wrap;
+}
+
+.headerLeft {
+  flex: 1;
+  min-width: 0;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.5rem, 2vw, 1rem);
 }
 
 /* Page Title Styling */
 .pageTitle {
-  font-size: 1.5rem;
+  font-size: clamp(var(--text-xl), 3vw, var(--text-2xl));
   font-weight: 600;
-  color: #1e293b;
-  margin: 0 0 0.75rem 0;
+  color: var(--color-text-primary);
+  margin: 0 0 clamp(0.5rem, 2vw, 0.75rem) 0;
 }
 
 /* Badge Group */
 .badgeGroup {
   display: flex;
-  gap: 0.5rem;
+  gap: clamp(0.375rem, 1.5vw, 0.5rem);
   flex-wrap: wrap;
+  margin-top: clamp(0.5rem, 1.5vw, 0.75rem);
 }
 
 /* Updated Badge Styles */
 .statsBadge {
-  background: rgba(139, 92, 246, 0.08);
-  color: #8b5cf6;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  font-weight: 500;
-  border: 1px solid rgba(139, 92, 246, 0.15);
+  background: var(--primary-alpha-8) !important;
+  color: var(--color-text-secondary) !important;
+  padding: clamp(0.25rem, 1vw, 0.375rem) clamp(0.5rem, 1.5vw, 0.75rem) !important;
+  border-radius: var(--radius-md) !important;
+  font-size: clamp(0.7rem, 1.8vw, 0.85rem) !important;
+  font-weight: 500 !important;
+  border: 1px solid var(--primary-alpha-15) !important;
+  white-space: nowrap;
+}
+
+/* Add button styling */
+.addButton {
+  white-space: nowrap;
 }
 
 /* Main Content Glass Section */
@@ -113,15 +140,15 @@
 
 /* Search Input Styling */
 .searchInput input {
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(139, 92, 246, 0.1);
-  font-size: 0.95rem;
-  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 0.8) !important;
+  border: 1px solid var(--primary-alpha-10) !important;
+  font-size: clamp(var(--text-sm), 2vw, var(--text-base)) !important;
+  transition: all 0.2s ease !important;
 }
 
 .searchInput input:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 0.8);
+  border-color: var(--primary-alpha-30) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
 }
 
 /* Action Icon Styling */
@@ -130,28 +157,28 @@
 }
 
 .actionIcon:hover {
-  background: rgba(139, 92, 246, 0.08);
+  background: var(--primary-alpha-8);
 }
 
 /* Menu Dropdown Styling */
 .menuDropdown {
-  background: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.95) !important;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.8);
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.08);
-  border-radius: 6px;
+  box-shadow: var(--shadow-md);
+  border-radius: var(--radius-md);
 }
 
 .menuItem {
-  color: #475569;
-  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  font-size: clamp(var(--text-sm), 2vw, 0.9rem);
   transition: all 0.2s ease;
 }
 
 .menuItem:hover {
-  background: rgba(139, 92, 246, 0.04);
-  color: #8b5cf6;
+  background: var(--primary-alpha-4);
+  color: var(--color-primary);
 }
 
 /* Table Container - Moved from SpeakersList but kept for reference */
@@ -211,15 +238,42 @@
 
   .headerSection,
   .mainContent {
-    padding: 1.5rem;
+    padding: 1rem;
+  }
+
+  .headerContent {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .headerLeft {
+    width: 100%;
+  }
+
+  .headerRight {
+    width: 100%;
+    justify-content: center;
   }
 
   .pageTitle {
-    font-size: 1.25rem;
+    font-size: clamp(1.25rem, 5vw, 1.5rem);
+    text-align: center;
+    margin-bottom: 0.5rem;
   }
 
   .badgeGroup {
-    gap: 0.25rem;
+    justify-content: center;
+    gap: 0.375rem;
+  }
+
+  .statsBadge {
+    font-size: 0.75rem !important;
+    padding: 0.25rem 0.5rem !important;
+  }
+
+  .addButton {
+    width: 100%;
+    justify-content: center;
   }
 
   .bgShape1,

--- a/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
+++ b/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
@@ -6,18 +6,23 @@
   flex-direction: column;
   overflow: hidden;
   cursor: pointer;
-  background: linear-gradient(180deg, 
-    rgba(255, 255, 255, 0.95) 0%, 
-    rgba(251, 250, 255, 0.9) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(251, 250, 255, 0.9) 100%
+  );
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .card:hover {
   box-shadow: 0 8px 28px rgba(139, 92, 246, 0.12) !important;
-  background: linear-gradient(180deg, 
-    rgba(255, 255, 255, 1) 0%, 
-    rgba(251, 250, 255, 0.95) 100%);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(251, 250, 255, 0.95) 100%
+  );
   transform: translateY(-2px) scale(1.01);
+  cursor: auto !important;
 }
 
 /* Featured card special styling */
@@ -48,7 +53,9 @@
 /* Add hover effect to tier indicator when card is hovered */
 .card:hover .tierIndicator {
   transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15), inset 0 1px 1px rgba(255, 255, 255, 0.3);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.15),
+    inset 0 1px 1px rgba(255, 255, 255, 0.3);
 }
 
 .tierText {
@@ -107,7 +114,11 @@
   width: clamp(70px, 12vw, 100px);
   height: clamp(70px, 12vw, 100px);
   border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.1), rgba(168, 85, 247, 0.1));
+  background: linear-gradient(
+    135deg,
+    rgba(139, 92, 246, 0.1),
+    rgba(168, 85, 247, 0.1)
+  );
   display: flex;
   align-items: center;
   justify-content: center;
@@ -203,7 +214,7 @@
   .tierIndicator {
     padding: 0.3rem 0.65rem;
   }
-  
+
   .tierText {
     font-size: 0.625rem;
   }
@@ -215,7 +226,7 @@
     /* Use full clamp() sizing on large screens */
     padding: clamp(0.25rem, 1.5vw, 0.375rem) clamp(0.5rem, 2.5vw, 0.875rem);
   }
-  
+
   .tierText {
     font-size: clamp(0.625rem, 1.5vw, 0.7rem);
   }
@@ -227,12 +238,12 @@
     align-items: flex-start;
     gap: var(--space-sm);
   }
-  
+
   .tierIndicator {
     /* Ensure tier indicator doesn't get too small on mobile */
     padding: 0.25rem 0.5rem;
   }
-  
+
   .tierText {
     /* Prevent tier text from becoming unreadable */
     font-size: max(0.625rem, 10px);

--- a/frontend/src/shared/components/chat/MobileChatSidebar/styles/index.module.css
+++ b/frontend/src/shared/components/chat/MobileChatSidebar/styles/index.module.css
@@ -12,7 +12,7 @@
   box-shadow: 
     0 -4px 20px rgba(139, 92, 246, 0.04),
     0 -2px 8px rgba(0, 0, 0, 0.04);
-  z-index: 1000;
+  z-index: 100; /* Reduced from 1000 to be below modals */
   transition: height 0.3s ease;
   display: flex;
   flex-direction: column;

--- a/frontend/src/shared/utils/formatting.js
+++ b/frontend/src/shared/utils/formatting.js
@@ -1,0 +1,93 @@
+/**
+ * Shared formatting utilities for consistent data presentation
+ */
+
+/**
+ * Converts 24-hour time string to 12-hour format with AM/PM
+ * @param {string} timeStr - Time in HH:MM format
+ * @returns {string} Formatted time (e.g., "2:30 PM")
+ */
+export const formatTime = (timeStr) => {
+  if (!timeStr) return '';
+  const [hours, minutes] = timeStr.split(':');
+  const hour = parseInt(hours);
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${displayHour}:${minutes} ${ampm}`;
+};
+
+/**
+ * Capitalizes snake_case or underscore-separated words
+ * @param {string} str - String to capitalize (e.g., "PANEL_DISCUSSION")
+ * @returns {string} Formatted string (e.g., "Panel Discussion")
+ */
+export const capitalizeWords = (str) => {
+  if (!str) return '';
+  return str.split('_').map(word => 
+    word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+  ).join(' ');
+};
+
+/**
+ * Truncates text with customizable options
+ * @param {string} text - Text to truncate
+ * @param {Object} options - Truncation options
+ * @param {number} options.maxLength - Maximum character length (default: 80)
+ * @param {string} options.suffix - Suffix to add when truncated (default: '...')
+ * @param {string} options.fallback - Fallback text when input is empty
+ * @param {boolean} options.wordBoundary - Truncate at word boundary (default: false)
+ * @returns {string} Truncated text
+ */
+export const truncateText = (text, options = {}) => {
+  const {
+    maxLength = 80,
+    suffix = '...',
+    fallback = '',
+    wordBoundary = false
+  } = options;
+  
+  if (!text) return fallback;
+  if (text.length <= maxLength) return text;
+  
+  let truncated = text.substring(0, maxLength);
+  
+  // If wordBoundary is true, cut at the last complete word
+  if (wordBoundary) {
+    const lastSpace = truncated.lastIndexOf(' ');
+    if (lastSpace > 0) {
+      truncated = truncated.substring(0, lastSpace);
+    }
+  }
+  
+  return truncated + suffix;
+};
+
+/**
+ * Convenience preset for truncating bio text
+ * @param {string} text - Bio text to truncate
+ * @returns {string} Truncated bio with fallback
+ */
+export const truncateBio = (text) => truncateText(text, { 
+  maxLength: 80, 
+  fallback: 'No bio provided',
+  wordBoundary: true 
+});
+
+/**
+ * Convenience preset for truncating descriptions
+ * @param {string} text - Description text to truncate
+ * @returns {string} Truncated description
+ */
+export const truncateDescription = (text) => truncateText(text, { 
+  maxLength: 150,
+  wordBoundary: true 
+});
+
+/**
+ * Convenience preset for truncating titles
+ * @param {string} text - Title text to truncate
+ * @returns {string} Truncated title
+ */
+export const truncateTitle = (text) => truncateText(text, { 
+  maxLength: 50 
+});


### PR DESCRIPTION
- Add new SpeakerCard component for mobile display (<768px)
- Keep efficient table layout for desktop/laptop screens
- Implement hybrid responsive design with useMediaQuery hook
- Make modals more compact with responsive sizing using clamp()
- Fix mobile header layout with centered elements and full-width button
- Fix table text overflow with truncation for long names/emails
- Reduce MobileChatSidebar z-index to appear behind modals
- Remove decorative corner gradient from mobile cards for cleaner look
- Align with design system using glassmorphism and design tokens## Description

