### PR TITLE
feat: add moderation features to mobile attendee cards with shared ut…

### DIFF
--- a/frontend/src/pages/EventAdmin/AttendeesManager/AttendeeRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/AttendeesManager/AttendeeRow/index.jsx
@@ -30,6 +30,7 @@ import {
   useCreateDirectMessageThreadMutation,
 } from '../../../../app/features/networking/api';
 import { IcebreakerModal } from '../../../../shared/components/IcebreakerModal';
+import { getModerationPermissions, getModerationRowStyles, createModerationHandlers } from '@/shared/utils/moderation';
 import { useDispatch } from 'react-redux';
 import { openThread } from '../../../../app/store/chatSlice';
 import styles from './styles.module.css';
@@ -298,43 +299,17 @@ const AttendeeRow = ({
     ((currentUserRole === 'ADMIN') || 
      (currentUserRole === 'ORGANIZER' && ['ATTENDEE', 'SPEAKER'].includes(attendee.role)));
 
-  // Moderation permissions: Organizers can ban/mute, Admins can do everything including remove
-  const canModerateUser = currentUserId !== attendee.user_id && 
-    (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
-    !attendee.is_banned; // Can't moderate already banned users
-  
-  const canUnbanUser = currentUserId !== attendee.user_id && 
-    (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
-    attendee.is_banned;
-  
-  const canChatModerateUser = currentUserId !== attendee.user_id && 
-    (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
-    !attendee.is_banned; // Can't chat moderate banned users
-  
-  const canChatUnmuteUser = currentUserId !== attendee.user_id && 
-    (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
-    attendee.is_chat_banned;
-
-  // Row styling based on moderation status
-  const getRowStyle = () => {
-    if (attendee.is_banned) {
-      return {
-        backgroundColor: '#FFFAFA',
-        borderLeft: '3px solid #FFF0F0',
-      };
-    }
-    if (attendee.is_chat_banned) {
-      return {
-        backgroundColor: '#FFFEFA',
-        borderLeft: '3px solid #FFF8F0',
-      };
-    }
-    return {};
-  };
+  // Get moderation permissions using shared utility
+  const {
+    canModerateUser,
+    canUnbanUser,
+    canChatModerateUser,
+    canChatUnmuteUser,
+  } = getModerationPermissions(currentUserId, currentUserRole, attendee);
 
   return (
     <>
-      <Table.Tr style={getRowStyle()}>
+      <Table.Tr style={getModerationRowStyles(attendee)}>
       <Table.Td>
         <Group gap="sm" wrap="nowrap">
           <Avatar

--- a/frontend/src/shared/utils/moderation.js
+++ b/frontend/src/shared/utils/moderation.js
@@ -1,0 +1,208 @@
+import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
+import { notifications } from '@mantine/notifications';
+
+/**
+ * Get moderation permissions for a user
+ */
+export const getModerationPermissions = (currentUserId, currentUserRole, targetUser) => {
+  const isInvitation = !targetUser.user_id;
+  const userId = targetUser.user_id;
+  const isBanned = targetUser.is_banned;
+  const isChatBanned = targetUser.is_chat_banned;
+  
+  return {
+    canModerateUser: !isInvitation && currentUserId !== userId && 
+      (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
+      !isBanned,
+    
+    canUnbanUser: !isInvitation && currentUserId !== userId && 
+      (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
+      isBanned,
+    
+    canChatModerateUser: !isInvitation && currentUserId !== userId && 
+      (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
+      !isBanned,
+    
+    canChatUnmuteUser: !isInvitation && currentUserId !== userId && 
+      (currentUserRole === 'ADMIN' || currentUserRole === 'ORGANIZER') &&
+      isChatBanned,
+  };
+};
+
+/**
+ * Get styling based on moderation status
+ */
+export const getModerationStyles = (user) => {
+  if (user.is_banned) {
+    return {
+      backgroundColor: 'rgba(255, 250, 250, 0.95)',
+      borderLeft: '3px solid rgba(239, 68, 68, 0.5)',
+    };
+  }
+  if (user.is_chat_banned) {
+    return {
+      backgroundColor: 'rgba(255, 254, 250, 0.95)',
+      borderLeft: '3px solid rgba(251, 191, 36, 0.5)',
+    };
+  }
+  return {};
+};
+
+/**
+ * Get row styling for table (slightly different opacity)
+ */
+export const getModerationRowStyles = (user) => {
+  if (user.is_banned) {
+    return {
+      backgroundColor: '#FFFAFA',
+      borderLeft: '3px solid #FFF0F0',
+    };
+  }
+  if (user.is_chat_banned) {
+    return {
+      backgroundColor: '#FFFEFA',
+      borderLeft: '3px solid #FFF8F0',
+    };
+  }
+  return {};
+};
+
+/**
+ * Create moderation handlers
+ */
+export const createModerationHandlers = ({
+  user,
+  currentUserRole,
+  banUser,
+  unbanUser,
+  chatBanUser,
+  chatUnbanUser,
+}) => {
+  const handleBan = () => {
+    openConfirmationModal({
+      title: 'Ban User from Event',
+      message: `Ban ${user.full_name} from the event? They will be removed and cannot rejoin.`,
+      confirmLabel: 'Ban User',
+      cancelLabel: 'Cancel',
+      isDangerous: true,
+      onConfirm: async () => {
+        try {
+          await banUser({
+            eventId: user.event_id,
+            userId: user.user_id,
+            reason: 'Violation of event guidelines',
+            moderation_notes: `Banned by ${currentUserRole}`,
+          }).unwrap();
+          
+          notifications.show({
+            title: 'Success',
+            message: `${user.full_name} has been banned from the event`,
+            color: 'red',
+          });
+        } catch (error) {
+          notifications.show({
+            title: 'Error',
+            message: error.data?.message || 'Failed to ban user',
+            color: 'red',
+          });
+        }
+      },
+    });
+  };
+
+  const handleUnban = () => {
+    openConfirmationModal({
+      title: 'Unban User',
+      message: `Allow ${user.full_name} to rejoin the event?`,
+      confirmLabel: 'Unban',
+      cancelLabel: 'Cancel',
+      onConfirm: async () => {
+        try {
+          await unbanUser({
+            eventId: user.event_id,
+            userId: user.user_id,
+          }).unwrap();
+          
+          notifications.show({
+            title: 'Success',
+            message: `${user.full_name} has been unbanned`,
+            color: 'green',
+          });
+        } catch (error) {
+          notifications.show({
+            title: 'Error',
+            message: error.data?.message || 'Failed to unban user',
+            color: 'red',
+          });
+        }
+      },
+    });
+  };
+
+  const handleChatBan = () => {
+    openConfirmationModal({
+      title: 'Mute User from Chat',
+      message: `Mute ${user.full_name} from sending chat messages? They can still view chat but cannot send messages.`,
+      confirmLabel: 'Mute Chat',
+      cancelLabel: 'Cancel',
+      onConfirm: async () => {
+        try {
+          await chatBanUser({
+            eventId: user.event_id,
+            userId: user.user_id,
+            reason: 'Inappropriate chat behavior',
+            moderation_notes: `Chat muted by ${currentUserRole}`,
+          }).unwrap();
+          
+          notifications.show({
+            title: 'Success',
+            message: `${user.full_name} has been muted from chat`,
+            color: 'yellow',
+          });
+        } catch (error) {
+          notifications.show({
+            title: 'Error',
+            message: error.data?.message || 'Failed to mute user from chat',
+            color: 'red',
+          });
+        }
+      },
+    });
+  };
+
+  const handleChatUnban = () => {
+    openConfirmationModal({
+      title: 'Unmute User from Chat',
+      message: `Allow ${user.full_name} to send chat messages again?`,
+      confirmLabel: 'Unmute',
+      cancelLabel: 'Cancel',
+      onConfirm: async () => {
+        try {
+          await chatUnbanUser({
+            eventId: user.event_id,
+            userId: user.user_id,
+          }).unwrap();
+          
+          notifications.show({
+            title: 'Success',
+            message: `${user.full_name} can now send chat messages`,
+            color: 'green',
+          });
+        } catch (error) {
+          notifications.show({
+            title: 'Error',
+            message: error.data?.message || 'Failed to unmute user from chat',
+            color: 'red',
+          });
+        }
+      },
+    });
+  };
+
+  return {
+    handleBan,
+    handleUnban,
+    handleChatBan,
+    handleChatUnban,
+  };
+};


### PR DESCRIPTION
…ilities

- Create shared moderation utilities in /shared/utils/moderation.js for consistency
- Add getModerationPermissions() to check user moderation rights
- Add getModerationStyles() for visual indicators (red for banned, yellow for muted)
- Add createModerationHandlers() to share ban/mute logic between components
- Update AttendeeCard with full moderation menu (ban/unban, mute/unmute)
- Remove View Profile button when not connected to save mobile menu space
- Add visual moderation indicators with colored borders on cards
- Update AttendeeRow to use shared utilities for permissions and styles
- Ensure consistent moderation behavior between mobile and desktop views

