### PR TITLE
refactor: optimize thread filtering with event-specific enrichment

### DIFF
--- a/backend/atria/api/api/routes/direct_messages.py
+++ b/backend/atria/api/api/routes/direct_messages.py
@@ -39,8 +39,10 @@ class DirectMessageThreadList(MethodView):
     def get(self):
         """Get user's message threads"""
         user_id = int(get_jwt_identity())
+        # Get optional event_id from query params for event-specific enrichment
+        event_id = request.args.get('event_id', type=int)
         return DirectMessageService.get_user_threads(
-            user_id, DirectMessageThreadSchema(many=True)
+            user_id, DirectMessageThreadSchema(many=True), event_id=event_id
         )
 
     @blp.arguments(DirectMessageThreadCreateSchema)

--- a/backend/atria/api/api/schemas/direct_message.py
+++ b/backend/atria/api/api/schemas/direct_message.py
@@ -29,6 +29,11 @@ class DirectMessageThreadSchema(ma.SQLAlchemyAutoSchema):
     last_message = ma.Method("get_last_message")
     unread_count = ma.Method("get_unread_count")
     other_user = ma.Method("get_other_user")
+    
+    # Optional event-specific fields (added by service when event_id provided)
+    # These are transient attributes set by the service layer
+    shared_event_ids = ma.List(ma.Integer(), dump_only=True, required=False)
+    other_user_in_event = ma.Boolean(dump_only=True, required=False)
 
     def get_last_message(self, obj):
         message = (
@@ -69,6 +74,7 @@ class DirectMessageThreadSchema(ma.SQLAlchemyAutoSchema):
                 "image_url": other_user.image_url,
             }
         return None
+
 
 
 class DirectMessageSchema(ma.SQLAlchemyAutoSchema):

--- a/frontend/src/app/features/networking/api.js
+++ b/frontend/src/app/features/networking/api.js
@@ -135,10 +135,13 @@ export const networkingApi = baseApi.injectEndpoints({
     // HTTP: GET /direct-messages/threads
     getDirectMessageThreads: builder.query({
       queryFn: async (arg, api, extraOptions) => {
+        // arg can be undefined or an object with eventId
+        const eventId = arg?.eventId;
         return queryWithFallback(
           {
             url: 'direct-message-threads',
             method: 'GET',
+            params: eventId ? { event_id: eventId } : undefined,
           },
           api,
           extraOptions

--- a/frontend/src/shared/components/chat/ChatSidebar/index.jsx
+++ b/frontend/src/shared/components/chat/ChatSidebar/index.jsx
@@ -35,8 +35,10 @@ function ChatSidebar() {
     }
   }, [eventId, dispatch]);
 
-  // Fetch threads
-  const { data, isLoading, error } = useGetDirectMessageThreadsQuery();
+  // Fetch threads - pass eventId when in event context for efficient filtering
+  const { data, isLoading, error } = useGetDirectMessageThreadsQuery(
+    currentEventId ? { eventId: currentEventId } : undefined
+  );
 
   // Extract threads array from the response
   // The backend sends { threads: [...] }

--- a/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
+++ b/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
@@ -1,10 +1,10 @@
 // src/shared/components/chat/MobileChatContainer/index.jsx
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams, useLocation } from 'react-router-dom';
 import { store } from '../../../../app/store';
 import { useGetDirectMessageThreadsQuery } from '../../../../app/features/networking/api';
-import { useGetEventUsersQuery, useGetEventQuery } from '../../../../app/features/events/api';
+import { useGetEventQuery } from '../../../../app/features/events/api';
 import { useThreadFiltering } from '@/shared/hooks/useThreadFiltering';
 import { 
   selectSidebarExpanded,
@@ -67,17 +67,16 @@ function MobileChatContainer() {
     }
   }, [eventId, sessionIdFromUrl, dispatch]);
 
-  // Get threads for sidebar
+  // Get threads for sidebar - pass eventId when in event context for efficient filtering
   const { 
     data, 
     isLoading: threadsLoading 
-  } = useGetDirectMessageThreadsQuery();
-
-  // Fetch event users when in event context
-  const { data: eventUsersData } = useGetEventUsersQuery(
-    { eventId: currentEventId },
-    { skip: !currentEventId }
+  } = useGetDirectMessageThreadsQuery(
+    currentEventId ? { eventId: currentEventId } : undefined
   );
+
+  // No longer need to fetch event users separately since backend provides shared_event_ids
+  // when we pass the event_id parameter to getDirectMessageThreads
   
   // Fetch event data for permissions
   const { data: eventData } = useGetEventQuery(currentEventId, {
@@ -87,11 +86,8 @@ function MobileChatContainer() {
   // Extract threads array from the response
   const threadsArray = data?.threads || data || [];
 
-  // Create a set of user IDs who are in the current event
-  const eventUserIds = useMemo(() => {
-    if (!eventUsersData?.event_users) return new Set();
-    return new Set(eventUsersData.event_users.map(user => user.user_id));
-  }, [eventUsersData]);
+  // No longer need eventUserIds since backend provides shared_event_ids
+  const eventUserIds = new Set();
 
   // Filter threads based on context using shared hook
   const filteredThreads = useThreadFiltering(


### PR DESCRIPTION
- Move shared_event_ids logic from schema to service layer
- Add event_id parameter to thread fetching for targeted enrichment
- Only compute event membership when in event context (avoiding N+1 queries)
- Unify desktop and mobile to use same backend enrichment approach
- Single bulk query to check event membership instead of computing all shared events

