### PR TITLE
fix: suppress privacy filtering warning for self-viewing in pending c…

### DIFF
--- a/backend/atria/api/services/connection.py
+++ b/backend/atria/api/services/connection.py
@@ -505,6 +505,7 @@ class ConnectionService:
     def _apply_user_privacy_filtering_with_event(connection, user_attr, viewer, event_id):
         """Apply privacy filtering to a user in a connection WITH EVENT CONTEXT"""
         from api.services.privacy import PrivacyService
+        import logging
         
         # Get the user object from the connection
         user = getattr(connection, user_attr)


### PR DESCRIPTION
…onnections

- Updated ConnectionSchema to only warn when privacy filtering is missing in unexpected cases
- Recipient field in /connections/pending is always the current user (verified in code)
- Added check to detect self-viewing and log debug instead of warning
- Confirmed ConnectionService.get_pending_requests only returns connections where recipient_id=user_id

