### PR TITLE
feat(analytics): integrate Plausible Analytics with backend proxy

### DIFF
--- a/backend/atria/api/api/routes/__init__.py
+++ b/backend/atria/api/api/routes/__init__.py
@@ -18,6 +18,7 @@ from .uploads import blp as uploads_blp
 from .invitations import blp as invitations_blp
 from .moderation import blp as moderation_blp
 from .health import blp as health_blp
+from .analytics import blp as analytics_blp
 
 __all__ = [
     # User blueprints
@@ -50,6 +51,8 @@ __all__ = [
     "moderation_blp",
     # Health check blueprint
     "health_blp",
+    # Analytics blueprint
+    "analytics_blp",
 ]
 
 
@@ -91,3 +94,5 @@ def register_blueprints(api):
     api.register_blueprint(invitations_blp)
     # Moderation
     api.register_blueprint(moderation_blp)
+    # Analytics (register last - no auth required, public endpoint)
+    api.register_blueprint(analytics_blp)

--- a/backend/atria/api/api/routes/analytics.py
+++ b/backend/atria/api/api/routes/analytics.py
@@ -1,0 +1,148 @@
+"""Analytics proxy routes for Plausible Analytics.
+
+This module provides proxy endpoints for Plausible analytics to bypass
+ad blockers while preserving user privacy. Plausible is privacy-focused,
+GDPR-compliant, and does not use cookies or collect personal data.
+"""
+from flask import request, Response
+from flask.views import MethodView
+from flask_smorest import Blueprint
+import requests
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Create Flask-Smorest blueprint to match Atria's pattern
+blp = Blueprint(
+    "analytics",
+    __name__,
+    url_prefix="/api/anonstats",
+    description="Analytics proxy endpoints"
+)
+
+# Plausible configuration
+PLAUSIBLE_BASE_URL = "https://plausible.sbtl.dev"
+PLAUSIBLE_SCRIPT_BASE = f"{PLAUSIBLE_BASE_URL}/js"
+PLAUSIBLE_EVENT_URL = f"{PLAUSIBLE_BASE_URL}/api/event"
+
+# Timeout for requests to Plausible
+REQUEST_TIMEOUT = 30
+
+
+@blp.route("/js/<path:script_name>")
+class AnalyticsScriptProxy(MethodView):
+    @blp.doc(
+        summary="Proxy Plausible analytics script",
+        description=(
+            "Proxies the Plausible analytics script to bypass ad blockers. "
+            "Returns JavaScript content or a harmless fallback on error."
+        ),
+        responses={
+            200: {"description": "Analytics script content"},
+        },
+    )
+    def get(self, script_name):
+        """Proxy Plausible analytics scripts"""
+        try:
+            # Construct the full URL to the Plausible script
+            script_url = f"{PLAUSIBLE_SCRIPT_BASE}/{script_name}"
+
+            # Fetch the script from Plausible
+            resp = requests.get(script_url, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+
+            # Return the script with appropriate headers
+            return Response(
+                resp.content,
+                status=resp.status_code,
+                headers={
+                    "Content-Type": "application/javascript",
+                    "Cache-Control": "public, max-age=3600",
+                    "X-Proxied-From": "plausible.sbtl.dev",
+                }
+            )
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to fetch analytics script: {e}")
+            # Return a minimal fallback that won't break the page
+            return Response(
+                'console.warn("Analytics script unavailable");',
+                status=200,
+                headers={"Content-Type": "application/javascript"}
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            return Response(
+                'console.warn("Analytics script unavailable");',
+                status=200,
+                headers={"Content-Type": "application/javascript"}
+            )
+
+
+@blp.route("/event")
+class AnalyticsEventProxy(MethodView):
+    @blp.doc(
+        summary="Proxy Plausible analytics events",
+        description=(
+            "Forwards analytics events to Plausible while preserving "
+            "client IP for accurate geolocation tracking."
+        ),
+        responses={
+            200: {"description": "Event forwarded successfully"},
+        },
+    )
+    def post(self):
+        """Forward analytics event to Plausible"""
+        try:
+            # Get the request body
+            body = request.get_data()
+
+            # Get the real client IP for geolocation
+            forwarded = request.headers.get("X-Forwarded-For", "")
+            client_ip = forwarded.split(",")[0].strip()
+            if not client_ip:
+                client_ip = request.remote_addr or ""
+
+            # Prepare headers for Plausible
+            headers = {
+                "Content-Type": request.headers.get(
+                    "Content-Type", "application/json"
+                ),
+                "User-Agent": request.headers.get("User-Agent", ""),
+                "X-Forwarded-For": request.headers.get(
+                    "X-Forwarded-For", request.remote_addr
+                ),
+                "X-Forwarded-Proto": request.headers.get(
+                    "X-Forwarded-Proto", "https"
+                ),
+                "X-Forwarded-Host": "atria.gg",
+                "X-Plausible-IP": client_ip,
+            }
+
+            # Forward the event to Plausible
+            resp = requests.post(
+                PLAUSIBLE_EVENT_URL,
+                data=body,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT
+            )
+
+            # Return Plausible's response
+            return Response(
+                resp.content,
+                status=resp.status_code,
+                headers={
+                    "Content-Type": resp.headers.get(
+                        "Content-Type", "application/json"
+                    ),
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to forward event: {e}")
+            # Return success to prevent client-side errors
+            return Response(
+                '{"status":"ok"}',
+                status=200,
+                headers={"Content-Type": "application/json"}
+            )

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,6 +76,15 @@
     />
 
     <title>atria</title>
+
+    <!-- Plausible Analytics (proxied through backend to bypass ad blockers) -->
+    <!-- Privacy-focused, GDPR compliant, no cookies, no personal data collection -->
+    <script
+      defer
+      data-domain="atria.gg"
+      data-api="/api/anonstats/event"
+      src="/api/anonstats/js/script.file-downloads.outbound-links.js"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/pages/Landing/Footer/index.jsx
+++ b/frontend/src/pages/Landing/Footer/index.jsx
@@ -26,7 +26,7 @@ const Footer = () => {
             </motion.a>
 
             <motion.a
-              href="https://www.linkedin.com/in/stevenglab/"
+              href="https://www.linkedin.com/company/atria-dot-gg/"
               whileHover={{ scale: 1.1 }}
               whileTap={{ scale: 0.95 }}
               className={styles.socialLink}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -82,16 +82,22 @@ export default defineConfig(({ mode }) => ({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://atria-api:5000',
+        target: 'http://traefik',
         changeOrigin: true,
         secure: false,
+        headers: {
+          Host: 'localhost',
+        },
       },
       '/socket.io': {
         // Socket.io proxy configuration
-        target: 'http://atria-api:5000',
+        target: 'http://traefik',
         changeOrigin: true,
         secure: false,
         ws: true, // Critical for WebSockets
+        headers: {
+          Host: 'localhost',
+        },
       },
     },
   },


### PR DESCRIPTION
Add privacy-focused analytics using Plausible with backend proxying to bypass ad blockers while maintaining user privacy.

Backend changes:
- Create analytics proxy blueprint with MethodView pattern
- Proxy Plausible script endpoint: /api/anonstats/js/<script_name>
- Proxy analytics events endpoint: /api/anonstats/event
- Preserve client IP via X-Forwarded-For and X-Plausible-IP headers
- Graceful error handling (returns harmless fallback on failure)
- Register analytics blueprint in routes/__init__.py

Frontend changes:
- Add Plausible script tag to index.html
- Configure for atria.gg domain tracking
- Track pageviews, file downloads, and outbound links
- Script loads via proxied backend endpoint

Development environment fixes:
- Update Vite proxy to use Traefik service instead of non-existent atria-api
- Add explicit Host: localhost header for Traefik routing
- Fix Socket.IO proxy configuration

Other updates:
- Update Landing page footer LinkedIn link to company page (https://www.linkedin.com/company/atria-dot-gg/)

Notes:
- Plausible filters localhost traffic by design (no dev analytics)
- Production will work correctly with atria.gg domain
- Backend proxy prevents ad blocker blocking
- GDPR compliant, no cookies, no personal data collection

