### PR TITLE
fix: correct nginx include file paths in Dockerfile

### DIFF
--- a/deploy/Dockerfile.frontend.prod
+++ b/deploy/Dockerfile.frontend.prod
@@ -21,8 +21,8 @@ RUN rm -rf /etc/nginx/conf.d/*
 
 # Copy custom nginx config
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
-COPY frontend/security-headers.conf /etc/nginx/conf.d/security-headers.conf
-COPY frontend/csp-header.conf /etc/nginx/conf.d/csp-header.conf
+COPY frontend/security-headers.conf /etc/nginx/security-headers.conf
+COPY frontend/csp-header.conf /etc/nginx/csp-header.conf
 
 # Copy built files from builder
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Copy security-headers.conf and csp-header.conf to /etc/nginx/ instead of /etc/nginx/conf.d/ so that the include directives in nginx.conf can find them correctly.

