### PR TITLE
refactor: extract SponsorsManager components for better organization

### DIFF
--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/BasicInfoSection.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/BasicInfoSection.jsx
@@ -1,0 +1,71 @@
+import { Grid, TextInput, Textarea, Select } from '@mantine/core';
+import styles from './styles/index.module.css';
+
+const BasicInfoSection = ({
+  formData,
+  errors,
+  isMobile,
+  sponsorTiers,
+  onFieldChange,
+}) => {
+  return (
+    <>
+      <Grid>
+        <Grid.Col span={isMobile ? 12 : 8}>
+          <TextInput
+            label="Sponsor Name"
+            placeholder="Enter sponsor name"
+            required
+            value={formData.name}
+            onChange={(e) => onFieldChange('name', e.target.value)}
+            error={errors.name}
+            classNames={{ input: styles.formInput }}
+          />
+        </Grid.Col>
+        <Grid.Col span={isMobile ? 12 : 4}>
+          <Select
+            label="Tier"
+            placeholder="Select tier"
+            required
+            clearable={false}
+            allowDeselect={false}
+            data={sponsorTiers.map((tier) => ({
+              value: tier.id,
+              label: tier.name,
+            }))}
+            value={formData.tierId || null}
+            onChange={(value) => {
+              // Only update if there's actually a value
+              if (value) {
+                onFieldChange('tierId', value);
+              }
+            }}
+            error={errors.tierId}
+            classNames={{ input: styles.formSelect }}
+          />
+        </Grid.Col>
+      </Grid>
+
+      <Textarea
+        label="Description"
+        placeholder="Enter sponsor description"
+        rows={3}
+        value={formData.description}
+        onChange={(e) => onFieldChange('description', e.target.value)}
+        error={errors.description}
+        classNames={{ input: styles.formTextarea }}
+      />
+
+      <TextInput
+        label="Website URL"
+        placeholder="https://example.com"
+        value={formData.websiteUrl}
+        onChange={(e) => onFieldChange('websiteUrl', e.target.value)}
+        error={errors.websiteUrl}
+        classNames={{ input: styles.formInput }}
+      />
+    </>
+  );
+};
+
+export default BasicInfoSection;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/ContactInfoSection.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/ContactInfoSection.jsx
@@ -1,0 +1,75 @@
+import { Grid, TextInput, Text, Badge, Collapse } from '@mantine/core';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import styles from './styles/index.module.css';
+
+const ContactInfoSection = ({
+  formData,
+  errors,
+  isMobile,
+  expanded,
+  onExpandedChange,
+  onFieldChange,
+}) => {
+  return (
+    <>
+      {isMobile ? (
+        <Badge
+          variant="light"
+          color="gray"
+          radius="sm"
+          className={styles.collapsibleHeader}
+          onClick={() => onExpandedChange(!expanded)}
+          rightSection={
+            expanded ? (
+              <IconChevronUp size={14} />
+            ) : (
+              <IconChevronDown size={14} />
+            )
+          }
+          fullWidth
+        >
+          Contact Information
+        </Badge>
+      ) : (
+        <Text className={styles.sectionTitle}>Contact Information</Text>
+      )}
+
+      <Collapse in={!isMobile || expanded}>
+        <Grid gutter={isMobile ? 'xs' : 'md'}>
+          <Grid.Col span={isMobile ? 12 : 4}>
+            <TextInput
+              label="Contact Name"
+              placeholder="John Doe"
+              value={formData.contactName}
+              onChange={(e) => onFieldChange('contactName', e.target.value)}
+              error={errors.contactName}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+          <Grid.Col span={isMobile ? 12 : 4}>
+            <TextInput
+              label="Contact Email"
+              placeholder="contact@example.com"
+              value={formData.contactEmail}
+              onChange={(e) => onFieldChange('contactEmail', e.target.value)}
+              error={errors.contactEmail}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+          <Grid.Col span={isMobile ? 12 : 4}>
+            <TextInput
+              label="Contact Phone"
+              placeholder="+1234567890"
+              value={formData.contactPhone}
+              onChange={(e) => onFieldChange('contactPhone', e.target.value)}
+              error={errors.contactPhone}
+              classNames={{ input: styles.formInput }}
+            />
+          </Grid.Col>
+        </Grid>
+      </Collapse>
+    </>
+  );
+};
+
+export default ContactInfoSection;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/LogoUploadSection.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/LogoUploadSection.jsx
@@ -1,0 +1,60 @@
+import { Group, Box, Text, FileButton, Image } from '@mantine/core';
+import { IconUpload } from '@tabler/icons-react';
+import { Button } from '../../../../shared/components/buttons';
+import PrivateImage from '../../../../shared/components/PrivateImage';
+import styles from './styles/index.module.css';
+
+const LogoUploadSection = ({
+  logoFile,
+  logoPreview,
+  existingLogoKey,
+  isMobile,
+  onLogoSelect,
+}) => {
+  const handleFileSelect = (file) => {
+    if (file) {
+      onLogoSelect(file);
+    }
+  };
+
+  return (
+    <Group className={styles.logoSection}>
+      <Box className={styles.logoUpload}>
+        <Text className={styles.logoLabel}>Logo</Text>
+        <FileButton
+          onChange={handleFileSelect}
+          accept="image/png,image/jpeg,image/gif,image/webp"
+        >
+          {(props) => (
+            <Button {...props} variant="secondary">
+              <IconUpload size={16} />
+              {existingLogoKey || logoPreview ? 'Change Logo' : 'Upload Logo'}
+            </Button>
+          )}
+        </FileButton>
+      </Box>
+
+      {logoPreview ? (
+        <Image
+          src={logoPreview}
+          alt="Logo preview"
+          width={isMobile ? 60 : 80}
+          height={isMobile ? 60 : 80}
+          fit="contain"
+          className={styles.logoPreview}
+        />
+      ) : existingLogoKey ? (
+        <PrivateImage
+          objectKey={existingLogoKey}
+          alt="Current logo"
+          width={isMobile ? 60 : 80}
+          height={isMobile ? 60 : 80}
+          fit="contain"
+          className={styles.logoPreview}
+        />
+      ) : null}
+    </Group>
+  );
+};
+
+export default LogoUploadSection;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/SocialLinksSection.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/SocialLinksSection.jsx
@@ -1,0 +1,67 @@
+import { Grid, TextInput, Text, Badge, Collapse } from '@mantine/core';
+import { IconChevronDown, IconChevronUp } from '@tabler/icons-react';
+import styles from './styles/index.module.css';
+
+const SOCIAL_PLATFORMS = [
+  { key: 'linkedin', label: 'LinkedIn', placeholder: 'https://linkedin.com/company/name' },
+  { key: 'twitter', label: 'Twitter', placeholder: 'https://twitter.com/username' },
+  { key: 'youtube', label: 'YouTube', placeholder: 'https://youtube.com/@channel' },
+  { key: 'tiktok', label: 'TikTok', placeholder: 'https://tiktok.com/@username' },
+  { key: 'instagram', label: 'Instagram', placeholder: 'https://instagram.com/username' },
+  { key: 'facebook', label: 'Facebook', placeholder: 'https://facebook.com/page' },
+  { key: 'other', label: 'Other', placeholder: 'https://example.com/profile' },
+];
+
+const SocialLinksSection = ({
+  socialLinks,
+  errors,
+  isMobile,
+  expanded,
+  onExpandedChange,
+  onSocialLinkChange,
+}) => {
+  return (
+    <>
+      {isMobile ? (
+        <Badge
+          variant="light"
+          color="gray"
+          radius="sm"
+          className={styles.collapsibleHeader}
+          onClick={() => onExpandedChange(!expanded)}
+          rightSection={
+            expanded ? (
+              <IconChevronUp size={14} />
+            ) : (
+              <IconChevronDown size={14} />
+            )
+          }
+          fullWidth
+        >
+          Social Media Links
+        </Badge>
+      ) : (
+        <Text className={styles.sectionTitle}>Social Media Links</Text>
+      )}
+
+      <Collapse in={!isMobile || expanded}>
+        <Grid gutter={isMobile ? 'xs' : 'md'}>
+          {SOCIAL_PLATFORMS.map((platform) => (
+            <Grid.Col key={platform.key} span={isMobile ? 12 : 6}>
+              <TextInput
+                label={platform.label}
+                placeholder={platform.placeholder}
+                value={socialLinks[platform.key] || ''}
+                onChange={(e) => onSocialLinkChange(platform.key, e.target.value)}
+                error={errors[`social_${platform.key}`]}
+                classNames={{ input: styles.formInput }}
+              />
+            </Grid.Col>
+          ))}
+        </Grid>
+      </Collapse>
+    </>
+  );
+};
+
+export default SocialLinksSection;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/index.jsx
@@ -1,21 +1,6 @@
-import React, { useState, useEffect } from 'react';
-import {
-  Modal,
-  Stack,
-  Grid,
-  TextInput,
-  Textarea,
-  Select,
-  Text,
-  Group,
-  FileButton,
-  Image,
-  Box,
-  Collapse,
-  Badge,
-} from '@mantine/core';
+import { useState } from 'react';
+import { Modal, Stack } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconUpload, IconChevronDown, IconChevronUp } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { Button } from '../../../../shared/components/buttons';
 import {
@@ -24,138 +9,47 @@ import {
   useGetSponsorTiersQuery,
 } from '../../../../app/features/sponsors/api';
 import { useUploadImageMutation } from '../../../../app/features/uploads/api';
-import { validateField, validateSocialLink, sponsorSchema } from '../schemas/sponsorSchema';
-import PrivateImage from '../../../../shared/components/PrivateImage';
+import useSponsorForm from './useSponsorForm';
+import BasicInfoSection from './BasicInfoSection';
+import ContactInfoSection from './ContactInfoSection';
+import SocialLinksSection from './SocialLinksSection';
+import LogoUploadSection from './LogoUploadSection';
 import styles from './styles/index.module.css';
 
-const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }) => {
+const SponsorModal = ({
+  opened,
+  onClose,
+  eventId,
+  mode,
+  sponsor,
+  sponsors = [],
+}) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
-  const [logoFile, setLogoFile] = useState(null);
-  const [logoPreview, setLogoPreview] = useState(null);
-  const [existingLogoKey, setExistingLogoKey] = useState(null);
-  const [errors, setErrors] = useState({});
   const [contactExpanded, setContactExpanded] = useState(false);
   const [socialExpanded, setSocialExpanded] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    websiteUrl: '',
-    contactName: '',
-    contactEmail: '',
-    contactPhone: '',
-    tierId: '',
-    socialLinks: {
-      linkedin: '',
-      twitter: '',
-      youtube: '',
-      tiktok: '',
-      instagram: '',
-      facebook: '',
-      other: '',
-    },
-  });
+
+  const {
+    formData,
+    errors,
+    logoFile,
+    logoPreview,
+    existingLogoKey,
+    handleFieldChange,
+    handleSocialLinkChange,
+    handleLogoSelect,
+    validateForm,
+    prepareDataForSubmission,
+    resetForm,
+  } = useSponsorForm(sponsor, mode);
 
   const { data: sponsorTiers = [] } = useGetSponsorTiersQuery({ eventId });
   const [createSponsor, { isLoading: isCreating }] = useCreateSponsorMutation();
   const [updateSponsor, { isLoading: isUpdating }] = useUpdateSponsorMutation();
   const [uploadImage] = useUploadImageMutation();
 
