### PR TITLE
feat: emit WebSocket notifications from HTTP mark-read endpoint

### DIFF
--- a/backend/atria/api/api/routes/direct_messages.py
+++ b/backend/atria/api/api/routes/direct_messages.py
@@ -218,6 +218,11 @@ class DirectMessageMarkRead(MethodView):
                 thread_id, user_id
             )
             
+            # If there were unread messages, notify the other user via WebSocket (if connected)
+            if had_unread:
+                from api.api.sockets.dm_notifications import emit_messages_read
+                emit_messages_read(thread_id, user_id, other_user_id)
+            
             # Return success response matching socket response format
             return {
                 "thread_id": thread_id,


### PR DESCRIPTION
- HTTP endpoint now sends messages_read event to other user via WebSocket if connected
- Allows HTTP fallback users to trigger real-time updates for WebSocket-connected users
- No real-time updates if both users are on HTTP fallback (requires polling)

