### PR TITLE
fix: add pytest-factoryboy to CI dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         cd backend/atria
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-cov pytest-flask pytest-mock factory-boy faker
+        pip install pytest pytest-cov pytest-flask pytest-mock pytest-factoryboy factory-boy faker
 
     - name: Create test database
       env:


### PR DESCRIPTION
Tests were failing with ModuleNotFoundError for pytest_factoryboy

