### PR TITLE
fix(frontend): add explicit objectFit style for Firefox compatibility

### DIFF
--- a/frontend/src/shared/components/PrivateImage/index.jsx
+++ b/frontend/src/shared/components/PrivateImage/index.jsx
@@ -55,6 +55,10 @@ const PrivateImage = ({
       width={width}
       height={height}
       fit={fit}
+      style={{
+        objectFit: fit,
+        ...props.style
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
- Firefox requires explicit CSS objectFit property in addition to Mantine's fit prop
- Fixes sponsor images not displaying correctly in Firefox on Sponsors page
- Working images in EventAdmin suggest this inline style approach resolves the issue

