### PR TITLE
fix: add hydrated class to AppLayout to prevent layout flash on hard …

### DIFF
--- a/frontend/src/app/router/layouts/AppLayout/index.jsx
+++ b/frontend/src/app/router/layouts/AppLayout/index.jsx
@@ -45,6 +45,12 @@ export const AppLayout = () => {
 
   const showEventNav = Boolean(eventId);
 
+  // Mark body as hydrated for app pages to prevent layout flash on hard refresh
+  useEffect(() => {
+    document.body.classList.add('hydrated');
+    return () => document.body.classList.remove('hydrated');
+  }, []);
+
   // Initialize socket when authenticated
   useEffect(() => {
     console.log('🔐 AppLayout useEffect - Auth check:', { isAuthenticated, hasUser: !!user });


### PR DESCRIPTION
…refresh

Add .hydrated class management to AppLayout component. Prevents width-shift flash on hard refresh for authenticated app pages (Settings, Events, Agenda, etc.) by marking body as hydrated when AppLayout mounts.

Landing page unaffected - uses scoped critical CSS with body[data-page='landing'] selectors.

