### PR TITLE
feat: add social media links to sponsor cards

### DIFF
--- a/backend/atria/api/api/schemas/sponsor.py
+++ b/backend/atria/api/api/schemas/sponsor.py
@@ -74,7 +74,7 @@ class SponsorCreateSchema(ma.Schema):
         if not value:
             return
 
-        valid_platforms = {"twitter", "linkedin", "facebook", "instagram"}
+        valid_platforms = {"twitter", "linkedin", "facebook", "instagram", "youtube", "tiktok", "other"}
         for platform, url in value.items():
             if platform not in valid_platforms:
                 raise ValidationError(f"Invalid social platform: {platform}")
@@ -122,7 +122,7 @@ class SponsorUpdateSchema(ma.Schema):
         if not value:
             return
 
-        valid_platforms = {"twitter", "linkedin", "facebook", "instagram"}
+        valid_platforms = {"twitter", "linkedin", "facebook", "instagram", "youtube", "tiktok", "other"}
         for platform, url in value.items():
             if platform not in valid_platforms:
                 raise ValidationError(f"Invalid social platform: {platform}")

--- a/backend/atria/api/models/sponsor.py
+++ b/backend/atria/api/models/sponsor.py
@@ -40,10 +40,13 @@ class Sponsor(db.Model):
     social_links = db.Column(
         db.JSON,
         default=lambda: {
-            "twitter": None,
             "linkedin": None,
-            "facebook": None,
+            "twitter": None,
+            "youtube": None,
+            "tiktok": None,
             "instagram": None,
+            "facebook": None,
+            "other": None,
         },
     )
 
@@ -97,7 +100,7 @@ class Sponsor(db.Model):
 
     def update_social_links(self, **kwargs):
         """Update social media links"""
-        valid_platforms = {"twitter", "linkedin", "facebook", "instagram"}
+        valid_platforms = {"twitter", "linkedin", "facebook", "instagram", "youtube", "tiktok", "other"}
 
         # Create a new dict to ensure SQLAlchemy detects the change
         social = dict(self.social_links or {})

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
@@ -45,10 +45,13 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
     contactPhone: '',
     tierId: '',
     socialLinks: {
-      twitter: '',
       linkedin: '',
-      facebook: '',
+      twitter: '',
+      youtube: '',
+      tiktok: '',
       instagram: '',
+      facebook: '',
+      other: '',
     },
   });
 
@@ -68,10 +71,13 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         contactPhone: sponsor.contact_phone || '',
         tierId: sponsor.tier_id || '',
         socialLinks: sponsor.social_links || {
-          twitter: '',
           linkedin: '',
-          facebook: '',
+          twitter: '',
+          youtube: '',
+          tiktok: '',
           instagram: '',
+          facebook: '',
+          other: '',
         },
       });
       setExistingLogoKey(sponsor.logo_url);
@@ -244,10 +250,13 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
       contactPhone: '',
       tierId: '',
       socialLinks: {
-        twitter: '',
         linkedin: '',
-        facebook: '',
+        twitter: '',
+        youtube: '',
+        tiktok: '',
         instagram: '',
+        facebook: '',
+        other: '',
       },
     });
     setLogoFile(null);
@@ -439,6 +448,16 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         <Grid gutter={isMobile ? "xs" : "md"}>
           <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
+              label="LinkedIn"
+              placeholder="https://linkedin.com/company/name"
+              value={formData.socialLinks.linkedin}
+              onChange={(e) => handleSocialLinkChange('linkedin', e.target.value)}
+              error={errors.social_linkedin}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+          <Grid.Col span={isMobile ? 12 : 6}>
+            <TextInput
               label="Twitter"
               placeholder="https://twitter.com/username"
               value={formData.socialLinks.twitter}
@@ -449,11 +468,31 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
           </Grid.Col>
           <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
-              label="LinkedIn"
-              placeholder="https://linkedin.com/company/name"
-              value={formData.socialLinks.linkedin}
-              onChange={(e) => handleSocialLinkChange('linkedin', e.target.value)}
-              error={errors.social_linkedin}
+              label="YouTube"
+              placeholder="https://youtube.com/@channel"
+              value={formData.socialLinks.youtube}
+              onChange={(e) => handleSocialLinkChange('youtube', e.target.value)}
+              error={errors.social_youtube}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+          <Grid.Col span={isMobile ? 12 : 6}>
+            <TextInput
+              label="TikTok"
+              placeholder="https://tiktok.com/@username"
+              value={formData.socialLinks.tiktok}
+              onChange={(e) => handleSocialLinkChange('tiktok', e.target.value)}
+              error={errors.social_tiktok}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+          <Grid.Col span={isMobile ? 12 : 6}>
+            <TextInput
+              label="Instagram"
+              placeholder="https://instagram.com/username"
+              value={formData.socialLinks.instagram}
+              onChange={(e) => handleSocialLinkChange('instagram', e.target.value)}
+              error={errors.social_instagram}
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>
@@ -469,11 +508,11 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
           </Grid.Col>
           <Grid.Col span={isMobile ? 12 : 6}>
             <TextInput
