### PR TITLE
perf: fix third N+1 query in privacy filtering

### DIFF
--- a/backend/atria/api/services/event_user.py
+++ b/backend/atria/api/services/event_user.py
@@ -123,7 +123,10 @@ class EventUserService:
             
             # Get privacy context without re-fetching users
             context = PrivacyService.get_viewer_context(user, viewer, event_id)
-            user_data = PrivacyService.filter_user_data(user, context, event_id)
+            
+            # Pass the event_user object to avoid another query for privacy overrides
+            # We'll need to modify filter_user_data to accept this
+            user_data = PrivacyService.filter_user_data(user, context, event_id, event_user)
             
             # Store the filtered email as a custom attribute (not a model property)
             # The schema will pick this up during serialization

--- a/backend/atria/api/services/privacy.py
+++ b/backend/atria/api/services/privacy.py
@@ -140,7 +140,7 @@ class PrivacyService:
         return result
     
     @staticmethod
-    def filter_user_data(user: User, context: Dict[str, Any], event_id: Optional[int] = None) -> Dict[str, Any]:
+    def filter_user_data(user: User, context: Dict[str, Any], event_id: Optional[int] = None, event_user=None) -> Dict[str, Any]:
         """
         Apply privacy rules to user data based on viewer context.
         
@@ -148,6 +148,7 @@ class PrivacyService:
             user: The user whose data is being filtered
             context: Viewer context from get_viewer_context()
             event_id: Optional event ID for event-specific privacy overrides
+            event_user: Optional pre-loaded EventUser to avoid extra query
             
         Returns:
             Filtered user data dictionary with appropriate fields
@@ -166,10 +167,12 @@ class PrivacyService:
         
         # Check for event-specific overrides
         if event_id:
-            event_user = EventUser.query.filter_by(
-                event_id=event_id,
-                user_id=user.id
-            ).first()
+            # Use pre-loaded event_user if provided, otherwise query
+            if not event_user:
+                event_user = EventUser.query.filter_by(
+                    event_id=event_id,
+                    user_id=user.id
+                ).first()
             
             if event_user and event_user.privacy_overrides:
                 # Merge event overrides with global settings


### PR DESCRIPTION
- Pass pre-loaded EventUser to privacy filter to avoid extra queries
- Eliminates 50+ database queries for privacy overrides
- Should significantly improve response time