-  useEffect(() => {
-    if (mode === 'edit' && sponsor) {
-      setFormData({
-        name: sponsor.name,
-        description: sponsor.description || '',
-        websiteUrl: sponsor.website_url || '',
-        contactName: sponsor.contact_name || '',
-        contactEmail: sponsor.contact_email || '',
-        contactPhone: sponsor.contact_phone || '',
-        tierId: sponsor.tier_id || '',
-        socialLinks: sponsor.social_links || {
-          linkedin: '',
-          twitter: '',
-          youtube: '',
-          tiktok: '',
-          instagram: '',
-          facebook: '',
-          other: '',
-        },
-      });
-      setExistingLogoKey(sponsor.logo_url);
-      setLogoPreview(null);
-    }
-  }, [mode, sponsor]);
-
-  const handleFieldChange = (field, value) => {
-    setFormData({ ...formData, [field]: value });
-    
-    // Map frontend field names to schema field names
-    const schemaField = {
-      websiteUrl: 'website_url',
-      contactName: 'contact_name',
-      contactEmail: 'contact_email',
-      contactPhone: 'contact_phone',
-      tierId: 'tier_id',
-    }[field] || field;
-    
-    const validation = validateField(schemaField, value);
-    if (!validation.success) {
-      setErrors({ ...errors, [field]: validation.error.errors[0].message });
-    } else {
-      const newErrors = { ...errors };
-      delete newErrors[field];
-      setErrors(newErrors);
-    }
-  };
-
-  const handleSocialLinkChange = (platform, value) => {
-    setFormData({
-      ...formData,
-      socialLinks: { ...formData.socialLinks, [platform]: value }
-    });
-    
-    const validation = validateSocialLink(platform, value);
-    const errorKey = `social_${platform}`;
-    
-    if (!validation.success) {
-      setErrors({ ...errors, [errorKey]: validation.error.errors[0].message });
-    } else {
-      const newErrors = { ...errors };
-      delete newErrors[errorKey];
-      setErrors(newErrors);
-    }
-  };
 
   const handleSubmit = async () => {
-    // Validate all fields before submission
-    const dataToValidate = {
-      name: formData.name,
-      description: formData.description,
-      website_url: formData.websiteUrl,
-      contact_name: formData.contactName,
-      contact_email: formData.contactEmail,
-      contact_phone: formData.contactPhone,
-      tier_id: formData.tierId,
-      social_links: formData.socialLinks,
-    };
-    
-    const validation = sponsorSchema.safeParse(dataToValidate);
-    
-    if (!validation.success) {
-      const fieldErrors = {};
-      validation.error.errors.forEach(err => {
-        const path = err.path.join('.');
-        // Map schema fields back to frontend field names
-        const frontendField = {
-          'website_url': 'websiteUrl',
-          'contact_name': 'contactName',
-          'contact_email': 'contactEmail',
-          'contact_phone': 'contactPhone',
-          'tier_id': 'tierId',
-        }[path] || path;
-        fieldErrors[frontendField] = err.message;
-      });
-      setErrors(fieldErrors);
-      
+    if (!validateForm()) {
       notifications.show({
         title: 'Validation Error',
         message: 'Please fix the errors in the form',
@@ -163,7 +57,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
       });
       return;
     }
-    
+
     try {
       let logoUrl = null;
 
@@ -177,16 +71,8 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         logoUrl = uploadResult.object_key;
       }
 
-      // Convert empty strings to null and map field names
       const dataToSend = {
-        name: formData.name,
-        description: formData.description || null,
-        website_url: formData.websiteUrl || null,
-        contact_name: formData.contactName || null,
-        contact_email: formData.contactEmail || null,
-        contact_phone: formData.contactPhone || null,
-        tier_id: formData.tierId, // Required field, no null fallback
-        social_links: formData.socialLinks,
+        ...prepareDataForSubmission(),
         ...(logoUrl && { logo_url: logoUrl }),
       };
 
@@ -195,17 +81,23 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         let newDisplayOrder = 10.0;
         if (formData.tierId && sponsors.length > 0) {
           // Find the highest display_order in the selected tier
-          const tierSponsors = sponsors.filter(s => s.tier_id === formData.tierId);
+          const tierSponsors = sponsors.filter(
+            (s) => s.tier_id === formData.tierId
+          );
           if (tierSponsors.length > 0) {
-            const maxOrder = Math.max(...tierSponsors.map(s => s.display_order || 0));
+            const maxOrder = Math.max(
+              ...tierSponsors.map((s) => s.display_order || 0)
+            );
             newDisplayOrder = maxOrder + 10.0;
           }
         } else if (sponsors.length > 0) {
           // No tier selected, just get the highest overall
-          const maxOrder = Math.max(...sponsors.map(s => s.display_order || 0));
+          const maxOrder = Math.max(
+            ...sponsors.map((s) => s.display_order || 0)
+          );
           newDisplayOrder = maxOrder + 10.0;
         }
-        
+
         await createSponsor({
           eventId,
           ...dataToSend,
@@ -236,43 +128,7 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
 
   const handleClose = () => {
     resetForm();
-    setErrors({});
     onClose();
-  };
-
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      description: '',
-      websiteUrl: '',
-      contactName: '',
-      contactEmail: '',
-      contactPhone: '',
-      tierId: '',
-      socialLinks: {
-        linkedin: '',
-        twitter: '',
-        youtube: '',
-        tiktok: '',
-        instagram: '',
-        facebook: '',
-        other: '',
-      },
-    });
-    setLogoFile(null);
-    setLogoPreview(null);
-    setExistingLogoKey(null);
-  };
-
-  const handleLogoSelect = (file) => {
-    setLogoFile(file);
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setLogoPreview(reader.result);
-      };
-      reader.readAsDataURL(file);
-    }
   };
 
   return (
@@ -287,237 +143,40 @@ const SponsorModal = ({ opened, onClose, eventId, mode, sponsor, sponsors = [] }
         header: styles.modalHeader,
       }}
     >
