### PR TITLE
feat: add session type color coding to SessionManager badges

### DIFF
--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
@@ -175,6 +175,23 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
     handleUpdate(updates);
   };
 
+  // Get the appropriate badge class based on session type
+  const getSessionTypeBadgeClass = (type) => {
+    const typeClassMap = {
+      'KEYNOTE': styles.badgeKeynote,
+      'WORKSHOP': styles.badgeWorkshop,
+      'PANEL': styles.badgePanel,
+      'PRESENTATION': styles.badgePresentation,
+      'NETWORKING': styles.badgeNetworking,
+      'QA': styles.badgeQa,
+    };
+    return typeClassMap[type] || styles.sessionTypeBadge;
+  };
+
+  const getSessionTypeLabel = (type) => {
+    return SESSION_TYPES.find(t => t.value === type)?.label || type;
+  };
+
   const handleDelete = () => {
     openConfirmationModal({
       title: 'Delete Session',
@@ -273,20 +290,25 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
 
         {/* Info Bar */}
         <Group className={styles.infoBar}>
-          <Select
-            value={sessionType}
-            onChange={(value) => {
-              setSessionType(value);
-              handleUpdate({ session_type: value });
-            }}
-            data={SESSION_TYPES}
-            size="sm"
-            style={{ width: 160 }}
-            styles={{
-              input: { cursor: 'pointer' },
-              rightSection: { pointerEvents: 'none' }
-            }}
-          />
+          <Group gap="xs" align="center">
+            <Badge className={getSessionTypeBadgeClass(sessionType)} size="sm">
+              {getSessionTypeLabel(sessionType)}
+            </Badge>
+            <Select
+              value={sessionType}
+              onChange={(value) => {
+                setSessionType(value);
+                handleUpdate({ session_type: value });
+              }}
+              data={SESSION_TYPES}
+              size="sm"
+              style={{ width: 140 }}
+              styles={{
+                input: { cursor: 'pointer' },
+                rightSection: { pointerEvents: 'none' }
+              }}
+            />
+          </Group>
           <Select
             value={chatMode}
             onChange={(value) => {

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.jsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.jsx
@@ -212,6 +212,19 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
     return SESSION_TYPES.find(t => t.value === type)?.label || type;
   };
 
+  // Get the appropriate badge class based on session type
+  const getSessionTypeBadgeClass = (type) => {
+    const typeClassMap = {
+      'KEYNOTE': styles.badgeKeynote,
+      'WORKSHOP': styles.badgeWorkshop,
+      'PANEL': styles.badgePanel,
+      'PRESENTATION': styles.badgePresentation,
+      'NETWORKING': styles.badgeNetworking,
+      'QA': styles.badgeQa,
+    };
+    return typeClassMap[type] || styles.sessionTypeBadge;
+  };
+
   return (
     <div className={`${styles.sessionCard} ${hasConflict ? styles.hasConflict : ''}`}>
       {/* Actions Menu - Top right corner */}
@@ -271,7 +284,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
 
         {/* Session Type and Conflict Badge */}
         <Group gap="xs">
-          <Badge className={styles.sessionTypeBadge} size="sm">
+          <Badge className={getSessionTypeBadgeClass(sessionType)} size="sm">
             {getSessionTypeLabel(sessionType)}
           </Badge>
           {hasConflict && (

--- a/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
@@ -392,12 +392,34 @@
   color: var(--color-text-secondary);
 }
 
-/* Session Type Badge */
+/* Session Type Badges - Compose base + type-specific styling */
 .sessionTypeBadge {
   composes: badge-base from '../../../../styles/design-tokens.css' !important;
-  background: rgba(139, 92, 246, 0.08) !important;
-  color: var(--color-primary) !important;
-  border: 1px solid rgba(139, 92, 246, 0.15) !important;
+}
+
+/* Session type specific badge classes */
+.badgeKeynote {
+  composes: badge-base badge-keynote from '../../../../styles/design-tokens.css' !important;
+}
+
+.badgeWorkshop {
+  composes: badge-base badge-workshop from '../../../../styles/design-tokens.css' !important;
+}
+
+.badgePanel {
+  composes: badge-base badge-panel from '../../../../styles/design-tokens.css' !important;
+}
+
+.badgePresentation {
+  composes: badge-base badge-presentation from '../../../../styles/design-tokens.css' !important;
+}
+
+.badgeQa {
+  composes: badge-base badge-qa from '../../../../styles/design-tokens.css' !important;
+}
+
+.badgeNetworking {
+  composes: badge-base badge-networking from '../../../../styles/design-tokens.css' !important;
 }
 
 /* Mobile Card Simplified Layout */

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -412,3 +412,48 @@
   margin-bottom: 1rem;
   line-height: 1.5;
 }
+
+/* ====================== Session Type Badges ====================== */
+/* Subtle badge styling for admin contexts using session type colors */
+
+/* Keynote - Purple (brand color) */
+.badge-keynote {
+  background: rgba(139, 92, 246, 0.08) !important;
+  color: #8b5cf6 !important;
+  border: 1px solid rgba(139, 92, 246, 0.15) !important;
+}
+
+/* Workshop - Teal */
+.badge-workshop {
+  background: rgba(20, 184, 166, 0.08) !important;
+  color: #14b8a6 !important;
+  border: 1px solid rgba(20, 184, 166, 0.15) !important;
+}
+
+/* Panel - Violet */
+.badge-panel {
+  background: rgba(168, 85, 247, 0.08) !important;
+  color: #a855f7 !important;
+  border: 1px solid rgba(168, 85, 247, 0.15) !important;
+}
+
+/* Presentation - Orange */
+.badge-presentation {
+  background: rgba(249, 115, 22, 0.08) !important;
+  color: #f97316 !important;
+  border: 1px solid rgba(249, 115, 22, 0.15) !important;
+}
+
+/* Q&A - Yellow */
+.badge-qa {
+  background: rgba(234, 179, 8, 0.08) !important;
+  color: #eab308 !important;
+  border: 1px solid rgba(234, 179, 8, 0.15) !important;
+}
+
+/* Networking - Green */
+.badge-networking {
+  background: rgba(34, 197, 94, 0.08) !important;
+  color: #22c55e !important;
+  border: 1px solid rgba(34, 197, 94, 0.15) !important;
+}


### PR DESCRIPTION
- Added session type badge classes to design-tokens.css with subtle colored backgrounds
- Created composed badge classes for each session type (Keynote, Workshop, Panel, etc.)
- Updated SessionCardMobile to use colored badges based on session type
- Updated desktop SessionCard to display colored badge alongside session type selector
- Maintains subtle admin-appropriate styling while providing visual differentiation

