### PR TITLE
fix: center attendees loading spinner vertically

### DIFF
--- a/frontend/src/pages/Networking/AttendeesGrid/styles/index.module.css
+++ b/frontend/src/pages/Networking/AttendeesGrid/styles/index.module.css
@@ -103,6 +103,7 @@
   align-items: center;
   justify-content: center;
   color: #64748B;
+  min-height: 400px;
 }
 
 /* Empty state */


### PR DESCRIPTION
Added min-height to loader class to properly center the loading spinner in the attendees grid view instead of having it pressed against the tabs

