### PR TITLE
fix(frontend): correct typing indicator alignment and animation

### DIFF
--- a/frontend/src/shared/components/chat/TypingIndicator/styles.module.css
+++ b/frontend/src/shared/components/chat/TypingIndicator/styles.module.css
@@ -2,7 +2,7 @@
 
 /* Container - aligns like a received message (other user's side) */
 .typingIndicator {
-  align-self: flex-end;
+  align-self: flex-start;
   animation: fadeIn 0.3s ease;
 }
 
@@ -18,7 +18,7 @@
   }
 }
 
-/* Bubble - matches incoming message style (from right side) */
+/* Bubble - matches incoming message style (from left side) */
 .typingBubble {
   display: flex;
   align-items: center;
@@ -26,7 +26,7 @@
   gap: 4px;
   padding: 10px 14px;
   border-radius: 16px;
-  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
@@ -44,9 +44,9 @@
   animation: bounce 1.4s infinite ease-in-out;
 }
 
-/* Staggered animation delays for each dot (reversed: 3, 2, 1) */
+/* Staggered animation delays for each dot (left to right: 1, 2, 3) */
 .dot:nth-child(1) {
-  animation-delay: 0.4s;
+  animation-delay: 0s;
 }
 
 .dot:nth-child(2) {
@@ -54,7 +54,7 @@
 }
 
 .dot:nth-child(3) {
-  animation-delay: 0s;
+  animation-delay: 0.4s;
 }
 
 /* Bounce animation - smooth up and down motion */


### PR DESCRIPTION
Fixes typing indicator to display on left side like incoming messages:
- Changed alignment from right (flex-end) to left (flex-start)
- Moved bubble tail from bottom-right to bottom-left
- Reversed dot animation order to go left-to-right (1, 2, 3)

