### PR TITLE
fix: transform MinIO presigned URLs to use external endpoint for brow…

### DIFF
--- a/backend/atria/api/services/storage.py
+++ b/backend/atria/api/services/storage.py
@@ -303,6 +303,25 @@ class StorageService:
                 object_name,
                 expires=expires
             )
+            
+            # Replace internal URL with external URL for browser access
+            if self.external_url:
+                # Parse the internal URL to preserve the path and query parameters
+                from urllib.parse import urlparse, urlunparse
+                parsed = urlparse(url)
+                external_parsed = urlparse(self.external_url)
+                
+                # Replace scheme, netloc with external values, keep path and params
+                external_url = urlunparse((
+                    external_parsed.scheme,
+                    external_parsed.netloc,
+                    parsed.path,
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment
+                ))
+                return external_url
+            
             return url
         except S3Error as e:
             raise Exception(f"Failed to generate URL: {str(e)}")


### PR DESCRIPTION
…ser access

- Keep using internal endpoint (minio-api.infrastructure.svc.cluster.local) for MinIO operations
- Transform generated presigned URLs to use external endpoint (storage.sbtl.dev) for browser access
- Preserves all query parameters including signatures and expiration
- Fixes issue where browsers couldn't access presigned URLs with internal cluster hostnames

