### PR TITLE
fix: add explicit dimensions to SponsorCard images for Firefox compat…

### DIFF
--- a/frontend/src/shared/components/SponsorCard/index.jsx
+++ b/frontend/src/shared/components/SponsorCard/index.jsx
@@ -55,6 +55,8 @@ export const SponsorCard = ({ sponsor }) => {
           <PrivateImage 
             objectKey={logo_url} 
             alt={`${name} logo`}
+            width={100}
+            height={100}
             fit="contain"
             className={styles.logo}
             placeholder={


### PR DESCRIPTION
…ibility

Firefox requires explicit width/height props on images for proper rendering. Added width={100} and height={100} to PrivateImage component in public SponsorCard to match the working implementation in admin SponsorCard.

