### PR TITLE
ci: skip tests and deployment for documentation changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,22 @@ name: Test Suite
 on:
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
   workflow_dispatch:  # Allow manual triggering
 
 env:


### PR DESCRIPTION
Added path filters to test workflow to ignore:
- Markdown files (README, docs)
- License files
- Git configuration
- GitHub templates

This prevents unnecessary CI runs when only documentation is updated, saving build time and resources.

