### PR TITLE
fix: prevent layout flash on hard refresh for app pages

### DIFF
--- a/frontend/src/app/router/layouts/AppLayout/index.jsx
+++ b/frontend/src/app/router/layouts/AppLayout/index.jsx
@@ -45,6 +45,12 @@ export const AppLayout = () => {
 
   const showEventNav = Boolean(eventId);
 
+  // Mark body as hydrated for app pages to prevent layout flash on hard refresh
+  useEffect(() => {
+    document.body.classList.add('hydrated');
+    return () => document.body.classList.remove('hydrated');
+  }, []);
+
   // Initialize socket when authenticated
   useEffect(() => {
     console.log('🔐 AppLayout useEffect - Auth check:', { isAuthenticated, hasUser: !!user });


### PR DESCRIPTION
## Summary

Hotfix for layout width-shift flash on hard refresh for authenticated app pages.

## Problem

When hard refreshing on app pages (Settings, Events, Agenda, etc.), CSS modules haven't loaded yet, causing the layout to appear "skinny" until React hydrates and CSS loads. Normal navigation works fine because React and CSS are already loaded.

Bug only appears on hard refresh (Cmd+Shift+R / Ctrl+Shift+R), which is why it wasn't caught initially.

## Solution

Add `.hydrated` class management to `AppLayout` component:
- Adds `.hydrated` when AppLayout mounts (prevents flash)
- Removes `.hydrated` when AppLayout unmounts (clean lifecycle)
- Only affects authenticated app pages (landing page unaffected)

## Why No Conflicts with Landing Page

Landing page critical CSS uses scoped selectors like `body[data-page="landing"]:not(.hydrated)`. App pages never get the `data-page="landing"` attribute, so no interference.

## Files Changed

- `frontend/src/app/router/layouts/AppLayout/index.jsx` - Added hydration marker useEffect

## Testing

- ✅ Tested on local dev environment
- ✅ Tested on dev.atria.gg
- ✅ Hard refresh on Settings page - no width shift
- ✅ Hard refresh on Events page - no width shift
- ✅ Normal navigation still works
- ✅ Landing page unaffected