### PR TITLE
fix: add missing user_id argument to get_recent_messages in socket ha…

### DIFF
--- a/backend/atria/api/api/sockets/chat.py
+++ b/backend/atria/api/api/sockets/chat.py
@@ -33,7 +33,7 @@ def handle_join_chat_room(user_id, data):
     join_room(f"room_{room_id}")
 
     # Get recent messages
-    messages = ChatRoomService.get_recent_messages(room_id)
+    messages = ChatRoomService.get_recent_messages(room_id, user_id)
 
     emit(
         "chat_room_joined",


### PR DESCRIPTION
…ndler

The socket handler for join_chat_room was missing the required user_id parameter when calling ChatRoomService.get_recent_messages(), causing TypeErrors in the backend.

