### PR TITLE
fix: make test_setup flexible for CI and local ports

### DIFF
--- a/backend/atria/tests/conftest.py
+++ b/backend/atria/tests/conftest.py
@@ -40,7 +40,9 @@ def app():
     os.environ['POSTGRES_USER'] = 'test_user'
     os.environ['POSTGRES_PASSWORD'] = 'test_pass'
     os.environ['POSTGRES_DB'] = 'test_atria'
-    os.environ['POSTGRES_PORT'] = '5433'
+    # Don't override POSTGRES_PORT if already set (CI uses 5432, local uses 5433)
+    if 'POSTGRES_PORT' not in os.environ:
+        os.environ['POSTGRES_PORT'] = '5433'
 
     # Set testing environment
     os.environ['FLASK_ENV'] = 'testing'

--- a/backend/atria/tests/test_setup.py
+++ b/backend/atria/tests/test_setup.py
@@ -16,7 +16,8 @@ def test_database_is_postgresql(app):
     db_uri = app.config['SQLALCHEMY_DATABASE_URI']
     assert 'postgresql' in db_uri
     assert 'test_atria' in db_uri  # Using test database
-    assert '5433' in db_uri  # Using test port
+    # Port can be 5432 (CI) or 5433 (local)
+    assert ('5432' in db_uri or '5433' in db_uri)  # Has valid test port
     print(f"✓ Using test database: {db_uri}")
 
 


### PR DESCRIPTION
- Test now accepts both port 5432 (CI) and 5433 (local)
- Don't override POSTGRES_PORT if already set in environment

