### PR TITLE
revert: change Docker images back to Docker Hub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:15
+        image: postgres:15
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -34,7 +34,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: redis:7
         ports:
           - 6379:6379
         options: >-
@@ -182,7 +182,7 @@ jobs:
 
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:15
+        image: postgres:15
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -194,7 +194,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: redis:7
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s


### PR DESCRIPTION
Docker Hub is experiencing an outage, but AWS ECR wasn't the solution. Reverting to original Docker Hub images to maintain consistency. Will retry CI/CD once Docker Hub is back online.

