### PR TITLE
fix: enforce CSP headers and resolve nginx add_header inheritance issue

### DIFF
--- a/deploy/Dockerfile.frontend.prod
+++ b/deploy/Dockerfile.frontend.prod
@@ -21,6 +21,8 @@ RUN rm -rf /etc/nginx/conf.d/*
 
 # Copy custom nginx config
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/security-headers.conf /etc/nginx/conf.d/security-headers.conf
+COPY frontend/csp-header.conf /etc/nginx/conf.d/csp-header.conf
 
 # Copy built files from builder
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/frontend/csp-header.conf
+++ b/frontend/csp-header.conf
@@ -1,0 +1,4 @@
+# Content Security Policy - Enforcing mode
+# This file is included in nginx.conf at both server and location block levels
+# to work around nginx's add_header inheritance behavior
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://player.vimeo.com https://f.vimeocdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://api.dicebear.com https://storage.sbtl.dev https://i.vimeocdn.com https:; connect-src 'self' wss://atria.gg https://storage.sbtl.dev https://player.vimeo.com https://fresnel.vimeocdn.com; frame-src 'self' https://player.vimeo.com; media-src https://vod-progressive.akamaized.net https://gcs-vimeo.akamaized.net; worker-src 'self' blob:; child-src 'self' blob: https://player.vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,11 +4,9 @@ server {
     root /usr/share/nginx/html;
 
     # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    # Test version first - reports but doesn't block
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' https://player.vimeo.com https://f.vimeocdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://api.dicebear.com https://storage.sbtl.dev https://i.vimeocdn.com https:; connect-src 'self' wss://atria.gg https://storage.sbtl.dev https://player.vimeo.com https://fresnel.vimeocdn.com; frame-src 'self' https://player.vimeo.com; media-src https://vod-progressive.akamaized.net https://gcs-vimeo.akamaized.net; worker-src 'self' blob:; child-src 'self' blob: https://player.vimeo.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    # Note: All headers must be repeated in location blocks due to nginx add_header inheritance
+    include security-headers.conf;
+    include csp-header.conf;
 
     # Enable gzip compression
     gzip on;
@@ -21,6 +19,8 @@ server {
     location ~* \.(js|css)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include security-headers.conf;
+        include csp-header.conf;
         access_log off;
     }
 
@@ -28,6 +28,8 @@ server {
     location ~* \.(woff|woff2|ttf|otf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include security-headers.conf;
+        include csp-header.conf;
         access_log off;
     }
 
@@ -35,6 +37,8 @@ server {
     location ~* \.(jpg|jpeg|png|gif|ico|svg|webp)$ {
         expires 30d;
         add_header Cache-Control "public, max-age=2592000";
+        include security-headers.conf;
+        include csp-header.conf;
         access_log off;
     }
 
@@ -42,18 +46,24 @@ server {
     location ~* \.(html)$ {
         expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include security-headers.conf;
+        include csp-header.conf;
     }
 
     # Don't cache service worker
     location = /sw.js {
         expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include security-headers.conf;
+        include csp-header.conf;
     }
 
     # Health check endpoint (useful for k8s)
     location = /health {
         access_log off;
         add_header Content-Type text/plain;
+        include security-headers.conf;
+        include csp-header.conf;
         return 200 "healthy\n";
     }
 
@@ -61,10 +71,12 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
 
-        # Security headers for HTML
+        # Cache headers for HTML
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+        include security-headers.conf;
+        include csp-header.conf;
     }
 
     # Deny access to hidden files (except .well-known)

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -1,0 +1,7 @@
+# Basic security headers
+# Note: In production these are also set by Traefik middleware, but included here for self-hosting
+# This file is included in nginx.conf at both server and location block levels
+# to work around nginx's add_header inheritance behavior
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;


### PR DESCRIPTION
- Created security-headers.conf for basic security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection)
- Created csp-header.conf for Content Security Policy
- Changed CSP from report-only to enforcing mode
- Added both include files to all location blocks to work around nginx's add_header inheritance behavior
- Updated production Dockerfile to copy both include files
- Added note that Traefik handles these in production, but included for self-hosting

This fixes the issue where CSP headers were being overridden by location-level add_header directives. Single source of truth for each header type makes updates easier.

