### PR TITLE
fix: increase mobile EventNav background opacity for better readability

### DIFF
--- a/frontend/src/pages/Navigation/EventNav/EventNav.module.css
+++ b/frontend/src/pages/Navigation/EventNav/EventNav.module.css
@@ -72,6 +72,13 @@
   text-decoration: none;
 }
 
+/* Mobile - when navbar covers full page (Mantine sm breakpoint) */
+@media (max-width: 768px) {
+  .navWrapper {
+    background: rgba(251, 250, 255, 0.8); /* Increased opacity for mobile full-page coverage */
+  }
+}
+
 /* Responsive adjustments for EventNav */
 @media (max-width: 480px) {
   .container {


### PR DESCRIPTION
- Increased background opacity from 0.1 to 0.8 on mobile (≤768px)
- Provides better contrast when nav drawer slides over page content
- Desktop retains subtle 0.1 opacity for glass effect
- Improves mobile UX by making navigation more prominent when open