-      <Stack spacing={isMobile ? "sm" : "md"} p={isMobile ? "md" : "lg"}>
-        <Grid>
-          <Grid.Col span={isMobile ? 12 : 8}>
-            <TextInput
-              label="Sponsor Name"
-              placeholder="Enter sponsor name"
-              required
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 4}>
-            <Select
-              label="Tier"
-              placeholder="Select tier"
-              required
-              data={sponsorTiers.map(tier => ({
-                value: tier.id,
-                label: tier.name,
-              }))}
-              value={formData.tierId}
-              onChange={(value) => handleFieldChange('tierId', value)}
-              error={errors.tierId}
-              classNames={{ input: styles.formSelect }}
-            />
-          </Grid.Col>
-        </Grid>
-
-        <Textarea
-          label="Description"
-          placeholder="Enter sponsor description"
-          rows={3}
-          value={formData.description}
-          onChange={(e) => handleFieldChange('description', e.target.value)}
-          error={errors.description}
-          classNames={{ input: styles.formTextarea }}
+      <Stack spacing={isMobile ? 'sm' : 'md'} p={isMobile ? 'md' : 'lg'}>
+        <BasicInfoSection
+          formData={formData}
+          errors={errors}
+          isMobile={isMobile}
+          sponsorTiers={sponsorTiers}
+          onFieldChange={handleFieldChange}
         />
 
-        <TextInput
-          label="Website URL"
-          placeholder="https://example.com"
-          value={formData.websiteUrl}
-          onChange={(e) => handleFieldChange('websiteUrl', e.target.value)}
-          error={errors.websiteUrl}
-          classNames={{ input: styles.formInput }}
+        <LogoUploadSection
+          logoFile={logoFile}
+          logoPreview={logoPreview}
+          existingLogoKey={existingLogoKey}
+          isMobile={isMobile}
+          onLogoSelect={handleLogoSelect}
         />
 
