### PR TITLE
feat: enhance SponsorModal mobile UX and tier visibility

### DIFF
--- a/frontend/src/pages/EventAdmin/SponsorsManager/DroppableTier/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/DroppableTier/index.jsx
@@ -15,8 +15,8 @@ const DroppableTier = ({ id, tier, children }) => {
     collisionPriority: CollisionPriority.Low,
   });
 
-  // Get the tier color from the first sponsor (they all have the same tier)
-  const tierColor = tier.sponsors.length > 0 ? tier.sponsors[0].tier_color : null;
+  // Get the tier color from the tier itself
+  const tierColor = tier.tier_color || (tier.sponsors.length > 0 ? tier.sponsors[0].tier_color : null);
   const badgeStyles = tierColor ? getGradientBadgeStyles(tierColor) : {};
 
   return (

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
@@ -11,8 +11,11 @@ import {
   FileButton,
   Image,
   Box,
+  Collapse,
+  Badge,
 } from '@mantine/core';
-import { IconUpload } from '@tabler/icons-react';
+import { useMediaQuery } from '@mantine/hooks';
+import { IconUpload, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { Button } from '../../../../shared/components/buttons';
 import {
@@ -26,10 +29,13 @@ import PrivateImage from '../../../../shared/components/PrivateImage';
 import styles from './styles/index.module.css';
 
 const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }) => {
+  const isMobile = useMediaQuery('(max-width: 768px)');
   const [logoFile, setLogoFile] = useState(null);
   const [logoPreview, setLogoPreview] = useState(null);
   const [existingLogoKey, setExistingLogoKey] = useState(null);
   const [errors, setErrors] = useState({});
+  const [contactExpanded, setContactExpanded] = useState(false);
+  const [socialExpanded, setSocialExpanded] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -272,9 +278,9 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         header: styles.modalHeader,
       }}
     >
-      <Stack spacing="md" p="lg">
+      <Stack spacing={isMobile ? "sm" : "md"} p={isMobile ? "md" : "lg"}>
         <Grid>
-          <Grid.Col span={8}>
+          <Grid.Col span={isMobile ? 12 : 8}>
             <TextInput
               label="Sponsor Name"
               placeholder="Enter sponsor name"
@@ -284,7 +290,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={4}>
+          <Grid.Col span={isMobile ? 12 : 4}>
             <Select
               label="Tier"
               placeholder="Select tier"
@@ -339,8 +345,8 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
             <Image
               src={logoPreview}
               alt="Logo preview"
-              width={100}
-              height={100}
+              width={isMobile ? 60 : 80}
+              height={isMobile ? 60 : 80}
               fit="contain"
               className={styles.logoPreview}
             />
@@ -348,18 +354,36 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
             <PrivateImage
               objectKey={existingLogoKey}
               alt="Current logo"
-              width={100}
-              height={100}
+              width={isMobile ? 60 : 80}
+              height={isMobile ? 60 : 80}
               fit="contain"
               className={styles.logoPreview}
             />
           ) : null}
         </Group>
 
-        <Text className={styles.sectionTitle}>Contact Information</Text>
+        {/* Contact Information Section */}
+        {isMobile ? (
+          <Badge
+            variant="light"
+            color="gray"
+            radius="sm"
+            className={styles.collapsibleHeader}
+            onClick={() => setContactExpanded(!contactExpanded)}
+            rightSection={
+              contactExpanded ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />
+            }
+            fullWidth
+          >
+            Contact Information
+          </Badge>
+        ) : (
+          <Text className={styles.sectionTitle}>Contact Information</Text>
+        )}
         
-        <Grid>
-          <Grid.Col span={4}>
+        <Collapse in={!isMobile || contactExpanded}>
+        <Grid gutter={isMobile ? "xs" : "md"}>
+          <Grid.Col span={isMobile ? 12 : 4}>
             <TextInput
               label="Contact Name"
               placeholder="John Doe"
@@ -369,7 +393,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={4}>
+          <Grid.Col span={isMobile ? 12 : 4}>
             <TextInput
               label="Contact Email"
               placeholder="contact@example.com"
@@ -379,7 +403,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={4}>
+          <Grid.Col span={isMobile ? 12 : 4}>
             <TextInput
               label="Contact Phone"
               placeholder="+1234567890"
@@ -390,11 +414,30 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
             />
           </Grid.Col>
         </Grid>
+        </Collapse>
 
-        <Text className={styles.sectionTitle}>Social Media Links</Text>
+        {/* Social Media Links Section */}
+        {isMobile ? (
+          <Badge
+            variant="light"
+            color="gray"
+            radius="sm"
+            className={styles.collapsibleHeader}
+            onClick={() => setSocialExpanded(!socialExpanded)}
+            rightSection={
+              socialExpanded ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />
+            }
+            fullWidth
+          >
+            Social Media Links
+          </Badge>
+        ) : (
+          <Text className={styles.sectionTitle}>Social Media Links</Text>
+        )}
 
