### PR TITLE
fix: enable proper DM thread opening on mobile devices

### DIFF
--- a/frontend/src/app/store/chatSlice.js
+++ b/frontend/src/app/store/chatSlice.js
@@ -10,6 +10,7 @@ const initialState = {
   activeTab: 'general', // 'general', 'event', 'chat', 'session'
   activeChatRoomId: null, // Currently open chat room ID
   lastSessionId: null, // Remember last viewed session
+  mobileActiveThreadId: null, // Active thread ID for mobile view
 };
 
 const chatSlice = createSlice({
@@ -83,6 +84,16 @@ const chatSlice = createSlice({
     setLastSessionId: (state, action) => {
       state.lastSessionId = action.payload;
     },
+    // Mobile-specific action for opening threads
+    openThreadMobile: (state, action) => {
+      const threadId = action.payload;
+      state.mobileActiveThreadId = threadId;
+      // Automatically expand sidebar when opening a thread on mobile
+      state.sidebarExpanded = true;
+    },
+    closeThreadMobile: (state) => {
+      state.mobileActiveThreadId = null;
+    },
   },
 });
 
@@ -96,6 +107,8 @@ export const {
   setActiveTab,
   setActiveChatRoomId,
   setLastSessionId,
+  openThreadMobile,
+  closeThreadMobile,
 } = chatSlice.actions;
 
 // Selectors
@@ -106,5 +119,6 @@ export const selectCurrentEventId = (state) => state.chat.currentEventId;
 export const selectActiveTab = (state) => state.chat.activeTab;
 export const selectActiveChatRoomId = (state) => state.chat.activeChatRoomId;
 export const selectLastSessionId = (state) => state.chat.lastSessionId;
+export const selectMobileActiveThreadId = (state) => state.chat.mobileActiveThreadId;
 
 export default chatSlice.reducer;

--- a/frontend/src/pages/Dashboard/ConnectionsSection/index.jsx
+++ b/frontend/src/pages/Dashboard/ConnectionsSection/index.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Avatar } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
+import { useMediaQuery } from '@mantine/hooks';
 import { useCreateDirectMessageThreadMutation } from '@/app/features/networking/api';
-import { useDispatch } from 'react-redux';
-import { openThread } from '@/app/store/chatSlice';
+import { useOpenThread } from '@/shared/hooks/useOpenThread';
 import { notifications } from '@mantine/notifications';
 import { IconMessageCircle } from '@tabler/icons-react';
 import { Button } from '@/shared/components/buttons';
