### PR TITLE
fix: prevent Plausible analytics double-counting on landing page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -110,19 +110,7 @@
     }
     </script>
 
-    <!-- Plausible Analytics will be loaded after page hydration -->
-    <!-- Privacy-focused, GDPR compliant, no cookies, no personal data collection -->
-    <script>
-      // Load analytics after hydration (skip during pre-rendering)
-      if (typeof window !== 'undefined' && !navigator.userAgent.includes('PrerendererBot')) {
-        var script = document.createElement('script');
-        script.defer = true;
-        script.setAttribute('data-domain', 'atria.gg');
-        script.setAttribute('data-api', '/api/anonstats/event');
-        script.src = '/api/anonstats/js/script.file-downloads.outbound-links.js';
-        document.head.appendChild(script);
-      }
-    </script>
+    <!-- Plausible Analytics loaded by React after hydration to prevent double-counting -->
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -209,16 +209,6 @@ ${criticalCSS}    </style>
       '$1community$2'
     );
 
-    console.log('🧹 Removing Plausible script to prevent double loading...');
-
-    // Remove the Plausible analytics script from pre-rendered HTML
-    // This prevents double-counting: script will load when React hydrates
-    // Pattern matches the entire script block that loads Plausible
-    html = html.replace(
-      /<script>\s*\/\/ Load analytics after hydration[\s\S]*?<\/script>/,
-      ''
-    );
-
     // Save it
     writeFileSync(INDEX_PATH, html, 'utf-8');
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,7 @@ import { RouterProvider } from 'react-router-dom';
 import { store } from './app/store';
 import { router } from './app/router/routes';
 import ErrorBoundary from './shared/components/ErrorBoundary';
+import { Analytics } from './shared/components/Analytics';
 
 import './styles/reset.css';
 import './styles/design-tokens.css';
@@ -20,6 +21,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <ErrorBoundary>
       <ReduxProvider store={store}>
         <MantineProvider>
+          <Analytics />
           <Notifications position="bottom-left" />
           <ModalsProvider>
             <RouterProvider router={router} />

--- a/frontend/src/shared/components/Analytics.jsx
+++ b/frontend/src/shared/components/Analytics.jsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+/**
+ * Analytics Component
+ *
+ * Loads Plausible analytics script once after React hydration.
+ * This prevents double-counting that would occur if the script
+ * was in the static HTML template (pre-render + hydration = 2 pageviews).
+ *
+ * Privacy-focused, GDPR compliant, no cookies, no personal data collection.
+ */
+export const Analytics = () => {
+  useEffect(() => {
+    // Only load in browser (not during SSR/pre-rendering)
+    if (typeof window === 'undefined') return;
+
+    // Check if script already exists to prevent duplicates
+    const existingScript = document.querySelector('script[data-domain="atria.gg"]');
+    if (existingScript) return;
+
+    // Create and inject Plausible script
+    const script = document.createElement('script');
+    script.defer = true;
+    script.setAttribute('data-domain', 'atria.gg');
+    script.setAttribute('data-api', '/api/anonstats/event');
+    script.src = '/api/anonstats/js/script.file-downloads.outbound-links.js';
+    document.head.appendChild(script);
+
+    // Cleanup function (removes script if component unmounts, though it typically won't)
+    return () => {
+      const scriptToRemove = document.querySelector('script[data-domain="atria.gg"]');
+      if (scriptToRemove) {
+        scriptToRemove.remove();
+      }
+    };
+  }, []); // Empty deps = run once on mount
+
+  // This component renders nothing
+  return null;
+};


### PR DESCRIPTION
## Problem
Plausible script in static HTML template loaded twice per landing page visit:
1. Browser executed script from pre-rendered HTML
2. React hydration processed template again, loading script second time

Result: Double pageviews, inaccurate bounce rate (near 0%).

## Solution
Moved Plausible loading from `index.html` to React component that runs once after mount.

## Changes
- `frontend/index.html`: Removed Plausible script
- `frontend/src/shared/components/Analytics.jsx`: New component loads script once
- `frontend/src/main.jsx`: Added Analytics component
- `frontend/scripts/prerender.mjs`: Removed obsolete cleanup code

## Verification
```bash
grep -c "data-domain" frontend/dist/index.html  # Returns 0
```

Pre-rendered HTML contains no Plausible script. Loads once via React.