### PR TITLE
feat: improve connection removal and thread filtering

### DIFF
--- a/frontend/src/shared/components/chat/ChatSidebar/index.jsx
+++ b/frontend/src/shared/components/chat/ChatSidebar/index.jsx
@@ -1,5 +1,5 @@
 // src/shared/components/chat/ChatSidebar/index.jsx
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Tabs, ActionIcon, Text, Group } from '@mantine/core';
@@ -16,7 +16,6 @@ import {
   selectCurrentEventId,
 } from '../../../../app/store/chatSlice';
 import { useGetDirectMessageThreadsQuery } from '../../../../app/features/networking/api';
-import { useGetEventUsersQuery } from '../../../../app/features/events/api';
 import { useThreadFiltering } from '@/shared/hooks/useThreadFiltering';
 import ChatThreadList from '../ChatThreadList';
 import styles from './styles/index.module.css';
@@ -39,29 +38,16 @@ function ChatSidebar() {
   // Fetch threads
   const { data, isLoading, error } = useGetDirectMessageThreadsQuery();
 
-  // Fetch event users when in event context
-  const { data: eventUsersData } = useGetEventUsersQuery(
-    { eventId: currentEventId },
-    { skip: !currentEventId }
-  );
-
   // Extract threads array from the response
   // The backend sends { threads: [...] }
   const threadsArray = data?.threads || data || [];
 
-  // Create a set of user IDs who are in the current event
-  const eventUserIds = useMemo(() => {
-    if (!eventUsersData?.event_users) return new Set();
-    console.log('Event users data:', eventUsersData);
-    // event_users have user_id field, not id
-    return new Set(eventUsersData.event_users.map(user => user.user_id));
-  }, [eventUsersData]);
-
   // Filter threads based on context using shared hook
+  // Note: Backend now includes shared_event_ids in each thread, so we don't need to fetch event users
   const filteredThreads = useThreadFiltering(
     threadsArray, 
     currentEventId, 
-    eventUserIds, 
+    new Set(), // Empty set since we use shared_event_ids from backend
     true // Enable debug logs for desktop version
   );
 

--- a/frontend/src/shared/hooks/useThreadFiltering.js
+++ b/frontend/src/shared/hooks/useThreadFiltering.js
@@ -45,7 +45,15 @@ export function useThreadFiltering(threadsArray, currentEventId, eventUserIds, e
     const filtered = threadsArray.filter((thread) => {
       const otherUserId = thread.other_user?.id;
       const isEventScopedThread = thread.event_scope_id === currentEventId;
-      const userInEvent = otherUserId && eventUserIds.has(otherUserId);
+      
+      // Use shared_event_ids if available (more efficient than checking eventUserIds)
+      let userInEvent;
+      if (thread.shared_event_ids) {
+        userInEvent = thread.shared_event_ids.includes(currentEventId);
+      } else {
+        // Fallback to old method if backend hasn't been updated
+        userInEvent = otherUserId && eventUserIds.has(otherUserId);
+      }
       
       // Show thread if:
       // 1. It's scoped to this specific event, OR
@@ -53,7 +61,7 @@ export function useThreadFiltering(threadsArray, currentEventId, eventUserIds, e
       const shouldShow = isEventScopedThread || (!thread.event_scope_id && userInEvent);
       
       if (enableDebugLogs) {
-        console.log('Event - Thread:', thread.id, 'event_scope_id:', thread.event_scope_id, 'other user:', otherUserId, 'in event:', userInEvent, 'show:', shouldShow);
+        console.log('Event - Thread:', thread.id, 'event_scope_id:', thread.event_scope_id, 'other user:', otherUserId, 'shared events:', thread.shared_event_ids, 'in event:', userInEvent, 'show:', shouldShow);
       }
       
       return shouldShow;


### PR DESCRIPTION
- Delete global threads on connection removal to reactivate event threads
- Copy messages instead of moving when merging threads (preserves context)
- Add shared_event_ids to thread response for efficient frontend filtering
- Remove dependency on fetching all event users for thread filtering
- Add transaction safety and error handling to connection removal
- Optimize shared events query using SQL intersect

This allows removed connections' event-scoped conversations to remain accessible while hiding global threads, maintaining admin messaging capabilities.