-        <Group className={styles.logoSection}>
-          <Box className={styles.logoUpload}>
-            <Text className={styles.logoLabel}>Logo</Text>
-            <FileButton
-              onChange={handleLogoSelect}
-              accept="image/png,image/jpeg,image/gif,image/webp"
-            >
-              {(props) => (
-                <Button {...props} variant="secondary">
-                  <IconUpload size={16} />
-                  {existingLogoKey || logoPreview ? 'Change Logo' : 'Upload Logo'}
-                </Button>
-              )}
-            </FileButton>
-          </Box>
-          {logoPreview ? (
-            <Image
-              src={logoPreview}
-              alt="Logo preview"
-              width={isMobile ? 60 : 80}
-              height={isMobile ? 60 : 80}
-              fit="contain"
-              className={styles.logoPreview}
-            />
-          ) : existingLogoKey ? (
-            <PrivateImage
-              objectKey={existingLogoKey}
-              alt="Current logo"
-              width={isMobile ? 60 : 80}
-              height={isMobile ? 60 : 80}
-              fit="contain"
-              className={styles.logoPreview}
-            />
-          ) : null}
-        </Group>
+        <ContactInfoSection
+          formData={formData}
+          errors={errors}
+          isMobile={isMobile}
+          expanded={contactExpanded}
+          onExpandedChange={setContactExpanded}
+          onFieldChange={handleFieldChange}
+        />
 
