### PR TITLE
fix: resolve Direct Message API schema serialization issues

### DIFF
--- a/backend/atria/api/api/schemas/direct_message.py
+++ b/backend/atria/api/api/schemas/direct_message.py
@@ -34,6 +34,7 @@ class DirectMessageThreadSchema(ma.SQLAlchemyAutoSchema):
     # These are transient attributes set by the service layer
     shared_event_ids = ma.List(ma.Integer(), dump_only=True, required=False)
     other_user_in_event = ma.Boolean(dump_only=True, required=False)
+    is_new = ma.Boolean(dump_only=True, required=False)  # Set when thread is newly created
 
     def get_last_message(self, obj):
         message = (


### PR DESCRIPTION
- Return model objects instead of dicts for proper schema serialization
- Add abort import from flask_smorest for error handling
- Add transient attributes (shared_event_ids, other_user_in_event, is_new) to thread responses
- Fix GET thread detail endpoint to include required fields for schema
- Add TODO for missing pagination implementation

Fixes AttributeError when schema methods expected model attributes but received dict keys. This ensures consistent API responses and enables proper test coverage.

