### PR TITLE
perf(backend): optimize DM thread queries with batch shared events lo…

### DIFF
--- a/frontend/src/app/store/chatSlice.js
+++ b/frontend/src/app/store/chatSlice.js
@@ -72,7 +72,9 @@ const chatSlice = createSlice({
       }
     },
     setCurrentEventId: (state, action) => {
+      console.log('🔴 Redux: setCurrentEventId called with:', action.payload, 'type:', typeof action.payload);
       state.currentEventId = action.payload;
+      console.log('🔴 Redux: currentEventId now set to:', state.currentEventId);
     },
     // Mobile chat tab actions
     setActiveTab: (state, action) => {

--- a/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/NetworkingManager/ChatRoomRow/index.jsx
@@ -72,10 +72,6 @@ const ChatRoomRow = ({ room, color, onEdit, isTableRow, isMobile }) => {
     navigate(`/app/events/${room.event_id}/networking?tab=chat&room=${room.id}`);
   };
 
-  // Show indicator if room has recent activity
-  const hasRecentActivity = room.last_activity && 
-    new Date(room.last_activity) > new Date(Date.now() - 3600000); // Within last hour
-
   // Mobile card layout
   if (isMobile) {
     return (

--- a/frontend/src/pages/Networking/ChatArea/index.jsx
+++ b/frontend/src/pages/Networking/ChatArea/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo, useRef, useCallback } from 'react';
+import { useState, useEffect, memo, useRef } from 'react';
 import { Text, Stack, Center } from '@mantine/core';
 import { LoadingSpinner } from '../../../shared/components/loading';
 import { IconHash, IconLock, IconGlobe, IconMicrophone } from '@tabler/icons-react';
@@ -64,6 +64,7 @@ function ChatAreaComponent({ eventId: eventIdProp }) {
         console.log(`⚠️ ChatArea unmounting: No active room to leave (ref was null)`);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty deps = only on true mount/unmount, uses ref to avoid closure issues
 
   // Extract chat rooms from paginated response and sort them

--- a/frontend/src/shared/components/chat/ChatSidebar/index.jsx
+++ b/frontend/src/shared/components/chat/ChatSidebar/index.jsx
@@ -35,23 +35,16 @@ function ChatSidebar() {
     }
   }, [eventId, dispatch]);
 
-  // Fetch threads - pass eventId when in event context for efficient filtering
-  const { data, isLoading, error } = useGetDirectMessageThreadsQuery(
-    currentEventId ? { eventId: currentEventId } : undefined
-  );
+  // Fetch threads - ALWAYS query with undefined (single cache approach)
+  // Backend now ALWAYS returns all threads with complete shared_event_ids metadata
+  const { data, isLoading, error } = useGetDirectMessageThreadsQuery(undefined); // Explicit undefined for consistent cache key!
 
   // Extract threads array from the response
   // The backend sends { threads: [...] }
   const threadsArray = data?.threads || data || [];
 
   // Filter threads based on context using shared hook
-  // Note: Backend now includes shared_event_ids in each thread, so we don't need to fetch event users
-  const filteredThreads = useThreadFiltering(
-    threadsArray, 
-    currentEventId, 
-    new Set(), // Empty set since we use shared_event_ids from backend
-    true // Enable debug logs for desktop version
-  );
+  const filteredThreads = useThreadFiltering(threadsArray, currentEventId);
 
   // Handle thread click
   const handleThreadClick = (threadId) => {

--- a/frontend/src/shared/components/chat/ChatWindow/index.jsx
+++ b/frontend/src/shared/components/chat/ChatWindow/index.jsx
@@ -68,7 +68,8 @@ function ChatWindow({ threadId }) {
     if (isNearBottom) {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [isOtherUserTyping]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOtherUserTyping]); // Refs are stable and don't need to be in deps
 
   // Handle window controls
   const handleClose = () => {

--- a/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
+++ b/frontend/src/shared/components/chat/MobileChatContainer/index.jsx
@@ -84,17 +84,13 @@ function MobileChatContainer() {
     }
   }, [eventId, sessionIdFromUrl, dispatch]);
 
-  // Get threads for sidebar - pass eventId when in event context for efficient filtering
-  const { 
-    data, 
-    isLoading: threadsLoading 
-  } = useGetDirectMessageThreadsQuery(
-    currentEventId ? { eventId: currentEventId } : undefined
-  );
+  // Get threads for sidebar - ALWAYS query with undefined (single cache approach)
+  // Backend now ALWAYS returns all threads with complete shared_event_ids metadata
+  const {
+    data,
+    isLoading: threadsLoading
+  } = useGetDirectMessageThreadsQuery(undefined); // Explicit undefined for consistent cache key!
 
-  // No longer need to fetch event users separately since backend provides shared_event_ids
-  // when we pass the event_id parameter to getDirectMessageThreads
-  
   // Fetch event data for permissions
   const { data: eventData } = useGetEventQuery(currentEventId, {
     skip: !currentEventId
@@ -103,16 +99,8 @@ function MobileChatContainer() {
   // Extract threads array from the response
   const threadsArray = data?.threads || data || [];
 
-  // No longer need eventUserIds since backend provides shared_event_ids
-  const eventUserIds = new Set();
-
   // Filter threads based on context using shared hook
-  const filteredThreads = useThreadFiltering(
-    threadsArray, 
-    currentEventId, 
-    eventUserIds, 
-    false // Disable debug logs for mobile version
-  );
+  const filteredThreads = useThreadFiltering(threadsArray, currentEventId);
 
   const handleThreadClick = (threadId) => {
     setActiveThreadId(threadId);

--- a/frontend/src/shared/components/chat/MobileChatSidebar/index.jsx
+++ b/frontend/src/shared/components/chat/MobileChatSidebar/index.jsx
@@ -44,6 +44,7 @@ function MobileChatSidebar({
   const unreadCount = (threads || []).filter(
     (thread) => thread.unread_count > 0
   ).length;
+  console.log('📱 MobileChatSidebar - threads.length:', threads?.length, 'unreadCount:', unreadCount, 'threads with unread:', threads?.map(t => ({ id: t.id, unread: t.unread_count })));
 
   return (
     <div

--- a/frontend/src/shared/components/chat/MobileChatWindow/index.jsx
+++ b/frontend/src/shared/components/chat/MobileChatWindow/index.jsx
@@ -63,7 +63,8 @@ function MobileChatWindow({ threadId, onClose }) {
     if (isNearBottom) {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [isOtherUserTyping]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOtherUserTyping]); // Refs are stable and don't need to be in deps
 
 
   const handleSendMessage = () => {

--- a/frontend/src/shared/hooks/useThreadFiltering.js
+++ b/frontend/src/shared/hooks/useThreadFiltering.js
@@ -3,70 +3,37 @@ import { useMemo } from 'react';
 
 /**
  * Custom hook for filtering chat threads based on event context
- * 
+ *
  * Handles the complex logic for determining which threads to show based on:
  * - Current event context (event vs general view)
  * - Thread scope (event-scoped vs global threads)
- * - User membership in events
- * 
- * @param {Array} threadsArray - Array of thread objects
+ * - User membership in events (via shared_event_ids from backend)
+ *
+ * @param {Array} threadsArray - Array of thread objects with shared_event_ids metadata
  * @param {number|null} currentEventId - Current event ID, null for general view
- * @param {Set} eventUserIds - Set of user IDs who are members of the current event
- * @param {boolean} enableDebugLogs - Whether to log filtering decisions (default: false)
- * 
  * @returns {Array} Filtered array of threads appropriate for the current context
  */
-export function useThreadFiltering(threadsArray, currentEventId, eventUserIds, enableDebugLogs = false) {
+export function useThreadFiltering(threadsArray, currentEventId) {
   return useMemo(() => {
-    if (enableDebugLogs) {
-      console.log('Filtering threads - currentEventId:', currentEventId);
-      console.log('All threads:', threadsArray);
-      console.log('Event user IDs:', Array.from(eventUserIds));
-    }
+    if (!threadsArray) return [];
 
     if (!currentEventId) {
-      // General context: Show only global threads (event_scope_id is null/undefined)
-      // Exclude event-scoped threads from general view
-      const filtered = threadsArray.filter((thread) => {
-        const isGlobalThread = !thread.event_scope_id;
-        
-        if (enableDebugLogs) {
-          console.log('General - Thread:', thread.id, 'event_scope_id:', thread.event_scope_id, 'isGlobal:', isGlobalThread);
+      // General tab: only show global threads (no event_scope_id)
+      return threadsArray.filter(thread => !thread.event_scope_id);
+    } else {
+      // Event tab: show threads where users share this event
+      return threadsArray.filter(thread => {
+        // Show event-scoped threads for this event
+        if (thread.event_scope_id === currentEventId) return true;
+
+        // Show global threads where the other user is in this event
+        // Backend ALWAYS provides shared_event_ids array (empty array [] if no shared events)
+        if (!thread.event_scope_id && thread.shared_event_ids?.includes(currentEventId)) {
+          return true;
         }
-        
-        return isGlobalThread;
+
+        return false;
       });
-      
-      return filtered;
     }
-
-    // Event context: Show threads with users who are in the current event
-    // This includes both global threads (for connected users) and event-scoped threads
-    const filtered = threadsArray.filter((thread) => {
-      const otherUserId = thread.other_user?.id;
-      const isEventScopedThread = thread.event_scope_id === currentEventId;
-      
-      // Use shared_event_ids if available (more efficient than checking eventUserIds)
-      let userInEvent;
-      if (thread.shared_event_ids) {
-        userInEvent = thread.shared_event_ids.includes(currentEventId);
-      } else {
-        // Fallback to old method if backend hasn't been updated
-        userInEvent = otherUserId && eventUserIds.has(otherUserId);
-      }
-      
-      // Show thread if:
-      // 1. It's scoped to this specific event, OR
-      // 2. It's a global thread with a user who's in this event
-      const shouldShow = isEventScopedThread || (!thread.event_scope_id && userInEvent);
-      
-      if (enableDebugLogs) {
-        console.log('Event - Thread:', thread.id, 'event_scope_id:', thread.event_scope_id, 'other user:', otherUserId, 'shared events:', thread.shared_event_ids, 'in event:', userInEvent, 'show:', shouldShow);
-      }
-      
-      return shouldShow;
-    });
-
-    return filtered;
-  }, [threadsArray, currentEventId, eventUserIds, enableDebugLogs]);
+  }, [threadsArray, currentEventId]);
 }


### PR DESCRIPTION
…okup

Add get_batch_shared_events() method to eliminate N+1 query problem when
fetching shared events for multiple user pairs. Uses single query with
subquery + join instead of individual queries per thread.

Changes:
- Add get_batch_shared_events() for efficient bulk event lookup
- Always include shared_event_ids metadata on all threads
- Maintains backwards compatibility with other_user_in_event field
- Single cache approach on backend enables frontend simplification

Performance: Reduces N queries to 1 query for thread lists with N threads