### PR TITLE
feat: standardize form input styling across application

### DIFF
--- a/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/styles.module.css
@@ -11,19 +11,18 @@
   margin-bottom: 0.25rem;
 }
 
-/* Form Input Styling */
+/* Form inputs within modals - Subtle and clean */
 .formInput {
-  background: rgba(255, 255, 255, 0.8) !important;
-  border: 1px solid var(--primary-alpha-10) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   font-size: clamp(0.875rem, 2vw, 0.95rem) !important;
   min-height: 44px !important; /* Touch-friendly size */
 }
 
 .formInput:focus {
-  border-color: var(--color-primary) !important;
-  background: rgba(255, 255, 255, 0.95) !important;
-  box-shadow: 0 0 0 3px var(--primary-alpha-10) !important;
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Select Dropdown Styling */

--- a/frontend/src/pages/EventAdmin/EventSettings/BrandingSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/BrandingSection/styles.module.css
@@ -21,33 +21,31 @@
   margin-top: 0.25rem;
 }
 
-/* Form Input Styling */
+/* Form inputs within modals - Subtle and clean */
 .formInput {
-  background: rgba(255, 255, 255, 0.8) !important;
-  border: 1px solid var(--primary-alpha-10) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   font-size: clamp(0.875rem, 2vw, 0.95rem) !important;
   min-height: 44px !important;
 }
 
 .formInput:focus {
-  border-color: var(--color-primary) !important;
-  background: rgba(255, 255, 255, 0.95) !important;
-  box-shadow: 0 0 0 3px var(--primary-alpha-10) !important;
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Color Input Styling */
 .colorInput {
-  background: rgba(255, 255, 255, 0.8) !important;
-  border: 1px solid var(--primary-alpha-10) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   min-height: 44px !important;
 }
 
 .colorInput:focus {
-  border-color: var(--color-primary) !important;
-  background: rgba(255, 255, 255, 0.95) !important;
-  box-shadow: 0 0 0 3px var(--primary-alpha-10) !important;
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Subsection Title */

--- a/frontend/src/pages/EventAdmin/EventSettings/ContentSections/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/ContentSections/styles.module.css
@@ -20,12 +20,12 @@
   border: 1px solid var(--primary-alpha-4);
 }
 
-/* Form inputs */
+/* Form inputs within modals - Subtle and clean */
 .formInput,
 .formTextarea,
 .formSelect {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid var(--primary-alpha-10);
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
@@ -33,9 +33,8 @@
 .formInput:focus,
 .formTextarea:focus,
 .formSelect:focus {
-  border-color: var(--color-primary);
-  background: rgba(255, 255, 255, 1);
-  box-shadow: 0 0 0 2px var(--primary-alpha-10);
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Divider */

--- a/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/NetworkingSection/styles.module.css
@@ -293,18 +293,17 @@
   border-bottom: 1px solid var(--primary-alpha-4);
 }
 
-/* Form inputs in modal */
+/* Form inputs within modals - Subtle and clean */
 .formTextarea {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid var(--primary-alpha-10);
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
 
 .formTextarea:focus {
-  border-color: var(--color-primary);
-  background: rgba(255, 255, 255, 1);
-  box-shadow: 0 0 0 2px var(--primary-alpha-10);
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Helper text */

--- a/frontend/src/pages/EventAdmin/EventSettings/VenueSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/VenueSection/styles.module.css
@@ -11,19 +11,18 @@
   margin-bottom: 0.25rem;
 }
 
-/* Form Input Styling */
+/* Form inputs within modals - Subtle and clean */
 .formInput {
-  background: rgba(255, 255, 255, 0.8) !important;
-  border: 1px solid var(--primary-alpha-10) !important;
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
   font-size: clamp(0.875rem, 2vw, 0.95rem) !important;
   min-height: 44px !important; /* Touch-friendly size */
 }
 
 .formInput:focus {
-  border-color: var(--color-primary) !important;
-  background: rgba(255, 255, 255, 0.95) !important;
-  box-shadow: 0 0 0 3px var(--primary-alpha-10) !important;
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Privacy Section */

--- a/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomModal/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomModal/styles/index.module.css
@@ -17,20 +17,20 @@
   border-bottom: 1px solid rgba(139, 92, 246, 0.04);
 }
 
-/* Form Inputs */
-.formInput input,
-.formSelect input,
-.formTextarea textarea {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(139, 92, 246, 0.1);
+/* Form inputs within modals - Subtle and clean */
+.formInput,
+.formSelect,
+.formTextarea {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
 }
 
-.formInput input:focus,
-.formSelect input:focus,
-.formTextarea textarea:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
+.formInput:focus,
+.formSelect:focus,
+.formTextarea:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Form Labels */

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.jsx
@@ -259,7 +259,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
             value={startTime}
             onChange={(value) => handleTimeChange('start_time', value)}
             placeholder="Start time"
-            classNames={{ input: styles.timeInput }}
+            classNames={{ input: styles.formTimeInput }}
             error={errors.start_time}
           />
           <Text size="sm" c="dimmed">to</Text>
@@ -267,13 +267,16 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
             value={endTime}
             onChange={(value) => handleTimeChange('end_time', value)}
             placeholder="End time"
-            classNames={{ input: styles.timeInput }}
+            classNames={{ input: styles.formTimeInput }}
             error={errors.end_time || errors.time_order}
           />
         </Group>
         
         {/* Pills - pushed to the right */}
         <Group ml="auto" gap="sm">
+          <Badge className={getSessionTypeBadgeClass(sessionType)} size="sm">
+            {getSessionTypeLabel(sessionType)}
+          </Badge>
           <Badge className={styles.durationPill} size="sm">
             {calculateDuration(startTime, endTime)}
           </Badge>
@@ -291,9 +294,6 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
         {/* Info Bar */}
         <Group className={styles.infoBar}>
           <Group gap="xs" align="center">
-            <Badge className={getSessionTypeBadgeClass(sessionType)} size="sm">
-              {getSessionTypeLabel(sessionType)}
-            </Badge>
             <Select
               value={sessionType}
               onChange={(value) => {
@@ -303,10 +303,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
               data={SESSION_TYPES}
               size="sm"
               style={{ width: 140 }}
-              styles={{
-                input: { cursor: 'pointer' },
-                rightSection: { pointerEvents: 'none' }
-              }}
+              classNames={{ input: styles.formSelect }}
             />
           </Group>
           <Select
@@ -318,10 +315,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
             data={CHAT_MODES}
             size="sm"
             style={{ width: 160 }}
-            styles={{
-              input: { cursor: 'pointer' },
-              rightSection: { pointerEvents: 'none' }
-            }}
+            classNames={{ input: styles.formSelect }}
           />
           <TextInput
             placeholder="Stream URL (e.g., Vimeo URL)"
@@ -330,6 +324,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
             value={streamUrl}
             onChange={(e) => setStreamUrl(e.target.value)}
             error={errors.stream_url}
+            classNames={{ input: styles.formInput }}
           />
         </Group>
 
@@ -353,6 +348,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
           maxRows={3}
           size="sm"
           error={errors.short_description}
+          classNames={{ input: styles.formTextarea }}
         />
 
         {/* Full Description */}
@@ -363,6 +359,7 @@ export const SessionCard = ({ session, eventId, hasConflict }) => {
           autosize
           minRows={2}
           maxRows={6}
+          classNames={{ input: styles.formTextarea }}
           className={styles.descriptionTextarea}
         />
       </div>

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.jsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.jsx
@@ -323,6 +323,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
                 label="Start Time"
                 error={errors.start_time}
                 size="sm"
+                classNames={{ input: styles.formTimeInput }}
               />
               <TimeSelect
                 value={endTime}
@@ -331,6 +332,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
                 label="End Time"
                 error={errors.end_time || errors.time_order}
                 size="sm"
+                classNames={{ input: styles.formTimeInput }}
               />
             </Group>
 
@@ -344,6 +346,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
               }}
               data={SESSION_TYPES}
               size="sm"
+              classNames={{ input: styles.formSelect }}
             />
 
             {/* Chat Mode */}
@@ -356,6 +359,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
               }}
               data={CHAT_MODES}
               size="sm"
+              classNames={{ input: styles.formSelect }}
             />
 
             {/* Stream URL */}
@@ -366,6 +370,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
               value={streamUrl}
               onChange={(e) => setStreamUrl(e.target.value)}
               error={errors.stream_url}
+              classNames={{ input: styles.formInput }}
             />
 
             {/* Speakers */}
@@ -389,6 +394,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
               maxRows={3}
               size="sm"
               error={errors.short_description}
+              classNames={{ input: styles.formTextarea }}
             />
 
             {/* Full Description */}
@@ -401,6 +407,7 @@ export const SessionCardMobile = ({ session, eventId, hasConflict }) => {
               minRows={3}
               maxRows={6}
               size="sm"
+              classNames={{ input: styles.formTextarea }}
             />
           </Stack>
         </div>

--- a/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
@@ -329,6 +329,24 @@
   min-height: 60px;
 }
 
+/* Form inputs within modals - Subtle and clean */
+.formInput,
+.formSelect,
+.formTextarea,
+.formTimeInput {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
+  transition: all 0.2s ease;
+}
+
+.formInput:focus,
+.formSelect:focus,
+.formTextarea:focus,
+.formTimeInput:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
+}
+
 .actions {
   margin-top: var(--mantine-spacing-sm);
   padding-top: var(--mantine-spacing-sm);

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/styles/index.module.css
@@ -44,20 +44,20 @@
   border-color: rgba(139, 92, 246, 0.12) !important;
 }
 
-/* Form Inputs */
-.formInput input,
-.formSelect input,
-.formTextarea textarea {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(139, 92, 246, 0.1);
+/* Form inputs within modals - Subtle and clean */
+.formInput,
+.formSelect,
+.formTextarea {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
 }
 
-.formInput input:focus,
-.formSelect input:focus,
-.formTextarea textarea:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
+.formInput:focus,
+.formSelect:focus,
+.formTextarea:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Button Group at Modal Bottom */
@@ -141,10 +141,10 @@
   }
   
   /* Compact form spacing on mobile */
-  .formInput input,
-  .formSelect input,
-  .formTextarea textarea {
-    font-size: 0.9rem;
-    padding: 0.5rem;
+  .formInput,
+  .formSelect,
+  .formTextarea {
+    font-size: 0.9rem !important;
+    padding: 0.5rem !important;
   }
 }

--- a/frontend/src/pages/EventAdmin/SponsorsManager/TierManagementModal/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/TierManagementModal/styles/index.module.css
@@ -15,16 +15,16 @@
   border-bottom: 1px solid rgba(139, 92, 246, 0.04);
 }
 
-/* Form Inputs */
-.formInput input {
-  background: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(139, 92, 246, 0.1);
+/* Form inputs within modals - Subtle and clean */
+.formInput {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
 }
 
-.formInput input:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
+.formInput:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Order text styling */

--- a/frontend/src/pages/Networking/ChatArea/MessageInput/index.jsx
+++ b/frontend/src/pages/Networking/ChatArea/MessageInput/index.jsx
@@ -1,6 +1,6 @@
 import { TextInput, ActionIcon, Text } from '@mantine/core';
 import { IconSend, IconVolumeOff } from '@tabler/icons-react';
-import styles from '../styles/index.module.css';
+import styles from './styles/index.module.css';
 
 export function MessageInput({ roomName, value, onChange, onSend, canSendMessages = true, muteReason }) {
   const handleKeyDown = (e) => {
@@ -41,11 +41,15 @@ export function MessageInput({ roomName, value, onChange, onSend, canSendMessage
             onClick={onSend}
             disabled={!value?.trim()}
             size="lg"
+            className={styles.sendButton}
+            radius="xl"
+            variant="light"
           >
             <IconSend size={18} />
           </ActionIcon>
         }
         className={styles.input}
+        classNames={{ input: styles.input }}
       />
     </div>
   );

--- a/frontend/src/pages/Networking/ChatArea/MessageInput/styles/index.module.css
+++ b/frontend/src/pages/Networking/ChatArea/MessageInput/styles/index.module.css
@@ -1,13 +1,51 @@
 .inputArea {
-  padding: var(--mantine-spacing-md);
-  border-top: 1px solid var(--mantine-color-gray-3);
-  background-color: var(--mantine-color-white);
-  flex-shrink: 0;
-  min-height: 60px; /* Slightly taller for better proportion */
+  padding: 12px;
+  border-top: 1px solid rgba(139, 92, 246, 0.06);
   display: flex;
   align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.5);
+  flex-shrink: 0;
+  min-height: 60px;
 }
 
 .input {
-  width: 100%;
+  flex: 1;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
+  border-radius: 20px !important;
+  padding: 8px 12px !important;
+  font-size: 14px !important;
+  background: rgba(255, 255, 255, 0.7) !important;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  transition: all 0.2s ease;
+}
+
+.input input {
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+}
+
+.input:focus-within {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
+  box-shadow: none !important;
+}
+
+.sendButton {
+  background: rgba(139, 92, 246, 0.1) !important;
+  color: #8b5cf6 !important;
+  transition: all 0.2s ease;
+}
+
+.sendButton:hover:not(:disabled) {
+  background: #8b5cf6 !important;
+  color: white !important;
+  transform: translateY(-1px);
+}
+
+.sendButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }

--- a/frontend/src/pages/Profile/AboutSection/index.jsx
+++ b/frontend/src/pages/Profile/AboutSection/index.jsx
@@ -14,12 +14,7 @@ export const AboutSection = ({ bio, isEditing, value, onChange }) => {
           maxRows={10}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          styles={{
-            input: {
-              backgroundColor: 'rgba(255, 255, 255, 0.8)',
-              border: '1px solid rgba(139, 92, 246, 0.1)',
-            }
-          }}
+          classNames={{ input: styles.formTextarea }}
         />
       ) : (
         <p className={styles.bioText}>

--- a/frontend/src/pages/Profile/AboutSection/styles/index.module.css
+++ b/frontend/src/pages/Profile/AboutSection/styles/index.module.css
@@ -13,3 +13,15 @@
   font-size: clamp(var(--text-sm), 2vw, 0.95rem);
   white-space: pre-wrap;
 }
+
+/* Form inputs within modals - Subtle and clean */
+.formTextarea {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
+  transition: all 0.2s ease;
+}
+
+.formTextarea:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
+}

--- a/frontend/src/pages/Profile/index.jsx
+++ b/frontend/src/pages/Profile/index.jsx
@@ -312,11 +312,13 @@ export const ProfilePage = () => {
                       label="First Name"
                       {...form.getInputProps('first_name')}
                       required
+                      classNames={{ input: styles.formInput }}
                     />
                     <TextInput
                       label="Last Name"
                       {...form.getInputProps('last_name')}
                       required
+                      classNames={{ input: styles.formInput }}
                     />
                   </Group>
                   <TextInput
@@ -324,16 +326,19 @@ export const ProfilePage = () => {
                     value={userProfile?.email}
                     disabled
                     description="Email cannot be changed"
+                    classNames={{ input: styles.formInput }}
                   />
                   <TextInput
                     label="Job Title"
                     placeholder="e.g., Software Engineer"
                     {...form.getInputProps('title')}
+                    classNames={{ input: styles.formInput }}
                   />
                   <TextInput
                     label="Company"
                     placeholder="e.g., Acme Corp"
                     {...form.getInputProps('company_name')}
+                    classNames={{ input: styles.formInput }}
                   />
                 </Stack>
               </form>
@@ -351,16 +356,19 @@ export const ProfilePage = () => {
                   label="LinkedIn"
                   placeholder="https://linkedin.com/in/username"
                   {...form.getInputProps('social_links.linkedin')}
+                  classNames={{ input: styles.formInput }}
                 />
                 <TextInput
                   label="Twitter"
                   placeholder="https://twitter.com/username"
                   {...form.getInputProps('social_links.twitter')}
+                  classNames={{ input: styles.formInput }}
                 />
                 <TextInput
                   label="Website"
                   placeholder="https://example.com"
                   {...form.getInputProps('social_links.website')}
+                  classNames={{ input: styles.formInput }}
                 />
               </Stack>
             </section>

--- a/frontend/src/pages/Profile/styles/index.module.css
+++ b/frontend/src/pages/Profile/styles/index.module.css
@@ -90,6 +90,18 @@
   width: 100%;
 }
 
+/* Form inputs within modals - Subtle and clean */
+.formInput {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
+  transition: all 0.2s ease;
+}
+
+.formInput:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
+}
+
 .editButtonGroup {
   display: flex;
   gap: var(--space-md);

--- a/frontend/src/shared/components/modals/session/EditSessionModal/styles/index.module.css
+++ b/frontend/src/shared/components/modals/session/EditSessionModal/styles/index.module.css
@@ -34,25 +34,24 @@
   margin-top: 0;
 }
 
-/* Form Inputs */
-.formInput input,
-.formSelect input,
-.formTextarea textarea,
-.shortDescriptionTextarea textarea,
-.formTimeInput input {
-  background: rgba(255, 255, 255, 0.5);
-  border: 1px solid rgba(139, 92, 246, 0.1);
+/* Form inputs within modals - Subtle and clean */
+.formInput,
+.formSelect,
+.formTextarea,
+.shortDescriptionTextarea,
+.formTimeInput {
+  background: rgba(255, 255, 255, 1) !important;
+  border: 1px solid rgba(139, 92, 246, 0.1) !important;
   transition: all 0.2s ease;
 }
 
-.formInput input:focus,
-.formSelect input:focus,
-.formTextarea textarea:focus,
-.shortDescriptionTextarea textarea:focus,
-.formTimeInput input:focus {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: rgba(255, 255, 255, 1);
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.05);
+.formInput:focus,
+.formSelect:focus,
+.formTextarea:focus,
+.shortDescriptionTextarea:focus,
+.formTimeInput:focus {
+  border-color: rgba(139, 92, 246, 0.3) !important;
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 /* Short description textarea - compact size */

--- a/frontend/src/styles/style-guide.md
+++ b/frontend/src/styles/style-guide.md
@@ -936,6 +936,44 @@ import { Button } from 'shared/components/buttons/Button';
 </Button>
 ```
 
+### Form Input Styling
+
+Our form inputs use a subtle, clean approach that maintains readability while fitting our overall aesthetic:
+
+```css
+/* Form Elements - Subtle and Clean */
+.formInput input,
+.formSelect input,
+.formTextarea textarea {
+  background: rgba(255, 255, 255, 1);
+  border: 1px solid rgba(139, 92, 246, 0.1);
+  transition: all 0.2s ease;
+}
+
+.formInput input:focus,
+.formSelect input:focus,
+.formTextarea textarea:focus {
+  border-color: rgba(139, 92, 246, 0.3);
+  background: rgba(255, 255, 255, 1);
+}
+```
+
+**⚠️ Important Implementation Note:**
+When applying these styles, check how your form library applies classes:
+- **Mantine forms**: Classes are applied directly to inputs via `classNames={{ input: styles.formInput }}`, so use `.formInput` (not `.formInput input`)
+- **Basic HTML forms**: If wrapping inputs in divs with classes, use `.formInput input`
+- **Always verify**: Check the rendered HTML to ensure your selectors match the actual DOM structure
+- **Use `!important`** when overriding Mantine defaults to ensure styles take precedence
+
+**Key Design Decisions:**
+- **Solid white background** instead of transparency for better readability and contrast
+- **Very subtle purple border** (0.1 opacity) for a clean, minimal look
+- **Gentle focus state** (0.3 opacity border) without shadow for minimal visual distraction
+- **Smooth transitions** for polished interactions
+- **No focus ring/shadow** to maintain the subtle aesthetic
+
+This approach provides just enough visual feedback without overwhelming the interface, keeping focus on the content rather than the form elements themselves.
+
 ### Glass Effect Pattern
 ```css
 .glassElement {


### PR DESCRIPTION
- Apply consistent subtle purple border design to all form inputs
- Update modal forms to use solid white backgrounds with rgba(139, 92, 246, 0.1) borders
- Enhance focus states with darker purple (0.3 opacity) without shadow effects
- Update ChatArea message input to match DM chat styling with rounded design
- Add purple-themed send button with hover effects
- Update style guide with implementation notes for Mantine form components
- Reposition session type badge in SessionCard desktop layout for better visual hierarchy

Components updated:
- EventSettings (all sections: BasicInfo, Branding, Venue, Networking, Content)
- SessionManager (SessionCard, SessionCardMobile)
- SponsorsManager (SponsorModal, TierManagementModal)
- NetworkingManager (ChatRoomModal)
- Profile sections with edit forms
- EditSessionModal
- ChatArea MessageInput

