### PR TITLE
fix(frontend): fix date parsing in Agenda and other components

### DIFF
--- a/frontend/src/pages/Agenda/DateNavigation/index.jsx
+++ b/frontend/src/pages/Agenda/DateNavigation/index.jsx
@@ -3,6 +3,7 @@ import styles from './styles/index.module.css';
 import PropTypes from 'prop-types';
 import { format, addDays } from 'date-fns';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { parseDateOnly } from '@/shared/hooks/formatDate';
 
 export const DateNavigation = ({
   startDate,
@@ -11,7 +12,7 @@ export const DateNavigation = ({
   onDateChange,
 }) => {
   const dates = Array.from({ length: dayCount }, (_, i) =>
-    addDays(new Date(startDate), i)
+    addDays(parseDateOnly(startDate), i)
   );
 
   const currentDate = dates[currentDay - 1];

--- a/frontend/src/pages/Dashboard/InvitationsSection/InvitationCard.jsx
+++ b/frontend/src/pages/Dashboard/InvitationsSection/InvitationCard.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../../app/features/eventInvitations/api';
 import { Button } from '../../../shared/components/buttons/Button';
 import { formatDistanceToNow } from 'date-fns';
+import { parseDateOnly } from '@/shared/hooks/formatDate';
 import { getRoleDisplayName } from '../../EventAdmin/AttendeesManager/schemas/attendeeSchemas';
 import styles from './styles/InvitationCard.module.css';
 
@@ -142,7 +143,7 @@ function InvitationCard({ invitation, type }) {
             <Text size="sm" color="dimmed">
               {invitation.event.organization.name} •{' '}
               {invitation.event.start_date
-                ? new Date(invitation.event.start_date).toLocaleDateString(
+                ? parseDateOnly(invitation.event.start_date).toLocaleDateString(
                     'en-US',
                     {
                       month: 'short',

--- a/frontend/src/pages/Organizations/OrganizationDashboard/EventsSection/index.jsx
+++ b/frontend/src/pages/Organizations/OrganizationDashboard/EventsSection/index.jsx
@@ -4,6 +4,7 @@ import { IconFileText, IconGlobe, IconArchive, IconCalendar, IconPlus, IconChevr
 import { useGetEventsQuery } from '../../../../app/features/events/api';
 import { Button } from '../../../../shared/components/buttons';
 import { EventModal } from '../../../../shared/components/modals/event/EventModal';
+import { parseDateOnly } from '@/shared/hooks/formatDate';
 import EventCard from './EventCard';
 import styles from './styles/index.module.css';
 
@@ -43,11 +44,11 @@ const EventsSection = ({ orgId, currentUserRole }) => {
 
     // Sort events
     // Draft and Published: by start_date ascending (soonest first)
-    groups.draft.sort((a, b) => new Date(a.start_date) - new Date(b.start_date));
-    groups.published.sort((a, b) => new Date(a.start_date) - new Date(b.start_date));
-    
+    groups.draft.sort((a, b) => parseDateOnly(a.start_date) - parseDateOnly(b.start_date));
+    groups.published.sort((a, b) => parseDateOnly(a.start_date) - parseDateOnly(b.start_date));
+
     // Archived: by start_date descending (most recent first)
-    groups.archived.sort((a, b) => new Date(b.start_date) - new Date(a.start_date));
+    groups.archived.sort((a, b) => parseDateOnly(b.start_date) - parseDateOnly(a.start_date));
 
     return groups;
   }, [data?.events]);

--- a/frontend/src/shared/components/modals/session/EditSessionModal/index.jsx
+++ b/frontend/src/shared/components/modals/session/EditSessionModal/index.jsx
@@ -13,6 +13,7 @@ import {
   useCreateSessionMutation,
   useUpdateSessionMutation,
 } from '@/app/features/sessions/api';
+import { parseDateOnly } from '@/shared/hooks/formatDate';
 import { useGetEventQuery } from '@/app/features/events/api';
 import { Button } from '@/shared/components/buttons';
 import { editSessionSchema } from './schemas/editSessionSchema';
@@ -37,10 +38,10 @@ const CHAT_MODES = [
 const getEventDays = (event) => {
   if (!event?.start_date || !event?.end_date) return [];
 
-  const start = new Date(event.start_date);
-  const end = new Date(event.end_date);
+  const start = parseDateOnly(event.start_date);
+  const end = parseDateOnly(event.end_date);
   const days = [];
-  let currentDate = start;
+  let currentDate = new Date(start);
   let dayNumber = 1;
 
   while (currentDate <= end) {


### PR DESCRIPTION
Fixed timezone-related date parsing issues in several components that were still using `new Date(dateString)` which interprets date-only strings as UTC midnight, causing off-by-one errors.

Updated components to use centralized `parseDateOnly()` utility:

1. Agenda DateNavigation: Fixed event day calculation
   - Was showing wrong dates for multi-day events

2. EditSessionModal: Fixed day dropdown generation
   - Session day options now show correct dates

3. OrganizationDashboard EventsSection: Fixed event sorting
   - Events now sort correctly by date

4. InvitationCard: Fixed event date display
   - Event invitations now show correct start date

Changes:
- frontend/src/pages/Agenda/DateNavigation/index.jsx
- frontend/src/shared/components/modals/session/EditSessionModal/index.jsx
- frontend/src/pages/Organizations/OrganizationDashboard/EventsSection/index.jsx
- frontend/src/pages/Dashboard/InvitationsSection/InvitationCard.jsx

