### PR TITLE
fix(frontend): add explicit width/height to sponsor images for Firefox

### DIFF
--- a/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
+++ b/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
@@ -103,6 +103,8 @@
 }
 
 .logo {
+  width: 100%;
+  height: clamp(70px, 12vw, 100px);
   max-height: clamp(70px, 12vw, 100px);
   max-width: 85%;
   object-fit: contain;


### PR DESCRIPTION
- Firefox requires explicit dimensions when using object-fit: contain
- Changed from only max-width/max-height to include width: 100% and explicit height
- Matches the pattern used in working EventAdmin SponsorCard

