### PR TITLE
fix: register pagination schemas to resolve broken OpenAPI refs

### DIFF
--- a/backend/atria/api/routes/chat_rooms.py
+++ b/backend/atria/api/routes/chat_rooms.py
@@ -25,7 +25,7 @@ from api.commons.decorators import (
 from api.commons.pagination import (
     paginate,
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.services.chat_room import ChatRoomService
 
@@ -60,7 +60,7 @@ class ChatRoomList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("chat_rooms", "ChatRoomBase"),
+            200: get_pagination_doc_reference("ChatRoomBase"),
             403: {"description": "Not authorized to access this event"},
             404: {"description": "Event not found"},
         },
@@ -227,7 +227,7 @@ class ChatMessageList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("messages", "ChatMessageBase"),
+            200: get_pagination_doc_reference("ChatMessageBase"),
             403: {"description": "Not authorized to access this chat room"},
             404: {"description": "Chat room not found"},
         },

--- a/backend/atria/api/routes/connections.py
+++ b/backend/atria/api/routes/connections.py
@@ -11,7 +11,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
     paginate,
 )
 from api.models import User
@@ -44,7 +44,7 @@ class ConnectionList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("connections", "ConnectionBase"),
+            200: get_pagination_doc_reference("ConnectionBase"),
         },
     )
     @jwt_required()
@@ -166,7 +166,7 @@ class PendingConnectionList(MethodView):
         description="Get all pending connection requests received by the current user",
         parameters=PAGINATION_PARAMETERS,
         responses={
-            200: get_pagination_schema("connections", "ConnectionBase"),
+            200: get_pagination_doc_reference("ConnectionBase"),
         },
     )
     @jwt_required()
@@ -187,7 +187,7 @@ class EventConnectionList(MethodView):
         description="Get all users connected with the current user who are also in this event",
         parameters=PAGINATION_PARAMETERS,
         responses={
-            200: get_pagination_schema("users", "UserBase"),
+            200: get_pagination_doc_reference("UserBase"),
             403: {"description": "Not authorized to access this event"},
             404: {"description": "Event not found"},
         },

--- a/backend/atria/api/routes/direct_messages.py
+++ b/backend/atria/api/routes/direct_messages.py
@@ -14,7 +14,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.services.direct_message import DirectMessageService
 
@@ -34,7 +34,7 @@ class DirectMessageThreadList(MethodView):
         description="Get all direct message threads for the current user",
         parameters=PAGINATION_PARAMETERS,
         responses={
-            200: get_pagination_schema("threads", "DirectMessageThreadBase"),
+            200: get_pagination_doc_reference("DirectMessageThreadBase"),
         },
     )
     @jwt_required()

--- a/backend/atria/api/routes/event_invitations.py
+++ b/backend/atria/api/routes/event_invitations.py
@@ -11,7 +11,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
     paginate,
 )
 from api.commons.decorators import (
@@ -46,7 +46,7 @@ class EventInvitationList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("invitations", "EventInvitationBase"),
+            200: get_pagination_doc_reference("EventInvitationDetail"),
             403: {"description": "Not authorized to view invitations"},
             404: {"description": "Event not found"},
         },

--- a/backend/atria/api/routes/event_users.py
+++ b/backend/atria/api/routes/event_users.py
@@ -15,7 +15,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.commons.decorators import (
     event_member_required,
@@ -90,7 +90,7 @@ class EventUserList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("event_users", "EventUserBase"),
+            200: get_pagination_doc_reference("EventUserBase"),
             403: {"description": "Not authorized to view event users"},
             404: {"description": "Event not found"},
         },
@@ -207,7 +207,7 @@ class EventUserAdminList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("event_users", "EventUserAdmin"),
+            200: get_pagination_doc_reference("EventUserAdmin"),
             403: {"description": "Not authorized to view admin details"},
             404: {"description": "Event not found"},
         },

--- a/backend/atria/api/routes/events.py
+++ b/backend/atria/api/routes/events.py
@@ -19,7 +19,7 @@ from api.commons.decorators import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.services.event import EventService
 
@@ -50,7 +50,7 @@ class EventList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("events", "EventBase"),
+            200: get_pagination_doc_reference("EventBase"),
             404: {"description": "Organization not found"},
         },
     )

--- a/backend/atria/api/routes/organization_invitations.py
+++ b/backend/atria/api/routes/organization_invitations.py
@@ -11,7 +11,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
     paginate,
 )
 from api.commons.decorators import (
@@ -47,7 +47,7 @@ class OrganizationInvitationList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("invitations", "OrganizationInvitationBase"),
+            200: get_pagination_doc_reference("OrganizationInvitationDetail"),
             403: {"description": "Not authorized to view invitations"},
             404: {"description": "Organization not found"},
         },