-        <Grid>
-          <Grid.Col span={6}>
+        <Collapse in={!isMobile || socialExpanded}>
+        <Grid gutter={isMobile ? "xs" : "md"}>
+          <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
               label="Twitter"
               placeholder="https://twitter.com/username"
@@ -404,7 +447,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={6}>
+          <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
               label="LinkedIn"
               placeholder="https://linkedin.com/company/name"
@@ -414,7 +457,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={6}>
+          <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
               label="Facebook"
               placeholder="https://facebook.com/page"
@@ -424,7 +467,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
-          <Grid.Col span={6}>
+          <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
               label="Instagram"
               placeholder="https://instagram.com/username"
@@ -435,6 +478,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
             />
           </Grid.Col>
         </Grid>
+        </Collapse>
 
         <div className={styles.buttonGroup}>
           <Button variant="subtle" onClick={handleClose}>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/styles/index.module.css
@@ -8,20 +8,40 @@
 
 /* Modal Header */
 .modalHeader {
-  font-size: 1.25rem;
+  font-size: clamp(1.125rem, 2.5vw, 1.25rem);
   font-weight: 600;
-  color: #1e293b;
-  padding: 1.5rem;
+  color: var(--color-text-primary);
+  padding: clamp(1rem, 2.5vw, 1.5rem);
   border-bottom: 1px solid rgba(139, 92, 246, 0.04);
 }
 
 /* Section Titles */
 .sectionTitle {
-  font-size: 1.1rem;
+  font-size: clamp(1rem, 2.5vw, 1.1rem);
   font-weight: 600 !important;
-  color: #1e293b;
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  color: var(--color-text-primary);
+  margin-top: clamp(1rem, 2.5vw, 1.5rem);
+  margin-bottom: clamp(0.5rem, 1.5vw, 0.75rem);
+}
+
+/* Collapsible Header Badge */
+.collapsibleHeader {
+  cursor: pointer;
+  width: 100%;
+  padding: 0.75rem 1rem !important;
+  font-size: 0.95rem !important;
+  font-weight: 500 !important;
+  background: rgba(139, 92, 246, 0.04) !important;
+  color: var(--color-text-primary) !important;
+  border: 1px solid rgba(139, 92, 246, 0.08) !important;
+  transition: all 0.2s ease;
+  margin-top: clamp(0.75rem, 2vw, 1rem);
+  margin-bottom: 0.5rem;
+}
+
+.collapsibleHeader:hover {
+  background: rgba(139, 92, 246, 0.06) !important;
+  border-color: rgba(139, 92, 246, 0.12) !important;
 }
 
 /* Form Inputs */
@@ -59,7 +79,7 @@
 .logoSection {
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
+  gap: clamp(0.75rem, 2vw, 1rem);
 }
 
 .logoUpload {
@@ -68,15 +88,63 @@
 }
 
 .logoLabel {
-  font-size: 0.875rem;
+  font-size: clamp(0.8rem, 2vw, 0.875rem);
   font-weight: 500 !important;
-  color: #1e293b;
-  margin-bottom: 0.5rem;
+  color: var(--color-text-primary);
+  margin-bottom: clamp(0.375rem, 1vw, 0.5rem);
 }
 
 .logoPreview {
   border: 1px solid rgba(139, 92, 246, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 0.25rem;
   background: rgba(255, 255, 255, 1);
+  max-width: 80px !important;
+  max-height: 80px !important;
+}
+
+/* Responsive Styles */
+@media (max-width: 768px) {
+  .modalContent {
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+  
+  .modalHeader {
+    font-size: 1.125rem;
+    padding: 1rem;
+  }
+  
+  .sectionTitle {
+    font-size: 0.95rem;
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  .logoSection {
+    gap: 0.75rem;
+  }
+  
+  .logoPreview {
+    max-width: 60px !important;
+    max-height: 60px !important;
+  }
+  
+  .buttonGroup {
+    padding: 1rem;
+    gap: 0.5rem;
+    flex-direction: column-reverse;
+  }
+  
+  .buttonGroup button {
+    width: 100%;
+  }
+  
+  /* Compact form spacing on mobile */
+  .formInput input,
+  .formSelect input,
+  .formTextarea textarea {
+    font-size: 0.9rem;
+    padding: 0.5rem;
+  }
 }


### PR DESCRIPTION
- Fix logo preview size (80px desktop, 60px mobile) with Mantine overrides
- Add collapsible sections for Contact and Social on mobile (start closed)
- Reorganize mobile layout with full-width fields and compact spacing
- Always show all defined tiers even when empty (better tier visibility)
- Fix tier badge colors to use tier data instead of sponsor data
- Remove "No Tier" category to encourage proper tier assignment
- Add responsive modal scrolling and button layout for mobile

