### PR TITLE
fix: enforce tier requirements for sponsors and improve UI feedback

### DIFF
--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
@@ -179,7 +179,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         contact_name: formData.contactName || null,
         contact_email: formData.contactEmail || null,
         contact_phone: formData.contactPhone || null,
-        tier_id: formData.tierId || null,
+        tier_id: formData.tierId, // Required field, no null fallback
         social_links: formData.socialLinks,
         ...(logoUrl && { logo_url: logoUrl }),
       };
@@ -294,13 +294,13 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
             <Select
               label="Tier"
               placeholder="Select tier"
+              required
               data={sponsorTiers.map(tier => ({
                 value: tier.id,
                 label: tier.name,
               }))}
               value={formData.tierId}
               onChange={(value) => handleFieldChange('tierId', value)}
-              clearable
               error={errors.tierId}
               classNames={{ input: styles.formSelect }}
             />

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsHeader/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsHeader/index.jsx
@@ -12,9 +12,14 @@ const SponsorsHeader = ({
   onTierManageClick
 }) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
-  // Count sponsors by tier and collect tier colors
+  // Count sponsors by tier and collect tier colors (exclude sponsors without tiers)
   const tierCounts = sponsors.reduce((acc, sponsor) => {
-    const tierName = sponsor.tier_name || 'No Tier';
+    // Skip sponsors without a tier
+    if (!sponsor.tier_id) {
+      return acc;
+    }
+    
+    const tierName = sponsor.tier_name;
     const tierId = sponsor.tier_id;
     const tierColor = sponsor.tier_color; // This comes from the sponsor's computed property
     

--- a/frontend/src/pages/EventAdmin/SponsorsManager/schemas/sponsorSchema.js
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/schemas/sponsorSchema.js
@@ -20,7 +20,7 @@ export const sponsorFieldSchemas = {
     .or(z.literal('')),
   
   // Sponsorship details
-  tier_id: z.string().optional(),
+  tier_id: z.string().min(1, 'Tier selection is required'),
   
   // Social links
   social_links: z.object({

--- a/frontend/src/pages/Sponsors/SponsorsList/index.jsx
+++ b/frontend/src/pages/Sponsors/SponsorsList/index.jsx
@@ -3,28 +3,24 @@ import SponsorCard from '@/shared/components/SponsorCard';
 import styles from './styles/index.module.css';
 
 export default function SponsorsList({ sponsors, tiers }) {
-  // Group sponsors by tier (handle snake_case from API)
-  const sponsorsByTier = sponsors.reduce((acc, sponsor) => {
-    const tierId = sponsor.tier_id || 'other';
-    if (!acc[tierId]) {
-      acc[tierId] = [];
-    }
-    acc[tierId].push(sponsor);
-    return acc;
-  }, {});
+  // Filter out sponsors without tiers and group by tier
+  const sponsorsByTier = sponsors
+    .filter(sponsor => sponsor.tier_id) // Only include sponsors with tiers
+    .reduce((acc, sponsor) => {
+      const tierId = sponsor.tier_id;
+      if (!acc[tierId]) {
+        acc[tierId] = [];
+      }
+      acc[tierId].push(sponsor);
+      return acc;
+    }, {});
 
   // Sort tiers by order (create a copy first to avoid mutating read-only array)
   const sortedTiers = [...tiers].sort((a, b) => a.order - b.order);
 
-  // Add "Other" tier at the end if there are sponsors without a tier
-  const tiersToDisplay = [
-    ...sortedTiers,
-    ...(sponsorsByTier.other ? [{ id: 'other', name: 'Other Sponsors', order: 999 }] : [])
-  ];
-
   return (
     <div className={styles.container}>
-      {tiersToDisplay.map((tier) => {
+      {sortedTiers.map((tier) => {
         const tiersSponsors = sponsorsByTier[tier.id];
         if (!tiersSponsors || tiersSponsors.length === 0) return null;
 

--- a/frontend/src/shared/components/buttons/Button.jsx
+++ b/frontend/src/shared/components/buttons/Button.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ButtonLoader } from '../loading';
 import styles from './Button.module.css';
 
 export const Button = ({ 
@@ -7,6 +8,7 @@ export const Button = ({
   onClick, 
   type = 'button',
   disabled = false,
+  loading = false,
   className = '',
   ...props 
 }) => {
@@ -16,11 +18,18 @@ export const Button = ({
     <button
       type={type}
       onClick={onClick}
-      disabled={disabled}
+      disabled={disabled || loading}
       className={buttonClass}
       {...props}
     >
-      {children}
+      {loading ? (
+        <>
+          <ButtonLoader />
+          <span style={{ marginLeft: '8px' }}>{children}</span>
+        </>
+      ) : (
+        children
+      )}
     </button>
   );
 };


### PR DESCRIPTION
- Made tier selection required in sponsor creation/edit modal
- Added loading spinner to Button component for async operations
- Removed "Other Sponsors" section from public sponsors page
- Fixed sponsors management header to exclude sponsors without tiers
- Prevent creation of sponsors without tier assignment
- Added disabled state to button during loading to prevent double-clicks