--- a/backend/atria/api/routes/organization_users.py
+++ b/backend/atria/api/routes/organization_users.py
@@ -13,7 +13,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.commons.decorators import org_admin_required, org_member_required
 from api.services.organization_user import OrganizationUserService
@@ -50,9 +50,7 @@ class OrganizationUserList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema(
-                "organization_users", "OrganizationUserBase"
-            ),
+            200: get_pagination_doc_reference("OrganizationUser"),
             403: {"description": "Not authorized to view organization users"},
             404: {"description": "Organization not found"},
         },

--- a/backend/atria/api/routes/organizations.py
+++ b/backend/atria/api/routes/organizations.py
@@ -13,7 +13,7 @@ from api.schemas import (
 from api.commons.decorators import org_admin_required, org_member_required
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.services.organization import OrganizationService
 
@@ -94,7 +94,7 @@ class OrganizationList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("organizations", "OrganizationBase"),
+            200: get_pagination_doc_reference("OrganizationBase"),
             401: {"description": "Not authenticated"},
             403: {"description": "Not authorized"},
         },

--- a/backend/atria/api/routes/session_speakers.py
+++ b/backend/atria/api/routes/session_speakers.py
@@ -14,7 +14,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.commons.decorators import (
     event_member_required,
@@ -54,9 +54,7 @@ class SessionSpeakerList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema(
-                "session_speakers", "SessionSpeakerBase"
-            ),
+            200: get_pagination_doc_reference("SessionSpeaker"),
             403: {"description": "Not authorized to view session speakers"},
             404: {"description": "Session not found"},
         },

--- a/backend/atria/api/routes/sessions.py
+++ b/backend/atria/api/routes/sessions.py
@@ -16,7 +16,7 @@ from api.schemas import (
 )
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.commons.decorators import (
     event_member_required,
@@ -58,10 +58,7 @@ class SessionList(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema(
-                "sessions",
-                "SessionDetail",
-            ),
+            200: get_pagination_doc_reference("SessionDetail"),
             404: {"description": "Event not found"},
         },
     )

--- a/backend/atria/api/routes/users.py
+++ b/backend/atria/api/routes/users.py
@@ -21,7 +21,7 @@ from api.schemas.privacy import (
 from api.schemas.dashboard import DashboardResponseSchema, UserInvitationsResponseSchema
 from api.commons.pagination import (
     PAGINATION_PARAMETERS,
-    get_pagination_schema,
+    get_pagination_doc_reference,
 )
 from api.services.user import UserService
 from api.services.dashboard import DashboardService
@@ -100,7 +100,7 @@ class UserEventsResource(MethodView):
             *PAGINATION_PARAMETERS,
         ],
         responses={
-            200: get_pagination_schema("events", "EventBase"),
+            200: get_pagination_doc_reference("EventBase"),
             403: {"description": "Not authorized"},
             404: {"description": "User not found"},
         },


### PR DESCRIPTION
## Problem
- Pagination endpoints had broken $ref links in OpenAPI spec
- Flask-SMOREST was not auto-registering pagination wrapper schemas  
- Caused 500 errors due to double serialization attempts
- Blocked Docusaurus documentation generation

## Solution
- Manual schema registration at app startup (routes/__init__.py)
- New get_pagination_doc_reference() helper for doc-only references
- Updated 12 route files with 16 pagination endpoints
- Changed from @blp.response(200, Schema) to @blp.response(200) with doc refs

## Changes
Core:
- pagination.py - Added get_pagination_doc_reference() and register_pagination_schemas()
- routes/__init__.py - Manual schema registration before blueprints

Route files (12):
- events.py, users.py, organizations.py
- organization_users.py, organization_invitations.py  
- event_users.py, event_invitations.py
- connections.py (3 endpoints)
- direct_messages.py
- chat_rooms.py (2 endpoints)
- sessions.py, session_speakers.py

## Verification
- All 16/16 endpoints have correct OpenAPI schema references  
- No more 500 serialization errors  
- Backend starts successfully
- 14 pagination schemas properly registered in OpenAPI spec  
- No API contract changes - fully backward compatible

## Known Issues (Pre-existing)
The following duplicate schema warnings remain (these existed before this PR):
- EventBase, OrganizationBase, SessionBase, UserBase, SchemaMeta

These are warnings only and do not affect functionality. They will be addressed in a future schema refactoring effort.

## Test Plan
- Backend starts without errors
- All pagination endpoints return 200 (with auth)
- OpenAPI spec validates all $ref links
- No new duplicate schema warnings introduced