-              label="Instagram"
-              placeholder="https://instagram.com/username"
-              value={formData.socialLinks.instagram}
-              onChange={(e) => handleSocialLinkChange('instagram', e.target.value)}
-              error={errors.social_instagram}
+              label="Other"
+              placeholder="https://example.com/profile"
+              value={formData.socialLinks.other}
+              onChange={(e) => handleSocialLinkChange('other', e.target.value)}
+              error={errors.social_other}
               classNames={{ input: styles.formInput }}
             />
           </Grid.Col>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/schemas/sponsorSchema.js
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/schemas/sponsorSchema.js
@@ -28,6 +28,9 @@ export const sponsorFieldSchemas = {
     linkedin: z.string().url('Invalid LinkedIn URL').optional().or(z.literal('')),
     facebook: z.string().url('Invalid Facebook URL').optional().or(z.literal('')),
     instagram: z.string().url('Invalid Instagram URL').optional().or(z.literal('')),
+    youtube: z.string().url('Invalid YouTube URL').optional().or(z.literal('')),
+    tiktok: z.string().url('Invalid TikTok URL').optional().or(z.literal('')),
+    other: z.string().url('Invalid URL').optional().or(z.literal('')),
   }).optional(),
 };
 

--- a/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
+++ b/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
@@ -167,10 +167,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-md);
+  gap: var(--space-xs); /* Reduced gap */
   margin-top: auto;
   padding-top: var(--space-md);
   border-top: 1px solid rgba(139, 92, 246, 0.06);
