### PR TITLE
fix(frontend): resolve ESLint warnings in vite config and error pages

### DIFF
--- a/frontend/src/pages/Errors/NotFound.jsx
+++ b/frontend/src/pages/Errors/NotFound.jsx
@@ -84,8 +84,7 @@ export const NotFound = () => {
         {/* Main Message */}
         <h1 className={styles.errorTitle}>Page Not Found</h1>
         <p className={styles.errorMessage}>
-          Looks like you've ventured into uncharted territory! The page you're
-          looking for doesn't exist or may have been moved.
+          {"Looks like you've ventured into uncharted territory! The page you're looking for doesn't exist or may have been moved."}
         </p>
 
         {/* Suggestions */}

--- a/frontend/src/shared/components/ErrorBoundary/index.jsx
+++ b/frontend/src/shared/components/ErrorBoundary/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { Button } from '@/shared/components/buttons';
 import styles from './styles.module.css';
 
@@ -18,7 +18,7 @@ class ErrorBoundary extends Component {
     };
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError() {
     // Update state so the next render will show the fallback UI
     return { hasError: true };
   }
@@ -75,8 +75,7 @@ class ErrorBoundary extends Component {
             {/* Error Message */}
             <h1 className={styles.errorTitle}>Oops! Something went wrong</h1>
             <p className={styles.errorMessage}>
-              We encountered an unexpected error. Don't worry — your data is safe,
-              and we're working to fix this.
+              {"We encountered an unexpected error. Don't worry — your data is safe, and we're working to fix this."}
             </p>
 
             {/* Error Details (for development) */}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -67,9 +67,6 @@ export default defineConfig(({ mode }) => ({
         },
         // Optimize chunk naming for better debugging
         chunkFileNames: (chunkInfo) => {
-          const facadeModuleId = chunkInfo.facadeModuleId
-            ? chunkInfo.facadeModuleId.split('/').pop()
-            : 'chunk';
           return `assets/${chunkInfo.name}-[hash].js`;
         },
       },


### PR DESCRIPTION
- Remove unused facadeModuleId variable in vite.config.js
- Remove unused React import from ErrorBoundary (use Component only)
- Remove unused error parameter from getDerivedStateFromError
- Escape apostrophes in JSX strings using curly brace syntax
  - ErrorBoundary: "Don't worry" message
  - NotFound: "you've" and "doesn't" in user message