-        {/* Contact Information Section */}
-        {isMobile ? (
-          <Badge
-            variant="light"
-            color="gray"
-            radius="sm"
-            className={styles.collapsibleHeader}
-            onClick={() => setContactExpanded(!contactExpanded)}
-            rightSection={
-              contactExpanded ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />
-            }
-            fullWidth
-          >
-            Contact Information
-          </Badge>
-        ) : (
-          <Text className={styles.sectionTitle}>Contact Information</Text>
-        )}
-        
-        <Collapse in={!isMobile || contactExpanded}>
-        <Grid gutter={isMobile ? "xs" : "md"}>
-          <Grid.Col span={isMobile ? 12 : 4}>
-            <TextInput
-              label="Contact Name"
-              placeholder="John Doe"
-              value={formData.contactName}
-              onChange={(e) => handleFieldChange('contactName', e.target.value)}
-              error={errors.contactName}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 4}>
-            <TextInput
-              label="Contact Email"
-              placeholder="contact@example.com"
-              value={formData.contactEmail}
-              onChange={(e) => handleFieldChange('contactEmail', e.target.value)}
-              error={errors.contactEmail}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 4}>
-            <TextInput
-              label="Contact Phone"
-              placeholder="+1234567890"
-              value={formData.contactPhone}
-              onChange={(e) => handleFieldChange('contactPhone', e.target.value)}
-              error={errors.contactPhone}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-        </Grid>
-        </Collapse>
-
-        {/* Social Media Links Section */}
-        {isMobile ? (
-          <Badge
-            variant="light"
-            color="gray"
-            radius="sm"
-            className={styles.collapsibleHeader}
-            onClick={() => setSocialExpanded(!socialExpanded)}
-            rightSection={
-              socialExpanded ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />
-            }
-            fullWidth
-          >
-            Social Media Links
-          </Badge>
-        ) : (
-          <Text className={styles.sectionTitle}>Social Media Links</Text>
-        )}
-
-        <Collapse in={!isMobile || socialExpanded}>
-        <Grid gutter={isMobile ? "xs" : "md"}>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="LinkedIn"
-              placeholder="https://linkedin.com/company/name"
-              value={formData.socialLinks.linkedin}
-              onChange={(e) => handleSocialLinkChange('linkedin', e.target.value)}
-              error={errors.social_linkedin}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="Twitter"
-              placeholder="https://twitter.com/username"
-              value={formData.socialLinks.twitter}
-              onChange={(e) => handleSocialLinkChange('twitter', e.target.value)}
-              error={errors.social_twitter}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="YouTube"
-              placeholder="https://youtube.com/@channel"
-              value={formData.socialLinks.youtube}
-              onChange={(e) => handleSocialLinkChange('youtube', e.target.value)}
-              error={errors.social_youtube}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="TikTok"
-              placeholder="https://tiktok.com/@username"
-              value={formData.socialLinks.tiktok}
-              onChange={(e) => handleSocialLinkChange('tiktok', e.target.value)}
-              error={errors.social_tiktok}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="Instagram"
-              placeholder="https://instagram.com/username"
-              value={formData.socialLinks.instagram}
-              onChange={(e) => handleSocialLinkChange('instagram', e.target.value)}
-              error={errors.social_instagram}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="Facebook"
-              placeholder="https://facebook.com/page"
-              value={formData.socialLinks.facebook}
-              onChange={(e) => handleSocialLinkChange('facebook', e.target.value)}
-              error={errors.social_facebook}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-          <Grid.Col span={isMobile ? 12 : 6}>
-            <TextInput
-              label="Other"
-              placeholder="https://example.com/profile"
-              value={formData.socialLinks.other}
-              onChange={(e) => handleSocialLinkChange('other', e.target.value)}
-              error={errors.social_other}
-              classNames={{ input: styles.formInput }}
-            />
-          </Grid.Col>
-        </Grid>
-        </Collapse>
+        <SocialLinksSection
+          socialLinks={formData.socialLinks}
+          errors={errors}
+          isMobile={isMobile}
+          expanded={socialExpanded}
+          onExpandedChange={setSocialExpanded}
+          onSocialLinkChange={handleSocialLinkChange}
+        />
 
         <div className={styles.buttonGroup}>
           <Button variant="subtle" onClick={handleClose}>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/useSponsorForm.js
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorModal/useSponsorForm.js
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react';
+import { validateField, validateSocialLink, sponsorSchema } from '../schemas/sponsorSchema';
+
+const useSponsorForm = (sponsor, mode) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    tierId: '',
+    description: '',
+    websiteUrl: '',
+    contactName: '',
+    contactEmail: '',
+    contactPhone: '',
+    socialLinks: {
+      linkedin: '',
+      twitter: '',
+      youtube: '',
+      tiktok: '',
+      instagram: '',
+      facebook: '',
+      other: '',
+    },
+  });
+
+  const [errors, setErrors] = useState({});
+  const [logoFile, setLogoFile] = useState(null);
+  const [logoPreview, setLogoPreview] = useState(null);
+  const [existingLogoKey, setExistingLogoKey] = useState(null);
+
+  // Initialize form data from sponsor when editing
+  useEffect(() => {
+    if (mode === 'edit' && sponsor) {
+      setFormData({
+        name: sponsor.name || '',
+        tierId: sponsor.tier_id || '',
+        description: sponsor.description || '',
+        websiteUrl: sponsor.website_url || '',
+        contactName: sponsor.contact_name || '',
+        contactEmail: sponsor.contact_email || '',
+        contactPhone: sponsor.contact_phone || '',
+        socialLinks: sponsor.social_links || {
+          linkedin: '',
+          twitter: '',
+          youtube: '',
+          tiktok: '',
+          instagram: '',
+          facebook: '',
+          other: '',
+        },
+      });
+      setExistingLogoKey(sponsor.logo_url || null);
+      setLogoPreview(null);
+    }
+  }, [sponsor, mode]);
+
+  const handleFieldChange = (field, value) => {
+    // Special handling for tierId - prevent clearing once set
+    if (field === 'tierId' && !value && formData.tierId) {
+      return; // Don't allow clearing the tier once it's set
+    }
+
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    // Map frontend field names to schema field names
+    const schemaField =
+      {
+        websiteUrl: 'website_url',
+        contactName: 'contact_name',
+        contactEmail: 'contact_email',
+        contactPhone: 'contact_phone',
+        tierId: 'tier_id',
+      }[field] || field;
+
+    const validation = validateField(schemaField, value);
+    if (!validation.success) {
+      setErrors((prev) => ({ ...prev, [field]: validation.error.errors[0].message }));
+    } else {
+      const newErrors = { ...errors };
+      delete newErrors[field];
+      setErrors(newErrors);
+    }
+  };
+
+  const handleSocialLinkChange = (platform, value) => {
+    setFormData((prev) => ({
+      ...prev,
+      socialLinks: { ...prev.socialLinks, [platform]: value },
+    }));
+
+    const validation = validateSocialLink(platform, value);
+    const errorKey = `social_${platform}`;
+
+    if (!validation.success) {
+      setErrors((prev) => ({ ...prev, [errorKey]: validation.error.errors[0].message }));
+    } else {
+      const newErrors = { ...errors };
+      delete newErrors[errorKey];
+      setErrors(newErrors);
+    }
+  };
+
+  const handleLogoSelect = (file) => {
+    setLogoFile(file);
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setLogoPreview(reader.result);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const validateForm = () => {
+    const dataToValidate = {
+      name: formData.name,
+      tier_id: formData.tierId,
+      description: formData.description,
+      website_url: formData.websiteUrl,
+      contact_name: formData.contactName,
+      contact_email: formData.contactEmail,
+      contact_phone: formData.contactPhone,
+      social_links: formData.socialLinks,
+    };
+
+    const validation = sponsorSchema.safeParse(dataToValidate);
+
+    if (!validation.success) {
+      const fieldErrors = {};
+      validation.error.errors.forEach((err) => {
+        const path = err.path.join('.');
+        // Map schema fields back to frontend field names
+        const frontendField =
+          {
+            tier_id: 'tierId',
+            website_url: 'websiteUrl',
+            contact_name: 'contactName',
+            contact_email: 'contactEmail',
+            contact_phone: 'contactPhone',
+          }[path] ||
+          (path.startsWith('social_links.')
+            ? `social_${path.replace('social_links.', '')}`
+            : path);
+        fieldErrors[frontendField] = err.message;
+      });
+      setErrors(fieldErrors);
+      return false;
+    }
+
+    return true;
+  };
+
+  const prepareDataForSubmission = () => {
+    return {
+      name: formData.name,
+      description: formData.description || null,
+      website_url: formData.websiteUrl || null,
+      contact_name: formData.contactName || null,
+      contact_email: formData.contactEmail || null,
+      contact_phone: formData.contactPhone || null,
+      tier_id: formData.tierId,
+      social_links: formData.socialLinks,
+    };
+  };
+
+  const resetForm = () => {
+    setFormData({
+      name: '',
+      tierId: '',
+      description: '',
+      websiteUrl: '',
+      contactName: '',
+      contactEmail: '',
+      contactPhone: '',
+      socialLinks: {
+        linkedin: '',
+        twitter: '',
+        youtube: '',
+        tiktok: '',
+        instagram: '',
+        facebook: '',
+        other: '',
+      },
+    });
+    setLogoFile(null);
+    setLogoPreview(null);
+    setExistingLogoKey(null);
+    setErrors({});
+  };
+
+  return {
+    formData,
+    setFormData,
+    errors,
+    setErrors,
+    logoFile,
+    logoPreview,
+    existingLogoKey,
+    handleFieldChange,
+    handleSocialLinkChange,
+    handleLogoSelect,
+    validateForm,
+    prepareDataForSubmission,
+    resetForm,
+  };
+};
+
+export default useSponsorForm;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/SponsorTierList.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/SponsorTierList.jsx
@@ -1,0 +1,51 @@
+import DroppableTier from '../DroppableTier';
+import SponsorCard from '../SponsorCard';
+import styles from './styles/index.module.css';
+
+const SponsorTierList = ({
+  sortedTierKeys,
+  localItems,
+  tierInfo,
+  sponsorLookup,
+  onEdit
+}) => {
+  return (
+    <div className={styles.sponsorsList}>
+      {sortedTierKeys.map((tierId) => {
+        const tierSponsors = localItems[tierId] || [];
+        const tier = tierInfo[tierId];
+
+        return (
+          <DroppableTier
+            key={tierId}
+            id={tierId}
+            tier={{
+              ...tier,
+              sponsors: tierSponsors
+                .map((id) => sponsorLookup[id])
+                .filter(Boolean),
+            }}
+          >
+            {tierSponsors.map((sponsorId, index) => {
+              const sponsor = sponsorLookup[sponsorId];
+              if (!sponsor) return null;
+
+              return (
+                <SponsorCard
+                  key={sponsorId}
+                  id={sponsorId}
+                  sponsor={sponsor}
+                  tierId={tierId}
+                  index={index}
+                  onEdit={() => onEdit(sponsor)}
+                />
+              );
+            })}
+          </DroppableTier>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SponsorTierList;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/SponsorsEmptyState.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/SponsorsEmptyState.jsx
@@ -1,0 +1,14 @@
+import { Box, Text } from '@mantine/core';
+import styles from './styles/index.module.css';
+
+const SponsorsEmptyState = () => {
+  return (
+    <Box className={styles.emptyState}>
+      <Text c="dimmed" ta="center">
+        {`No sponsors added yet. Click "Add Sponsor" to get started.`}
+      </Text>
+    </Box>
+  );
+};
+
+export default SponsorsEmptyState;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/index.jsx
@@ -1,38 +1,78 @@
-import React, { useState, useMemo, useEffect } from 'react';
-import { Text, Box } from '@mantine/core';
-import { notifications } from '@mantine/notifications';
+import { useState, useMemo, useEffect } from 'react';
 import { DragDropProvider } from '@dnd-kit/react';
-import { move } from '@dnd-kit/helpers';
-import { 
+import {
   useUpdateSponsorMutation,
-  useGetSponsorTiersQuery 
+  useGetSponsorTiersQuery,
 } from '../../../../app/features/sponsors/api';
-import SponsorCard from '../SponsorCard';
-import DroppableTier from '../DroppableTier';
 import SponsorModal from '../SponsorModal';
-import styles from './styles/index.module.css';
+import SponsorsEmptyState from './SponsorsEmptyState';
+import SponsorTierList from './SponsorTierList';
+import useSponsorDragDrop from './useSponsorDragDrop';
 
 const SponsorsList = ({ sponsors, eventId }) => {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [selectedSponsor, setSelectedSponsor] = useState(null);
   const [updateSponsor] = useUpdateSponsorMutation();
   const { data: allTiers = [] } = useGetSponsorTiersQuery({ eventId });
-  const [localItems, setLocalItems] = useState({});
+
+  // Build tier info lookup from all tiers and sponsors
+  const tierInfo = useMemo(() => {
+    const info = {};
+
+    // First add all tiers from the API
+    allTiers.forEach((tier) => {
+      info[tier.id] = {
+        id: tier.id,
+        name: tier.name,
+        description: tier.description,
+        tier_order: tier.order_index || 999,
+        tier_color: tier.color || null,
+      };
+    });
+
+    // Also include any tier info from sponsors (in case of data mismatch)
+    sponsors.forEach((sponsor) => {
+      if (sponsor.tier_id && !info[sponsor.tier_id]) {
+        info[sponsor.tier_id] = {
+          id: sponsor.tier_id,
+          name: sponsor.tier_name || 'Unknown Tier',
+          tier_order: sponsor.tier_order || 999,
+        };
+      }
+    });
+
+    return info;
+  }, [sponsors, allTiers]);
+
+  const sponsorLookup = useMemo(() => {
+    const lookup = {};
+    sponsors.forEach((sponsor) => {
+      lookup[sponsor.id] = sponsor;
+    });
+    return lookup;
+  }, [sponsors]);
+
+  // Use custom hook for drag-drop functionality
+  const { localItems, setLocalItems, handleDragOver, handleDragEnd } = useSponsorDragDrop(
+    sponsorLookup,
+    tierInfo,
+    updateSponsor
+  );
 
   // Initialize local items from sponsors and all tiers
   useEffect(() => {
     const grouped = {};
-    
+
     // First, initialize all tiers (even empty ones)
     allTiers.forEach((tier) => {
       grouped[tier.id] = [];
     });
-    
+
     // Then add sponsors to their respective tiers
     const sortedSponsors = [...sponsors].sort((a, b) => {
       const tierDiff = (a.tier_order || 999) - (b.tier_order || 999);
       if (tierDiff !== 0) return tierDiff;
-      
+
       const aOrder = a.display_order !== null ? a.display_order : 999;
       const bOrder = b.display_order !== null ? b.display_order : 999;
       return aOrder - bOrder;
@@ -48,191 +88,17 @@ const SponsorsList = ({ sponsors, eventId }) => {
         grouped[tierKey].push(sponsor.id);
       }
     });
-    
+
     setLocalItems(grouped);
-  }, [sponsors, allTiers]);
+  }, [sponsors, allTiers, setLocalItems]);
 
-  // Create lookups
-  const tierInfo = useMemo(() => {
-    const info = {};
-    
-    // Add all tiers from API
-    allTiers.forEach((tier) => {
-      info[tier.id] = {
-        id: tier.id,
-        name: tier.name,
-        tier_order: tier.order_index || 999,
-        tier_color: tier.color || null,
-      };
-    });
-    
-    // Also include any tier info from sponsors (in case of data mismatch)
-    sponsors.forEach((sponsor) => {
-      if (sponsor.tier_id && !info[sponsor.tier_id]) {
-        info[sponsor.tier_id] = {
-          id: sponsor.tier_id,
-          name: sponsor.tier_name || 'Unknown Tier',
-          tier_order: sponsor.tier_order || 999,
-        };
-      }
-    });
-    
-    return info;
-  }, [sponsors, allTiers]);
-
-  const sponsorLookup = useMemo(() => {
-    const lookup = {};
-    sponsors.forEach((sponsor) => {
-      lookup[sponsor.id] = sponsor;
-    });
-    return lookup;
-  }, [sponsors]);
-
-  const handleDragOver = (event) => {
-    // Use the move helper to update local state during drag
-    setLocalItems((items) => move(items, event));
-  };
-
-  const handleDragEnd = async (event) => {
-    console.log('Drag end event:', event);
-    const { operation } = event;
-    
-    if (!operation) return;
-    
-    const { source, target } = operation;
-    
-    // Extract the sponsor ID and tier information
-    const draggedSponsorId = source.id;
-    const draggedSponsor = sponsorLookup[draggedSponsorId];
-    
-    if (!draggedSponsor) {
-      console.error('Could not find sponsor with id:', draggedSponsorId);
-      return;
-    }
-
-    // Find which tier the sponsor is now in
-    let newTierId = null;
-    let newIndex = 0;
-    
-    for (const [tierId, sponsorIds] of Object.entries(localItems)) {
-      const index = sponsorIds.indexOf(draggedSponsorId);
-      if (index !== -1) {
-        newTierId = tierId;
-        newIndex = index;
-        break;
-      }
-    }
-
-    if (newTierId === null) {
-      console.error('Could not find sponsor in any tier after drag');
-      return;
-    }
-
-    // Calculate new display_order based on position
-    let newDisplayOrder;
-    const tierSponsors = localItems[newTierId] || [];
-    
-    if (newIndex === 0) {
-      // Moving to the beginning
-      const firstSponsor = tierSponsors.length > 1 ? sponsorLookup[tierSponsors[1]] : null;
-      newDisplayOrder = firstSponsor ? (firstSponsor.display_order || 10) / 2 : 1;
-    } else if (newIndex === tierSponsors.length - 1) {
-      // Moving to the end
-      const prevSponsor = sponsorLookup[tierSponsors[newIndex - 1]];
-      newDisplayOrder = prevSponsor ? (prevSponsor.display_order || newIndex) + 1 : newIndex + 1;
-    } else {
-      // Moving between two sponsors
-      const prevSponsor = sponsorLookup[tierSponsors[newIndex - 1]];
-      const nextSponsor = sponsorLookup[tierSponsors[newIndex + 1]];
-      
-      if (prevSponsor && nextSponsor) {
-        const prevOrder = prevSponsor.display_order || newIndex;
-        const nextOrder = nextSponsor.display_order || newIndex + 2;
-        newDisplayOrder = (prevOrder + nextOrder) / 2;
-      } else {
-        newDisplayOrder = newIndex + 1;
-      }
-    }
-
-    // Check if tier changed
-    const oldTierId = draggedSponsor.tier_id || 'no-tier';
-    const tierChanged = oldTierId.toString() !== newTierId.toString();
-
-    console.log('Tier change check:', {
-      oldTierId,
-      newTierId,
-      tierChanged,
-      draggedSponsor
-    });
-
-    try {
-      const updateData = {
-        sponsorId: draggedSponsorId,
-        display_order: newDisplayOrder,
-      };
-
-      // If moving to a different tier
-      if (tierChanged) {
-        // Make sure we're passing the correct tier_id format
-        if (newTierId === 'no-tier') {
-          updateData.tier_id = null;
-        } else {
-          // Parse as integer only if it's a valid number
-          const parsedTierId = parseInt(newTierId);
-          updateData.tier_id = isNaN(parsedTierId) ? newTierId : parsedTierId;
-        }
-      }
-
-      console.log('Updating sponsor with data:', updateData);
-      await updateSponsor(updateData).unwrap();
-
-      if (tierChanged) {
-        const sourceTierName = tierInfo[oldTierId]?.name || 'No Tier';
-        const targetTierName = tierInfo[newTierId]?.name || 'No Tier';
-        notifications.show({
-          title: 'Success',
-          message: `Moved ${draggedSponsor.name} from ${sourceTierName} to ${targetTierName}`,
-          color: 'green',
-        });
-      }
-    } catch (error) {
-      console.error('Error updating sponsor:', error);
-      notifications.show({
-        title: 'Error',
-        message: error.data?.message || 'Failed to reorder sponsor',
-        color: 'red',
-      });
-      
-      // Revert the local state on error
-      setLocalItems((items) => {
-        const newItems = { ...items };
-        // Remove from current position
-        Object.keys(newItems).forEach(key => {
-          newItems[key] = newItems[key].filter(id => id !== draggedSponsorId);
-        });
-        // Add back to original position
-        if (!newItems[oldTierId]) {
-          newItems[oldTierId] = [];
-        }
-        newItems[oldTierId].push(draggedSponsorId);
-        return newItems;
-      });
-    }
-  };
-
-  const handleEditClick = (sponsor) => {
+  const handleEdit = (sponsor) => {
     setSelectedSponsor(sponsor);
     setEditModalOpen(true);
   };
 
   if (sponsors.length === 0) {
-    return (
-      <Box className={styles.emptyState}>
-        <Text c="dimmed" ta="center">
-          No sponsors added yet. Click "Add Sponsor" to get started.
-        </Text>
-      </Box>
-    );
+    return <SponsorsEmptyState />;
   }
 
   // Sort tier keys by tier_order
@@ -245,52 +111,25 @@ const SponsorsList = ({ sponsors, eventId }) => {
   return (
     <>
       <DragDropProvider onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
-        <div className={styles.sponsorsList}>
-          {sortedTierKeys.map((tierId) => {
-            const tierSponsors = localItems[tierId] || [];
-            const tier = tierInfo[tierId];
-            
-            return (
-              <DroppableTier
-                key={tierId}
-                id={tierId}
-                tier={{
-                  ...tier,
-                  sponsors: tierSponsors.map(id => sponsorLookup[id]).filter(Boolean)
-                }}
-              >
-                {tierSponsors.map((sponsorId, index) => {
-                  const sponsor = sponsorLookup[sponsorId];
-                  if (!sponsor) return null;
-                  
-                  return (
-                    <SponsorCard
-                      key={sponsorId}
-                      id={sponsorId}
-                      sponsor={sponsor}
-                      tierId={tierId}
-                      index={index}
-                      onEdit={handleEditClick}
-                    />
-                  );
-                })}
-              </DroppableTier>
-            );
-          })}
-        </div>
+        <SponsorTierList
+          sortedTierKeys={sortedTierKeys}
+          localItems={localItems}
+          tierInfo={tierInfo}
+          sponsorLookup={sponsorLookup}
+          onEdit={handleEdit}
+        />
       </DragDropProvider>
 
-      {editModalOpen && (
+      {editModalOpen && selectedSponsor && (
         <SponsorModal
+          eventId={eventId}
+          sponsor={selectedSponsor}
+          mode="edit"
           opened={editModalOpen}
           onClose={() => {
             setEditModalOpen(false);
             setSelectedSponsor(null);
           }}
-          eventId={eventId}
-          mode="edit"
-          sponsor={selectedSponsor}
-          sponsors={sponsors}
         />
       )}
     </>

--- a/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/useSponsorDragDrop.js
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/SponsorsList/useSponsorDragDrop.js
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { move } from '@dnd-kit/helpers';
+import { notifications } from '@mantine/notifications';
+
+const useSponsorDragDrop = (sponsorLookup, tierInfo, updateSponsor) => {
+  const [localItems, setLocalItems] = useState({});
+
+  const handleDragOver = (event) => {
+    // Use the move helper to update local state during drag
+    setLocalItems((items) => move(items, event));
+  };
+
+  const handleDragEnd = async (event) => {
+    console.log('Drag end event:', event);
+    const { operation } = event;
+
+    if (!operation) return;
+
+    const { source } = operation;
+
+    // Extract the sponsor ID and tier information
+    const draggedSponsorId = source.id;
+    const draggedSponsor = sponsorLookup[draggedSponsorId];
+
+    if (!draggedSponsor) {
+      console.error('Could not find sponsor with id:', draggedSponsorId);
+      return;
+    }
+
+    // Find which tier the sponsor is now in
+    let newTierId = null;
+    let newIndex = 0;
+
+    for (const [tierId, sponsorIds] of Object.entries(localItems)) {
+      const index = sponsorIds.indexOf(draggedSponsorId);
+      if (index !== -1) {
+        newTierId = tierId;
+        newIndex = index;
+        break;
+      }
+    }
+
+    if (!newTierId) {
+      console.error('Could not determine new tier for sponsor');
+      return;
+    }
+
+    // Get all sponsor IDs in the new tier (after the move)
+    const sponsorIdsInNewTier = localItems[newTierId] || [];
+
+    // Calculate new display_order based on position
+    let newDisplayOrder;
+
+    if (sponsorIdsInNewTier.length === 1) {
+      // Only sponsor in tier (just moved here)
+      newDisplayOrder = 10;
+    } else if (newIndex === 0) {
+      // Moved to beginning
+      const nextId = sponsorIdsInNewTier[1];
+      const nextSponsor = nextId ? sponsorLookup[nextId] : null;
+      newDisplayOrder = nextSponsor ? nextSponsor.display_order / 2 : 5;
+    } else if (newIndex === sponsorIdsInNewTier.length - 1) {
+      // Moved to end
+      const prevId = sponsorIdsInNewTier[newIndex - 1];
+      const prevSponsor = prevId ? sponsorLookup[prevId] : null;
+      newDisplayOrder = prevSponsor ? prevSponsor.display_order + 10 : (newIndex + 1) * 10;
+    } else {
+      // Moved between two sponsors
+      const prevId = sponsorIdsInNewTier[newIndex - 1];
+      const nextId = sponsorIdsInNewTier[newIndex + 1];
+      const prevSponsor = prevId ? sponsorLookup[prevId] : null;
+      const nextSponsor = nextId ? sponsorLookup[nextId] : null;
+
+      if (prevSponsor && nextSponsor) {
+        newDisplayOrder = (prevSponsor.display_order + nextSponsor.display_order) / 2;
+      } else {
+        newDisplayOrder = (newIndex + 1) * 10;
+      }
+    }
+
+    // Tier IDs are strings (e.g., "platinum", "gold", "silver")
+    const oldTierId = draggedSponsor.tier_id || null;
+    const newTierIdStr = newTierId; // Keep as string
+
+    console.log('Moving sponsor:', {
+      sponsorId: draggedSponsor.id,
+      sponsorName: draggedSponsor.name,
+      fromTier: oldTierId,
+      toTier: newTierIdStr,
+      newIndex,
+      newDisplayOrder
+    });
+
+    // Check if tier actually changed
+    const tierChanged = oldTierId !== newTierIdStr;
+
+    try {
+      // Update the sponsor in the backend
+      await updateSponsor({
+        sponsorId: draggedSponsor.id,
+        tier_id: newTierIdStr, // Send as string
+        display_order: newDisplayOrder,
+      }).unwrap();
+
+      if (tierChanged) {
+        const sourceTierName = tierInfo[oldTierId]?.name || 'No Tier';
+        const targetTierName = tierInfo[newTierId]?.name || 'No Tier';
+
+        notifications.show({
+          message: `Moved ${draggedSponsor.name} from ${sourceTierName} to ${targetTierName}`,
+          color: 'green',
+        });
+      } else {
+        notifications.show({
+          message: `Reordered ${draggedSponsor.name} within ${tierInfo[newTierId]?.name || 'tier'}`,
+          color: 'green',
+        });
+      }
+    } catch (error) {
+      console.error('Failed to update sponsor:', error);
+      notifications.show({
+        title: 'Error',
+        message: error.data?.message || 'Failed to update sponsor position',
+        color: 'red',
+      });
+
+      // Revert local state on error
+      const grouped = {};
+
+      // Re-initialize all tiers
+      Object.keys(tierInfo).forEach((tierId) => {
+        grouped[tierId] = [];
+      });
+
+      // Re-add sponsors to their original positions
+      Object.values(sponsorLookup).forEach((sponsor) => {
+        if (sponsor.tier_id) {
+          const tierKey = sponsor.tier_id;
+          if (!grouped[tierKey]) {
+            grouped[tierKey] = [];
+          }
+          grouped[tierKey].push(sponsor.id);
+        }
+      });
+
+      setLocalItems(grouped);
+    }
+  };
+
+  return {
+    localItems,
+    setLocalItems,
+    handleDragOver,
+    handleDragEnd,
+  };
+};
+
+export default useSponsorDragDrop;

--- a/frontend/src/pages/EventAdmin/SponsorsManager/index.jsx
+++ b/frontend/src/pages/EventAdmin/SponsorsManager/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Text } from '@mantine/core';
 import { LoadingOverlay } from '../../../shared/components/loading';
 import { useParams } from 'react-router-dom';
@@ -15,9 +15,14 @@ const SponsorsManager = () => {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [tierModalOpen, setTierModalOpen] = useState(false);
 
-  const { data: sponsors = [], isLoading, error, refetch } = useGetSponsorsQuery({ 
-    eventId: parseInt(eventId), 
-    activeOnly: false 
+  const {
+    data: sponsors = [],
+    isLoading,
+    error,
+    refetch,
+  } = useGetSponsorsQuery({
+    eventId: parseInt(eventId),
+    activeOnly: false,
   });
 
   if (error) {
@@ -25,17 +30,14 @@ const SponsorsManager = () => {
       <div className={styles.container}>
         <div className={styles.bgShape1} />
         <div className={styles.bgShape2} />
-        
+
         <div className={styles.contentWrapper}>
           <section className={styles.mainContent}>
             <div style={{ textAlign: 'center', padding: '3rem' }}>
               <Text c="red" size="lg" mb="md">
                 Error loading sponsors: {error.data?.message || 'Unknown error'}
               </Text>
-              <Button 
-                variant="primary"
-                onClick={refetch}
-              >
+              <Button variant="primary" onClick={refetch}>
                 Retry
               </Button>
             </div>
@@ -61,11 +63,8 @@ const SponsorsManager = () => {
         {/* Main Content Section */}
         <section className={styles.mainContent}>
           <LoadingOverlay visible={isLoading} />
-          
-          <SponsorsList 
-            sponsors={sponsors} 
-            eventId={parseInt(eventId)}
-          />
+
+          <SponsorsList sponsors={sponsors} eventId={parseInt(eventId)} />
         </section>
 
         <SponsorModal


### PR DESCRIPTION
- Break down large SponsorModal into focused components:
  - BasicInfoSection for name, tier, description, and URL
  - ContactInfoSection for contact details
  - SocialLinksSection for social media links
  - LogoUploadSection for logo upload functionality
  - useSponsorForm hook for form state and validation logic

- Refactor SponsorsList for cleaner separation:
  - SponsorTierList for tier-based sponsor display
  - SponsorsEmptyState for empty state UI
  - useSponsorDragDrop hook for drag-and-drop logic

- Add protection against tier deselection with clearable=false and allowDeselect=false
- Maintain existing Zod validation throughout refactoring
- Follow established component organization patterns

