### PR TITLE
test: add timezone field to event creation fixtures

### DIFF
--- a/backend/atria/tests/test_integration/test_chat_integration.py
+++ b/backend/atria/tests/test_integration/test_chat_integration.py
@@ -45,7 +45,8 @@ class TestChatIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Test Company'
+                'company_name': 'Test Company',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']
@@ -782,7 +783,8 @@ class TestChatIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Silent Co'
+                'company_name': 'Silent Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']

--- a/backend/atria/tests/test_integration/test_connection_integration.py
+++ b/backend/atria/tests/test_integration/test_connection_integration.py
@@ -57,7 +57,8 @@ class TestConnectionIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Network Co'
+                'company_name': 'Network Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']
@@ -180,7 +181,8 @@ class TestConnectionIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'DM Co'
+                'company_name': 'DM Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']
@@ -460,7 +462,8 @@ class TestConnectionIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Summit Co'
+                'company_name': 'Summit Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']
@@ -578,7 +581,8 @@ class TestConnectionIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Tech Co'
+                'company_name': 'Tech Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']

--- a/backend/atria/tests/test_integration/test_dm_integration.py
+++ b/backend/atria/tests/test_integration/test_dm_integration.py
@@ -53,7 +53,8 @@ class TestDirectMessageIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Network Co'
+                'company_name': 'Network Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']
@@ -313,7 +314,8 @@ class TestDirectMessageIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': (utc_now + timedelta(days=30)).isoformat(),
                 'end_date': (utc_now + timedelta(days=31)).isoformat(),
-                'company_name': 'Scope Co'
+                'company_name': 'Scope Co',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']

--- a/backend/atria/tests/test_integration/test_event_integration.py
+++ b/backend/atria/tests/test_integration/test_event_integration.py
@@ -37,7 +37,8 @@ class TestEventIntegration:
             'event_type': 'CONFERENCE',
             'start_date': future_start.isoformat(),
             'end_date': future_end.isoformat(),
-            'company_name': 'Test Company'
+            'company_name': 'Test Company',
+            'timezone': 'UTC'
         }
         data.update(overrides)
         return data

--- a/backend/atria/tests/test_integration/test_session_integration.py
+++ b/backend/atria/tests/test_integration/test_session_integration.py
@@ -35,7 +35,8 @@ class TestSessionIntegration:
             'event_type': 'CONFERENCE',
             'start_date': future_start.isoformat(),
             'end_date': future_end.isoformat(),
-            'company_name': 'Test Company'
+            'company_name': 'Test Company',
+            'timezone': 'UTC'
         }
         data.update(overrides)
         return data
@@ -470,7 +471,8 @@ class TestSessionIntegration:
                 'event_type': 'CONFERENCE',
                 'start_date': start_date.isoformat(),
                 'end_date': end_date.isoformat(),
-                'company_name': 'Test Corp'
+                'company_name': 'Test Corp',
+                'timezone': 'UTC'
             }
         )
         event_id = json.loads(event_response.data)['id']


### PR DESCRIPTION
Update all event creation test fixtures to include timezone field, which is now required by EventCreateSchema.

Changes:
- Add 'timezone': 'UTC' to event creation payloads
- Update test fixtures in:
  - test_event_integration.py (_get_event_data helper)
  - test_session_integration.py (_get_event_data helper + inline)
  - test_chat_integration.py (_create_event_with_session + inline)
  - test_connection_integration.py (4 inline creations)
  - test_dm_integration.py (2 inline creations)

Fixes 33 failing integration tests that were broken by the required timezone field addition in EventCreateSchema.

