### PR TITLE
refactor: update ChatArea and notification badge styling

### DIFF
--- a/frontend/src/pages/Networking/ChatArea/MessageInput/index.jsx
+++ b/frontend/src/pages/Networking/ChatArea/MessageInput/index.jsx
@@ -42,7 +42,7 @@ export function MessageInput({ roomName, value, onChange, onSend, canSendMessage
             disabled={!value?.trim()}
             size="lg"
             className={styles.sendButton}
-            radius="xl"
+            radius="sm"
             variant="light"
           >
             <IconSend size={18} />

--- a/frontend/src/pages/Networking/ChatArea/MessageInput/styles/index.module.css
+++ b/frontend/src/pages/Networking/ChatArea/MessageInput/styles/index.module.css
@@ -1,19 +1,17 @@
 .inputArea {
-  padding: 12px;
+  padding: 8px 12px;
   border-top: 1px solid rgba(139, 92, 246, 0.06);
   display: flex;
   align-items: center;
   gap: 8px;
   background: rgba(255, 255, 255, 0.5);
   flex-shrink: 0;
-  min-height: 60px;
 }
 
 .input {
   flex: 1;
   border: 1px solid rgba(139, 92, 246, 0.1) !important;
-  border-radius: 20px !important;
-  padding: 8px 12px !important;
+  border-radius: 6px !important;
   font-size: 14px !important;
   background: rgba(255, 255, 255, 0.7) !important;
   backdrop-filter: blur(5px);
@@ -24,7 +22,7 @@
 .input input {
   background: transparent !important;
   border: none !important;
-  padding: 0 !important;
+  padding: 8px 12px !important;
 }
 
 .input:focus-within {

--- a/frontend/src/pages/Networking/styles/index.module.css
+++ b/frontend/src/pages/Networking/styles/index.module.css
@@ -205,9 +205,18 @@
   min-height: 0;
 }
 
-/* Custom Badge */
+/* Custom Badge - Purple with 0.8 opacity and yellow text */
 .customBadge {
   margin-left: 0.5rem;
+  background: rgba(139, 92, 246, 0.8) !important; /* 0.8 opacity */
+  color: #FFD666 !important; /* Yellow from logo */
+  border: none !important; /* No border */
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace !important;
+  font-weight: 600 !important;
+  height: 22px !important;
+  min-width: 22px !important;
+  padding: 0 8px !important;
+  font-size: 12px !important;
 }
 
 /* Chat Wrapper - Forces proper height */


### PR DESCRIPTION
- Revert ChatArea message input to rounded-square design (6px radius)
- Use subtle borders and compact vertical padding for input area
- Update send button to use small radius for cohesive rectangular shape
- Style notification badge with purple (0.8 opacity) and yellow text (#FFD666)
- Use monospace font for clear number display in badge
- Remove badge border for cleaner appearance

