### PR TITLE
refactor: separate has_user() from user_can_access() for clearer sema…

### DIFF
--- a/backend/atria/api/api/schemas/organization.py
+++ b/backend/atria/api/api/schemas/organization.py
@@ -71,7 +71,7 @@ class OrganizationDetailSchema(OrganizationSchema):
         try:
             current_user_id = int(get_jwt_identity())
             user = User.query.get(current_user_id)
-            if user and obj.has_user(user):
+            if user and obj.user_can_access(user):
                 return obj.get_user_role(user).value
         except Exception:
             pass

--- a/backend/atria/api/api/sockets/chat.py
+++ b/backend/atria/api/api/sockets/chat.py
@@ -242,7 +242,7 @@ def handle_get_chat_rooms(user_id, data):
         emit("error", {"message": "Event not found"})
         return
 
-    if not event.has_user(current_user):
+    if not event.user_can_access(current_user):
         emit("error", {"message": "Not authorized to access this event"})
         return
 
@@ -279,7 +279,7 @@ def handle_join_session_chat_rooms(user_id, data):
     
     # Check if user is part of the event
     current_user = User.query.get(user_id)
-    if not session.event.has_user(current_user):
+    if not session.event.user_can_access(current_user):
         emit("error", {"message": "Not authorized to access this session"})
         return
     

--- a/backend/atria/api/commons/decorators.py
+++ b/backend/atria/api/commons/decorators.py
@@ -82,7 +82,7 @@ def org_member_required():
                     "message": f"Organization with id {org_id} not found"
                 }, 404
 
-            if not org.has_user(current_user):
+            if not org.user_can_access(current_user):
                 return {"message": "Not a member of this organization"}, 403
 
             return f(*args, **kwargs)
@@ -94,8 +94,8 @@ def org_member_required():
 
 def event_member_required():
     """Check if user has any role in event and is not banned
-    
-    #! NOTE: Organization owners automatically pass this check via Event.has_user()
+
+    #! NOTE: Organization owners automatically pass this check via Event.user_can_access()
     #! which grants them access to all events in their organization.
     """
 
@@ -115,7 +115,7 @@ def event_member_required():
                 return {"message": "No event ID found"}, 400
 
             event = Event.query.get_or_404(event_id)
-            if not event.has_user(current_user):
+            if not event.user_can_access(current_user):
                 return {"message": "Not authorized to access this event"}, 403
 
             # Check if user is banned from the event
@@ -136,8 +136,8 @@ def event_member_required():
 
 def event_member_or_admin_required():
     """Check if user has any role in event - admins/organizers can access even if banned
-    
-    #! NOTE: Organization owners automatically pass this check via Event.has_user()
+
+    #! NOTE: Organization owners automatically pass this check via Event.user_can_access()
     #! and are treated as ADMINs via Event.get_user_role().
     """
 
@@ -157,7 +157,7 @@ def event_member_or_admin_required():
                 return {"message": "No event ID found"}, 400
 
             event = Event.query.get_or_404(event_id)
-            if not event.has_user(current_user):
+            if not event.user_can_access(current_user):
                 return {"message": "Not authorized to access this event"}, 403
 
             # Get user's event role
@@ -245,8 +245,8 @@ def event_admin_required():
 
 def session_access_required():
     """Check if user has access to session's event
-    
-    #! NOTE: Organization owners have access via Event.has_user() which includes
+
+    #! NOTE: Organization owners have access via Event.user_can_access() which includes
     #! org owner checks.
     """
 
@@ -258,7 +258,7 @@ def session_access_required():
             session_id = kwargs.get("session_id")
 
             session = Session.query.get_or_404(session_id)
-            if not session.event.has_user(current_user):
+            if not session.event.user_can_access(current_user):
                 return {
                     "message": "Not authorized to access this session"
                 }, 403
@@ -272,8 +272,8 @@ def session_access_required():
 
 def chat_room_access_required():
     """Check if user has access to chat room's event
-    
-    #! NOTE: Organization owners have access via Event.has_user() which includes
+
+    #! NOTE: Organization owners have access via Event.user_can_access() which includes
     #! org owner checks.
     """
 
@@ -287,7 +287,7 @@ def chat_room_access_required():
             chat_room = ChatRoom.query.get_or_404(room_id)
             event = Event.query.get_or_404(chat_room.event_id)
 
-            if not event.has_user(current_user):
+            if not event.user_can_access(current_user):
                 return {
                     "message": "Not authorized to access this chat room"
                 }, 403

--- a/backend/atria/api/commons/socket_decorators.py
+++ b/backend/atria/api/commons/socket_decorators.py
@@ -66,7 +66,7 @@ def socket_event_member_required(f):
             disconnect()
             return
 
-        if not event.has_user(current_user):
+        if not event.user_can_access(current_user):
             emit("error", {"message": "Not authorized to access this event"})
             disconnect()
             return
@@ -110,7 +110,7 @@ def socket_chat_room_access_required(f):
             return
 
         event = Event.query.get(chat_room.event_id)
-        if not event.has_user(current_user):
+        if not event.user_can_access(current_user):
             emit(
                 "error", {"message": "Not authorized to access this chat room"}
             )

--- a/backend/atria/api/models/organization.py
+++ b/backend/atria/api/models/organization.py
@@ -73,8 +73,21 @@ class Organization(db.Model):
         return org_user.role if org_user else None
 
     def has_user(self, user) -> bool:
-        """Check if user is in organization"""
+        """Check if user has an explicit OrganizationUser record
+
+        This method only checks for actual organization membership.
+        For organizations, has_user() and user_can_access() are the same
+        since there's no implicit access like with events.
+        """
         return user in self.users
+
+    def user_can_access(self, user) -> bool:
+        """Check if user can access this organization
+
+        For organizations, this is the same as has_user().
+        Provided for API consistency with Event model.
+        """
+        return self.has_user(user)
 
     def get_users_by_role(self, role: OrganizationUserRole):
         """Get all users with specific role"""

--- a/backend/atria/api/services/organization.py
+++ b/backend/atria/api/services/organization.py
@@ -29,7 +29,7 @@ class OrganizationService:
         # If user_id provided, verify membership
         if user_id:
             user = User.query.get_or_404(user_id)
-            if not org.has_user(user):
+            if not org.user_can_access(user):
                 raise ValueError("Not a member of this organization")
 
         return org
@@ -191,7 +191,7 @@ class OrganizationService:
         user = User.query.get_or_404(user_id)
 
         # Verify user is member
-        if not org.has_user(user):
+        if not org.user_can_access(user):
             raise ValueError("Not a member of this organization")
 
         # Build query
@@ -217,7 +217,7 @@ class OrganizationService:
         user = User.query.get_or_404(user_id)
 
         # Verify user is member
-        if not org.has_user(user):
+        if not org.user_can_access(user):
             raise ValueError("Not a member of this organization")
 
         # Build query with proper filtering


### PR DESCRIPTION
…ntics

- Split Event.has_user() into two methods:
  - has_user(): checks literal EventUser membership only
  - user_can_access(): checks membership OR org owner status
- Added same pattern to Organization model for API consistency
- Updated all authorization checks to use user_can_access()
- Fixed bug where org owners couldn't create events due to implicit access

This separation makes the code's intent clearer:
- has_user() for membership management (preventing duplicates)
- user_can_access() for permission checks