### PR TITLE
feat: hide networking header on screens with limited vertical space

### DIFF
--- a/frontend/src/pages/Networking/styles/index.module.css
+++ b/frontend/src/pages/Networking/styles/index.module.css
@@ -292,6 +292,17 @@
   padding: 0;
 }
 
+/* Limited vertical space (laptops like MacBook Air) */
+@media (min-width: 769px) and (max-height: 1050px) {
+  .headerSection {
+    display: none; /* Remove header entirely to save vertical space */
+  }
+  
+  .contentWrapper {
+    padding-top: 1rem; /* Reduce top padding since header is gone */
+  }
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .headerSection {


### PR DESCRIPTION
- Add media query for laptop screens with ≤1050px height
- Completely remove header section (display: none) to maximize vertical space
- Reduce top padding when header is hidden
- Improves UX on MacBook Air and similar laptop screens

Affects screens with width ≥769px and height ≤1050px

