### PR TITLE
fix: correct Manage Sessions navigation route in speakers manager

### DIFF
--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.jsx
@@ -22,7 +22,6 @@ const SpeakerCard = ({
   speaker,
   onEditSpeaker,
   currentUserRole,
-  organizationId,
 }) => {
   const navigate = useNavigate();
   const [updateUser] = useUpdateEventUserMutation();
@@ -112,7 +111,7 @@ const SpeakerCard = ({
               
               <Menu.Item
                 leftSection={<IconMicrophone size={16} />}
-                onClick={() => navigate(`/app/organizations/${organizationId}/events/${speaker.event_id}/admin/sessions`)}
+                onClick={() => navigate(`/app/events/${speaker.event_id}/admin/sessions`)}
               >
                 Manage Sessions
               </Menu.Item>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.jsx
@@ -19,7 +19,6 @@ const SpeakerRow = ({
   speaker,
   onEditSpeaker,
   currentUserRole,
-  organizationId,
 }) => {
   const navigate = useNavigate();
   const [updateUser] = useUpdateEventUserMutation();
@@ -213,7 +212,7 @@ const SpeakerRow = ({
                 
                 <Menu.Item
                   leftSection={<IconMicrophone size={16} />}
-                  onClick={() => navigate(`/app/organizations/${organizationId}/events/${speaker.event_id}/admin/sessions`)}
+                  onClick={() => navigate(`/app/events/${speaker.event_id}/admin/sessions`)}
                 >
                   Manage Sessions
                 </Menu.Item>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakersList/index.jsx
@@ -11,7 +11,6 @@ const SpeakersList = ({
   speakers,
   currentUserRole,
   onEditSpeaker,
-  organizationId,
 }) => {
   const [sortBy, setSortBy] = useState('name');
   const [sortOrder, setSortOrder] = useState('asc');
@@ -134,7 +133,6 @@ const SpeakersList = ({
               speaker={speaker}
               onEditSpeaker={onEditSpeaker}
               currentUserRole={currentUserRole}
-              organizationId={organizationId}
             />
           ))}
         </div>
@@ -171,7 +169,6 @@ const SpeakersList = ({
               speaker={speaker}
               onEditSpeaker={onEditSpeaker}
               currentUserRole={currentUserRole}
-              organizationId={organizationId}
             />
           ))}
         </Table.Tbody>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/index.jsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/index.jsx
@@ -192,7 +192,6 @@ const SpeakersManager = () => {
             speakers={filteredSpeakers}
             currentUserRole={currentUserRole}
             onEditSpeaker={handleEditSpeaker}
-            organizationId={eventData?.organization_id}
           />
 
           {speakersData?.total_pages > 1 && (


### PR DESCRIPTION
## Summary
Fixed 404 error when clicking "Manage Sessions" from the speaker menu in the speakers management page.

## Problem
The "Manage Sessions" button was using an incorrect route pattern that doesn't exist in the app's route configuration:
- ❌ `/app/organizations/{orgId}/events/{eventId}/admin/sessions`
- ✅ `/app/events/{eventId}/admin/sessions`

## Changes
- Updated navigation route in `SpeakerCard` and `SpeakerRow` components to use the correct pattern
- Removed unused `organizationId` prop from SpeakerCard, SpeakerRow, and SpeakersList components
- Navigation now correctly routes to the SessionManager page

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Manually tested in browser - navigating from speakers manager to sessions manager works correctly
- [ ] No console errors
- [ ] Route pattern matches defined routes in protectedRoutes.jsx

## Impact
- Event admins can now successfully navigate from a speaker's menu to the sessions management page
- Cleaner component props by removing unused organizationId parameter