### PR TITLE
fix: eliminate FOUC in ChatWindow ActionIcon buttons

### DIFF
--- a/frontend/src/shared/components/chat/ChatWindow/index.jsx
+++ b/frontend/src/shared/components/chat/ChatWindow/index.jsx
@@ -45,7 +45,6 @@ function ChatWindow({ threadId }) {
     threadId,
   });
 
-
   // Handle window controls
   const handleClose = () => {
     dispatch(closeThread(threadId));
@@ -82,8 +81,8 @@ function ChatWindow({ threadId }) {
         <div className={styles.header}>
           <Text size="sm">Loading...</Text>
           <Group gap="xs">
-            <ActionIcon size="xs" onClick={handleClose}>
-              <IconX size={14} />
+            <ActionIcon size="xs" className={styles.headerAction} onClick={handleClose}>
+              <IconX size={14} className={styles.headerAction} />
             </ActionIcon>
           </Group>
         </div>
@@ -110,7 +109,6 @@ function ChatWindow({ threadId }) {
           <ActionIcon
             size="xs"
             variant="subtle"
-            color="gray"
             className={styles.headerAction}
             onClick={(e) => {
               e.stopPropagation();
@@ -118,22 +116,21 @@ function ChatWindow({ threadId }) {
             }}
           >
             {isMaximized ? (
-              <IconMinimize size={14} />
+              <IconMinimize size={14} className={styles.headerAction} />
             ) : (
-              <IconMaximize size={14} />
+              <IconMaximize size={14} className={styles.headerAction} />
             )}
           </ActionIcon>
           <ActionIcon
             size="xs"
             variant="subtle"
-            color="gray"
             className={styles.headerAction}
             onClick={(e) => {
               e.stopPropagation();
               handleClose();
             }}
           >
-            <IconX size={14} />
+            <IconX size={14} className={styles.headerAction} />
           </ActionIcon>
         </Group>
       </div>
@@ -175,7 +172,7 @@ function ChatWindow({ threadId }) {
           disabled={!messageInput.trim()}
           className={styles.sendButton}
         >
-          <IconSend size={16} />
+          <IconSend size={16} className={styles.sendButton} />
         </ActionIcon>
       </div>
     </div>

--- a/frontend/src/shared/components/chat/ChatWindow/styles/index.module.css
+++ b/frontend/src/shared/components/chat/ChatWindow/styles/index.module.css
@@ -10,7 +10,7 @@
   -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.9);
   border-radius: 8px 8px 0 0;
-  box-shadow: 
+  box-shadow:
     0 -2px 8px rgba(139, 92, 246, 0.03),
     0 2px 12px rgba(0, 0, 0, 0.08),
     0 1px 3px rgba(0, 0, 0, 0.04);
@@ -23,7 +23,7 @@
 .maximized {
   width: 400px;
   height: 500px;
-  box-shadow: 
+  box-shadow:
     0 -4px 16px rgba(139, 92, 246, 0.06),
     0 4px 24px rgba(0, 0, 0, 0.1),
     0 2px 6px rgba(0, 0, 0, 0.05);
@@ -44,7 +44,9 @@
 
 /* Header action buttons */
 .headerAction {
-  transition: all 0.2s ease;
+  color: #64748b !important;
+  background: transparent !important;
+  transition: all 0.2s ease !important;
 }
 
 .headerAction:hover {
@@ -54,6 +56,7 @@
 
 /* Send button styling */
 .sendButton {
+  color: #64748b;
   transition: all 0.2s ease;
 }
 


### PR DESCRIPTION
Apply CSS to loading state icons so we do not get a FOUC while waiting for chat messages to load.
