### PR TITLE
fix: improve visibility of moderation status in table rows

### DIFF
--- a/frontend/src/shared/utils/moderation.js
+++ b/frontend/src/shared/utils/moderation.js
@@ -49,19 +49,20 @@ export const getModerationStyles = (user) => {
 };
 
 /**
- * Get row styling for table (slightly different opacity)
+ * Get row styling for table (more visible while still subtle)
  */
 export const getModerationRowStyles = (user) => {
+  // Full ban takes precedence over chat ban
   if (user.is_banned) {
     return {
-      backgroundColor: '#FFFAFA',
-      borderLeft: '3px solid #FFF0F0',
+      backgroundColor: 'rgba(254, 242, 242, 0.6)',
+      borderLeft: '4px solid rgba(239, 68, 68, 0.4)',
     };
   }
-  if (user.is_chat_banned) {
+  if (user.is_chat_banned && !user.is_banned) {
     return {
-      backgroundColor: '#FFFEFA',
-      borderLeft: '3px solid #FFF8F0',
+      backgroundColor: 'rgba(254, 252, 232, 0.6)',
+      borderLeft: '4px solid rgba(251, 146, 60, 0.4)',
     };
   }
   return {};


### PR DESCRIPTION
- Increase background opacity from very light to 0.6 for better visibility
- Make border thicker (4px) and more opaque for clearer indication
- Ensure full ban styling takes precedence over chat ban with explicit check
- Keep card styling unchanged as it was already working well
- Maintain subtle design while making moderation status more noticeable at a glance

