### PR TITLE
fix: ensure deployment waits for tests to pass

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,9 +1,11 @@
 name: Build and Deploy Atria
 
 on:
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Test Suite"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:  # Keep manual trigger option
 
 env:
   BACKEND_IMAGE: sbtl/atria-backend
@@ -12,6 +14,11 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Only run if tests passed (or manual trigger)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     outputs:
       image-tag: ${{ steps.generate-tag.outputs.tag }}
     steps:
@@ -63,7 +70,7 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
     - name: Deploy to k3s server
       uses: appleboy/ssh-action@v1.0.0
@@ -74,25 +81,25 @@ jobs:
         port: ${{ secrets.K3S_PORT }}
         script: |
           IMAGE_TAG="${{ needs.build-and-push.outputs.image-tag }}"
-          
+
           # Set KUBECONFIG to use user's config
           export KUBECONFIG=$HOME/.kube/config
-          
+
           # Pull the new images with specific tag
           echo "Pulling new Docker images with tag: ${IMAGE_TAG}"
           sudo k3s crictl pull ${{ env.BACKEND_IMAGE }}:${IMAGE_TAG}
           sudo k3s crictl pull ${{ env.FRONTEND_IMAGE }}:${IMAGE_TAG}
-          
+
           # Update deployments with specific image tag
           echo "Updating Kubernetes deployments..."
           kubectl set image deployment/backend-deployment backend=${{ env.BACKEND_IMAGE }}:${IMAGE_TAG} -n atria
           kubectl set image deployment/frontend-deployment frontend=${{ env.FRONTEND_IMAGE }}:${IMAGE_TAG} -n atria
-          
+
           # Wait for rollout to complete
           echo "Waiting for backend rollout..."
           kubectl rollout status deployment/backend-deployment -n atria --timeout=300s
-          
+
           echo "Waiting for frontend rollout..."
           kubectl rollout status deployment/frontend-deployment -n atria --timeout=300s
-          
+
           echo "Deployment completed successfully!"


### PR DESCRIPTION
Changed deployment workflow to trigger only after Test Suite completes successfully. This prevents deploying code that may have runtime errors even if it builds successfully.

- Deploy now waits for test completion
- Only deploys if tests pass
- Manual workflow_dispatch still available for emergency deploys

