### PR TITLE
fix: remove form from useEffect dependencies to prevent infinite loops

### DIFF
--- a/frontend/src/pages/Organizations/OrganizationDashboard/MembersSection/MembersList/index.jsx
+++ b/frontend/src/pages/Organizations/OrganizationDashboard/MembersSection/MembersList/index.jsx
@@ -180,7 +180,7 @@ const MembersList = ({ orgId, searchQuery, roleFilter, currentUserRole }) => {
             <tbody>
               {filteredMembers.map((member) => (
                 <MemberRow
-                  key={member.id}
+                  key={member.user_id}
                   member={member}
                   orgId={orgId}
                   currentUserRole={currentUserRole}
@@ -194,7 +194,7 @@ const MembersList = ({ orgId, searchQuery, roleFilter, currentUserRole }) => {
         <div className={styles.memberCards}>
           {filteredMembers.map((member) => (
             <MemberCard
-              key={member.id}
+              key={member.user_id}
               member={member}
               currentUserRole={currentUserRole}
               onRoleUpdate={handleRoleUpdate}

--- a/frontend/src/pages/Profile/index.jsx
+++ b/frontend/src/pages/Profile/index.jsx
@@ -102,7 +102,9 @@ export const ProfilePage = () => {
         },
       });
     }
-  }, [userProfile, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userProfile]);
 
   // Parallax effect for background shapes
   useEffect(() => {

--- a/frontend/src/pages/Settings/components/PrivacySettings/EventOverrides.jsx
+++ b/frontend/src/pages/Settings/components/PrivacySettings/EventOverrides.jsx
@@ -95,7 +95,9 @@ const EventOverrides = () => {
       form.reset();
       setOriginalValues(null);
     }
-  }, [overridesData, selectedEventId, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overridesData, selectedEventId]);
 
   // Track changes
   useEffect(() => {

--- a/frontend/src/pages/Settings/components/PrivacySettings/index.jsx
+++ b/frontend/src/pages/Settings/components/PrivacySettings/index.jsx
@@ -66,7 +66,9 @@ const PrivacySettings = () => {
       form.setValues(privacyData.privacy_settings);
       setOriginalValues(privacyData.privacy_settings);
     }
-  }, [privacyData, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [privacyData]);
 
   // Track changes
   useEffect(() => {

--- a/frontend/src/shared/components/modals/event/EventModal/index.jsx
+++ b/frontend/src/shared/components/modals/event/EventModal/index.jsx
@@ -65,14 +65,19 @@ export const EventModal = ({
     ) {
       form.setFieldValue('end_date', form.values.start_date);
     }
-  }, [form.values.start_date, form.values.event_type, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // The form object from useForm is stable, but including it triggers updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.values.start_date, form.values.event_type]);
 
   // Reset form when modal is closed
   useEffect(() => {
     if (!opened) {
       form.reset();
     }
-  }, [opened, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened]);
 
   const availableEventTypes = allowConferences
     ? EVENT_TYPES

--- a/frontend/src/shared/components/modals/organization/InviteUserModal/index.jsx
+++ b/frontend/src/shared/components/modals/organization/InviteUserModal/index.jsx
@@ -39,7 +39,9 @@ export const InviteUserModal = ({ organizationId, opened, onClose }) => {
         lastName: userExists.user.last_name,
       });
     }
-  }, [userExists, form]);
+    // IMPORTANT: DO NOT add 'form' to dependencies - it causes infinite re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userExists]);
 
   const handleSubmit = async (values) => {
     try {


### PR DESCRIPTION
The Mantine useForm hook's form object was causing infinite re-renders when included in useEffect dependency arrays. This blocked navigation and other UI interactions.

Fixed in:
- EventModal (2 instances)
- EventOverrides.jsx
- PrivacySettings/index.jsx
- Profile/index.jsx
- InviteUserModal/index.jsx
- MembersList key prop warning (using user_id instead of undefined id)

Added explicit comments to prevent ESLint from re-adding these dependencies.