@@ -11,7 +11,8 @@ import styles from './styles/index.module.css';
 
 export const ConnectionsSection = ({ connections }) => {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
+  const openThread = useOpenThread();
+  const isMobile = useMediaQuery('(max-width: 768px)');
   const [createThread, { isLoading: isCreatingThread }] = useCreateDirectMessageThreadMutation();
   const [messagingUserId, setMessagingUserId] = useState(null);
 
@@ -42,12 +43,15 @@ export const ConnectionsSection = ({ connections }) => {
       const threadId = result.thread_id || result.id || result.data?.thread_id || result.data?.id;
       
       if (threadId) {
-        dispatch(openThread(threadId));
-        notifications.show({
-          title: 'Success',
-          message: `Started conversation with ${userName}`,
-          color: 'green',
-        });
+        openThread(threadId);
+        // Only show notification on desktop - mobile makes it obvious with full screen
+        if (!isMobile) {
+          notifications.show({
+            title: 'Success',
+            message: `Started conversation with ${userName}`,
+            color: 'green',
+          });
+        }
       } else {
         throw new Error('Failed to get thread ID');
       }

--- a/frontend/src/pages/Network/ConnectionCard/index.jsx
+++ b/frontend/src/pages/Network/ConnectionCard/index.jsx
@@ -1,17 +1,19 @@
 import { useState } from 'react';
 import { Avatar, Group, Text, Badge, Button, ActionIcon } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import { IconBrandLinkedin, IconBrandTwitter, IconWorld, IconMessageCircle } from '@tabler/icons-react';
 import { useCreateDirectMessageThreadMutation } from '@/app/features/networking/api';
-import { useDispatch, useSelector } from 'react-redux';
-import { openThread } from '@/app/store/chatSlice';
+import { useSelector } from 'react-redux';
+import { useOpenThread } from '@/shared/hooks/useOpenThread';
 import { notifications } from '@mantine/notifications';
 import { useNavigate } from 'react-router-dom';
 import styles from './styles/index.module.css';
 
 export function ConnectionCard({ connection }) {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
   const currentUser = useSelector((state) => state.auth.user);
+  const openThread = useOpenThread();
+  const isMobile = useMediaQuery('(max-width: 768px)');
   const [createThread, { isLoading: isCreatingThread }] = useCreateDirectMessageThreadMutation();
   const [isMessaging, setIsMessaging] = useState(false);
 
@@ -30,13 +32,16 @@ export function ConnectionCard({ connection }) {
       const threadId = result.thread_id || result.id || result.data?.thread_id || result.data?.id;
       
       if (threadId) {
-        dispatch(openThread(threadId));
+        openThread(threadId);
         
-        notifications.show({
-          title: 'Success',
-          message: `Started conversation with ${otherUser.full_name}`,
-          color: 'green',
-        });
+        // Only show notification on desktop - mobile makes it obvious with full screen
+        if (!isMobile) {
+          notifications.show({
+            title: 'Success',
+            message: `Started conversation with ${otherUser.full_name}`,
+            color: 'green',
+          });
+        }
       } else {
         console.error('No thread ID in result:', result);
         throw new Error('Failed to get thread ID');

--- a/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
+++ b/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
@@ -10,10 +10,12 @@ import {
   selectSidebarExpanded,
   selectCurrentEventId,
   selectActiveChatRoomId,
+  selectMobileActiveThreadId,
   toggleSidebar,
   setCurrentEventId,
   setActiveChatRoomId,
-  setActiveTab
+  setActiveTab,
+  closeThreadMobile
 } from '../../../../app/store/chatSlice';
 import MobileChatSidebar from '../MobileChatSidebar';
 import MobileChatWindow from '../MobileChatWindow';
@@ -33,6 +35,7 @@ function MobileChatContainer() {
   const sidebarExpanded = useSelector(selectSidebarExpanded);
   const currentEventId = useSelector(selectCurrentEventId);
   const activeChatRoomId = useSelector(selectActiveChatRoomId);
+  const mobileActiveThreadId = useSelector(selectMobileActiveThreadId);
   const [activeThreadId, setActiveThreadId] = useState(null);
   const [activeRoom, setActiveRoom] = useState(null);
   
@@ -42,6 +45,20 @@ function MobileChatContainer() {
   
   // Parse sessionId to ensure it's a number (only use sessionId from URL, not lastSessionId)
   const currentSessionId = sessionIdFromUrl ? parseInt(sessionIdFromUrl, 10) : null;
+
+  // Respond to Redux state changes for mobile thread opening
+  useEffect(() => {
+    if (mobileActiveThreadId && mobileActiveThreadId !== activeThreadId) {
+      setActiveThreadId(mobileActiveThreadId);
+      setActiveRoom(null);
+      // Switch to appropriate tab based on context
+      if (currentEventId) {
+        dispatch(setActiveTab('event'));
+      } else {
+        dispatch(setActiveTab('general'));
+      }
+    }
+  }, [mobileActiveThreadId, activeThreadId, currentEventId, dispatch]);
 
   // Update current event ID and handle tab switching
   useEffect(() => {
@@ -120,6 +137,7 @@ function MobileChatContainer() {
     setActiveThreadId(null);
     setActiveRoom(null);
     dispatch(setActiveChatRoomId(null));
+    dispatch(closeThreadMobile());
     // Show thread list when closing a chat
     if (!sidebarExpanded) {
       dispatch(toggleSidebar());

--- a/frontend/src/shared/hooks/useOpenThread.js
+++ b/frontend/src/shared/hooks/useOpenThread.js
@@ -1,0 +1,29 @@
+import { useDispatch } from 'react-redux';
+import { useMediaQuery } from '@mantine/hooks';
+import { openThread, openThreadMobile } from '@/app/store/chatSlice';
+
+/**
+ * Unified hook for opening chat threads that works for both desktop and mobile
+ * Automatically detects the environment and dispatches the appropriate action
+ */
+export function useOpenThread() {
+  const dispatch = useDispatch();
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
+  const handleOpenThread = (threadId) => {
+    if (!threadId) {
+      console.error('No thread ID provided to openThread');
+      return;
+    }
+
+    if (isMobile) {
+      // Mobile: Use mobile-specific action that also expands sidebar
+      dispatch(openThreadMobile(threadId));
+    } else {
+      // Desktop: Use standard action for windowed chat system
+      dispatch(openThread(threadId));
+    }
+  };
+
+  return handleOpenThread;
+}


### PR DESCRIPTION
- Add mobile-specific Redux state and actions for thread management
- Create unified useOpenThread hook that detects mobile/desktop environment
- Update MobileChatContainer to respond to Redux state changes
- Suppress success notifications on mobile (unnecessary with full-screen chat)
- Update all message button handlers to use unified approach

Components updated:
- AttendeesGrid
- ConnectionCard
- ConnectionsSection
- MobileChatContainer

Now clicking "Message" on mobile properly expands sidebar and opens the thread