+  flex-wrap: nowrap;
 }
 
 .websiteLink {
@@ -178,12 +179,17 @@
   align-items: center;
   gap: var(--space-xs);
   color: var(--color-primary) !important;
-  font-size: clamp(var(--text-xs), 2vw, var(--text-sm)) !important;
+  font-size: clamp(0.7rem, 1.5vw, 0.875rem) !important; /* Smaller text */
   font-weight: 500 !important;
   text-decoration: none !important;
   transition: all 0.2s ease;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   letter-spacing: 0.01em;
+  flex-shrink: 1; /* Allow shrinking */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .websiteLink:hover {
@@ -193,8 +199,10 @@
 
 .socialLinks {
   display: flex;
-  gap: var(--space-xs);
+  gap: 0;
   align-items: center;
+  flex-wrap: nowrap;
+  flex-shrink: 0; /* Don't allow the container to shrink */
 }
 
 /* Base social icon style */
@@ -206,10 +214,12 @@
 .socialIcon:global(.mantine-ActionIcon-root) {
   background: transparent !important;
   transition: all 0.2s ease !important;
+  /* Default size for fewer icons */
   width: 32px !important;
   height: 32px !important;
   min-width: 32px !important;
   min-height: 32px !important;
+  flex-shrink: 0;
 }
 
 .socialIcon:global(.mantine-ActionIcon-root:hover) {
@@ -218,8 +228,26 @@
 }
 
 .socialIcon:global(.mantine-ActionIcon-root svg) {
+  /* Default icon size */
   width: 20px !important;
   height: 20px !important;
+}
+
+/* Compact mode when there are many social links (5+) */
+.socialLinksCompact .socialIcon:global(.mantine-ActionIcon-root) {
+  width: 26px !important;
+  height: 26px !important;
+  min-width: 26px !important;
+  min-height: 26px !important;
+}
+
+.socialLinksCompact .socialIcon:global(.mantine-ActionIcon-root:hover) {
+  transform: translateY(-1px) scale(1.05) !important;
+}
+
+.socialLinksCompact .socialIcon:global(.mantine-ActionIcon-root svg) {
+  width: 16px !important;
+  height: 16px !important;
 }
 
 /* Platform-specific styles using design tokens */
@@ -256,6 +284,33 @@
 
 .socialIconInstagram:global(.mantine-ActionIcon-root:hover) {
   color: var(--social-instagram) !important;
+  background: transparent !important;
+}
+
+.socialIconYoutube {
+  composes: social-link-youtube from '../../../styles/design-tokens.css';
+}
+
+.socialIconYoutube:global(.mantine-ActionIcon-root:hover) {
+  color: var(--social-youtube) !important;
+  background: transparent !important;
+}
+
+.socialIconTiktok {
+  composes: social-link-tiktok from '../../../styles/design-tokens.css';
+}
+
+.socialIconTiktok:global(.mantine-ActionIcon-root:hover) {
+  color: var(--social-tiktok) !important;
+  background: transparent !important;
+}
+
+.socialIconOther {
+  composes: social-link-other from '../../../styles/design-tokens.css';
+}
+
+.socialIconOther:global(.mantine-ActionIcon-root:hover) {
+  color: var(--color-primary) !important;
   background: transparent !important;
 }
 

--- a/frontend/src/shared/components/SponsorCard/index.jsx
+++ b/frontend/src/shared/components/SponsorCard/index.jsx
@@ -1,14 +1,26 @@
 import { Card, Text, Group, ActionIcon, Anchor } from '@mantine/core';
-import { IconExternalLink, IconBrandTwitter, IconBrandLinkedin, IconBrandFacebook, IconBrandInstagram } from '@tabler/icons-react';
+import { 
+  IconExternalLink, 
+  IconBrandTwitter, 
+  IconBrandLinkedin, 
+  IconBrandFacebook, 
+  IconBrandInstagram,
+  IconBrandYoutubeFilled,
+  IconBrandTiktok,
+  IconWorld
+} from '@tabler/icons-react';
 import PrivateImage from '../PrivateImage';
 import { useGradientBadge } from '../../hooks/useGradientBadge';
 import styles from './SponsorCard.module.css';
 
 const socialIcons = {
-  twitter: IconBrandTwitter,
   linkedin: IconBrandLinkedin,
+  twitter: IconBrandTwitter,
+  youtube: IconBrandYoutubeFilled,
+  tiktok: IconBrandTiktok,
+  instagram: IconBrandInstagram,
   facebook: IconBrandFacebook,
-  instagram: IconBrandInstagram
+  other: IconWorld
 };
 
 export const SponsorCard = ({ sponsor }) => {
@@ -99,28 +111,36 @@ export const SponsorCard = ({ sponsor }) => {
             </Anchor>
           )}
 
-          {social_links && Object.keys(social_links).length > 0 && (
-            <Group gap={0} className={styles.socialLinks}>
-              {Object.entries(social_links).map(([platform, url]) => {
-                if (!url) return null;
-                const Icon = socialIcons[platform];
-                return Icon ? (
-                  <ActionIcon
-                    key={platform}
-                    component="a"
-                    href={url}
-                    target="_blank"
-                    size="md"
-                    variant="subtle"
-                    className={`${styles.socialIcon} ${styles[`socialIcon${platform.charAt(0).toUpperCase() + platform.slice(1)}`]}`}
-                    aria-label={`${name} on ${platform}`}
-                  >
-                    <Icon size={20} />
-                  </ActionIcon>
-                ) : null;
-              })}
-            </Group>
-          )}
+          {social_links && Object.keys(social_links).length > 0 && (() => {
+            // Count how many social links are actually populated
+            const activeSocialCount = Object.values(social_links).filter(url => url).length;
+            // Use smaller size only when we have all 7 social links
+            const isCompact = activeSocialCount >= 7;
+            
+            return (
+              <Group gap={0} className={`${styles.socialLinks} ${isCompact ? styles.socialLinksCompact : ''}`}>
+                {['linkedin', 'twitter', 'youtube', 'tiktok', 'instagram', 'facebook', 'other'].map((platform) => {
+                  const url = social_links[platform];
+                  if (!url) return null;
+                  const Icon = socialIcons[platform];
+                  return Icon ? (
+                    <ActionIcon
+                      key={platform}
+                      component="a"
+                      href={url}
+                      target="_blank"
+                      size={isCompact ? "sm" : "md"}
+                      variant="subtle"
+                      className={`${styles.socialIcon} ${styles[`socialIcon${platform.charAt(0).toUpperCase() + platform.slice(1)}`]}`}
+                      aria-label={`${name} on ${platform}`}
+                    >
+                      <Icon size={isCompact ? 16 : 20} />
+                    </ActionIcon>
+                  ) : null;
+                })}
+              </Group>
+            );
+          })()}
         </div>
       </div>
     </Card>

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -69,6 +69,8 @@
   --social-twitter: #1da1f2; /* Twitter/X blue */
   --social-facebook: #1877f2; /* Facebook blue */
   --social-instagram: #e4405f; /* Instagram pink/red */
+  --social-youtube: #ff0000; /* YouTube red */
+  --social-tiktok: #000000; /* TikTok black */
 
   /* Spacing Scale */
   --space-xs: 0.25rem; /* 4px */
@@ -547,6 +549,36 @@
 }
 
 .social-link-email:hover {
+  color: var(--color-primary) !important;
+  background: rgba(139, 92, 246, 0.08) !important;
+}
+
+/* YouTube specific */
+.social-link-youtube {
+  composes: social-link-base;
+}
+
+.social-link-youtube:hover {
+  color: var(--social-youtube) !important;
+  background: rgba(255, 0, 0, 0.08) !important;
+}
+
+/* TikTok specific */
+.social-link-tiktok {
+  composes: social-link-base;
+}
+
+.social-link-tiktok:hover {
+  color: var(--social-tiktok) !important;
+  background: rgba(0, 0, 0, 0.08) !important;
+}
+
+/* Other/Generic link */
+.social-link-other {
+  composes: social-link-base;
+}
+
+.social-link-other:hover {
   color: var(--color-primary) !important;
   background: rgba(139, 92, 246, 0.08) !important;
 }


### PR DESCRIPTION
- Add social media brand colors and reusable social link styles to design tokens
- Update SponsorCard to display Twitter, LinkedIn, Facebook, and Instagram links
- Fix backend SponsorListSchema to include social_links field in API responses
- Style social icons with platform-specific hover colors and no background
- Set icon sizes to 32x32px clickable area with 20x20px icons