### PR TITLE
fix(frontend): use flex properties to fix Firefox sponsor image display

### DIFF
--- a/frontend/src/shared/components/PrivateImage/index.jsx
+++ b/frontend/src/shared/components/PrivateImage/index.jsx
@@ -55,10 +55,6 @@ const PrivateImage = ({
       width={width}
       height={height}
       fit={fit}
-      style={{
-        objectFit: fit,
-        ...props.style
-      }}
       {...props}
     />
   );

--- a/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
+++ b/frontend/src/shared/components/SponsorCard/SponsorCard.module.css
@@ -110,6 +110,8 @@
   object-fit: contain;
   position: relative;
   z-index: 1;
+  flex-grow: 1 !important;
+  flex-shrink: 1 !important;
 }
 
 .logoPlaceholder {


### PR DESCRIPTION
- Added flex-grow: 1 and flex-shrink: 1 to .logo class
- Firefox wasn't properly sizing images without explicit flex properties
- Reverted unnecessary objectFit style changes in PrivateImage
- Kept width/height properties for proper dimensions

