### PR TITLE
feat(dashboard): add scrollable organizations list with alphabetical …

### DIFF
--- a/backend/atria/api/services/dashboard.py
+++ b/backend/atria/api/services/dashboard.py
@@ -105,10 +105,12 @@ class DashboardService:
 
     @staticmethod
     def _get_user_organizations(user_id: int):
-        """Get user's organizations with role and basic stats"""
-        org_users = OrganizationUser.query.filter_by(user_id=user_id).options(
+        """Get user's organizations with role and basic stats (alphabetically ordered, case-insensitive)"""
+        org_users = OrganizationUser.query.filter_by(user_id=user_id).join(
+            Organization
+        ).options(
             joinedload(OrganizationUser.organization)
-        ).all()
+        ).order_by(func.lower(Organization.name).asc()).all()
 
         organizations = []
         for org_user in org_users:

--- a/frontend/src/pages/Dashboard/OrganizationsSection/styles/index.module.css
+++ b/frontend/src/pages/Dashboard/OrganizationsSection/styles/index.module.css
@@ -15,7 +15,7 @@
 
 /* Card System Classes */
 .cardList {
-  composes: card-list from '../../../../styles/design-tokens.css';
+  composes: card-list-scrollable from '../../../../styles/design-tokens.css';
 }
 
 .card {

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -242,6 +242,50 @@
   gap: clamp(0.75rem, 2vw, 1rem);
 }
 
+/* Scrollable Card List - For sections with many cards (5+ items) */
+.card-list-scrollable {
+  composes: card-list;
+  max-height: 550px !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  padding-right: 4px; /* Space for scrollbar */
+}
+
+/* Custom scrollbar styling for scrollable card lists */
+.card-list-scrollable::-webkit-scrollbar {
+  width: 8px;
+}
+
+.card-list-scrollable::-webkit-scrollbar-track {
+  background: rgba(139, 92, 246, 0.02);
+  border-radius: 4px;
+}
+
+.card-list-scrollable::-webkit-scrollbar-thumb {
+  background: rgba(139, 92, 246, 0.15);
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.card-list-scrollable::-webkit-scrollbar-thumb:hover {
+  background: rgba(139, 92, 246, 0.25);
+}
+
+/* Firefox scrollbar styling */
+.card-list-scrollable {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139, 92, 246, 0.15) rgba(139, 92, 246, 0.02);
+}
+
+/* Disable max-height on mobile/tablet - allow natural page scrolling */
+@media (max-width: 1023px) {
+  .card-list-scrollable {
+    max-height: none !important;
+    overflow-y: visible !important;
+    padding-right: 0;
+  }
+}
+
 /* Empty State */
 .empty-state {
   text-align: center;


### PR DESCRIPTION
…sorting

- Add reusable .card-list-scrollable class to design tokens
  - Max height of 550px (~5 cards) on desktop with custom purple scrollbar
  - Disabled on mobile/tablet for natural page scrolling
  - Proper !important overrides for Mantine compatibility

- Update OrganizationsSection to use scrollable card list
  - Improves UX for users with many organizations

- Add alphabetical sorting to organizations query
  - Case-insensitive sorting using func.lower()
  - Organizations now display in predictable A-Z order
  - Makes scrollable list easier to scan and navigate

