### PR TITLE
fix: resolve frontend linting errors and add docs/GitHub nav icons

### DIFF
--- a/frontend/src/pages/Landing/Hero/Hero.module.css
+++ b/frontend/src/pages/Landing/Hero/Hero.module.css
@@ -101,11 +101,25 @@
   padding: 0 var(--space-comfort);
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-comfort);
 }
 
 .navLinks {
   display: flex;
   gap: var(--space-comfort);
+}
+
+/* Icon links container - top left, desktop only */
+.navIconLinks {
+  display: none; /* Hidden on mobile */
+  gap: var(--space-comfort);
+}
+
+@media (min-width: 768px) {
+  .navIconLinks {
+    display: flex;
+  }
 }
 
 .navLink {
@@ -123,6 +137,23 @@
 }
 
 .navLink:hover {
+  color: var(--color-almost-white);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Individual icon link styling - minimal white aesthetic */
+.navIconLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  color: rgba(255, 255, 255, 0.8);
+  transition: var(--transition-smooth);
+  border-radius: 50%; /* Circular background */
+  text-decoration: none;
+}
+
+.navIconLink:hover {
   color: var(--color-almost-white);
   background: rgba(255, 255, 255, 0.1);
 }

--- a/frontend/src/pages/Landing/Hero/index.jsx
+++ b/frontend/src/pages/Landing/Hero/index.jsx
@@ -4,6 +4,7 @@ import { gsap } from 'gsap';
 import { useGSAP } from '@gsap/react';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { ScrambleTextPlugin } from 'gsap/ScrambleTextPlugin';
+import { IconBrandGithubFilled } from '@tabler/icons-react';
 import { useModalManager } from '../shared/useModalManager.jsx';
 import MagneticButton from '../shared/MagneticButton';
 import styles from './Hero.module.css';
@@ -69,10 +70,6 @@ const Hero = () => {
   }, []);
 
   // Modal handlers - now lazy-loaded, no Mantine dependency
-  const handleForgotPassword = () => {
-    openModal('forgotPassword');
-  };
-
   const handleLogin = () => {
     openModal('login');
   };
@@ -342,6 +339,7 @@ const Hero = () => {
       {/* Navigation */}
       <nav ref={navRef} className={styles.nav}>
         <div className={styles.navContent}>
+          {/* Main nav links */}
           <div className={styles.navLinks}>
             <button onClick={handleLogin} className={styles.navLink}>
               Login
@@ -353,6 +351,35 @@ const Hero = () => {
               Demo
             </button>
           </div>
+
+          {/* Icon links - far right, desktop only */}
+          <div className={styles.navIconLinks}>
+            <a
+              href="https://docs.atria.gg"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.navIconLink}
+              aria-label="Documentation"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                <path d="M7 3m0 2.667a2.667 2.667 0 0 1 2.667 -2.667h8.666a2.667 2.667 0 0 1 2.667 2.667v8.666a2.667 2.667 0 0 1 -2.667 2.667h-8.666a2.667 2.667 0 0 1 -2.667 -2.667z" />
+                <path d="M4.012 7.26a2.005 2.005 0 0 0 -1.012 1.737v10c0 1.1 .9 2 2 2h10c.75 0 1.158 -.385 1.5 -1" />
+                <path d="M11 7h5" />
+                <path d="M11 10h6" />
+                <path d="M11 13h3" />
+              </svg>
+            </a>
+            <a
+              href="https://github.com/thesubtleties/atria"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.navIconLink}
+              aria-label="GitHub Repository"
+            >
+              <IconBrandGithubFilled size={20} />
+            </a>
+          </div>
         </div>
       </nav>
 
@@ -361,7 +388,7 @@ const Hero = () => {
         <div className={styles.container}>
           <div className={styles.heroContent}>
             <div ref={logoRef} className={styles.logoContainer}>
-              <img src={AtriaLogo} alt="Atria" className={styles.logo} fetchpriority="high" width="512" height="512" />
+              <img src={AtriaLogo} alt="Atria" className={styles.logo} fetchPriority="high" width="512" height="512" />
               <h1 
                 className={styles.logoText} 
                 style={{ opacity: fontLoaded ? 1 : 0, transition: 'opacity 0.3s ease' }}

--- a/frontend/src/shared/components/modals/profile/EditAvatarModal/index.jsx
+++ b/frontend/src/shared/components/modals/profile/EditAvatarModal/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Modal, Stack, Select, Text, Avatar, Group } from '@mantine/core';
+import { Modal, Select, Text, Avatar } from '@mantine/core';
 import { Button } from '@/shared/components/buttons';
 import {
   TOP_OPTIONS,


### PR DESCRIPTION
## Summary

- Fix all frontend linting errors flagged in CI
- Add documentation and GitHub icon links to landing page navigation (desktop only)

## Linting Fixes

- ✅ Remove unused imports (`Stack`, `Group`) from `EditAvatarModal`
- ✅ Remove unused `handleForgotPassword` function from Hero component
- ✅ Fix `fetchpriority` to `fetchPriority` (React camelCase prop)

## Navigation Enhancement

**Desktop (768px+):**
- Added docs and GitHub icon links at far right of nav
- Layout: `[Login] [Sign Up] [Demo] [📚 Docs] [🐙 GitHub]`
- Minimal white aesthetic with circular hover effect
- Uses Tabler `IconBrandGithubFilled` + inline SVG library icon

**Mobile (<768px):**
- Icons hidden for cleaner mobile UX
- Layout: `[Login] [Sign Up] [Demo]`

## Test Plan

- [x] All ESLint errors resolved
- [x] Icons display correctly on desktop
- [x] Icons hidden on mobile
- [x] Hover states work (circular white background)
- [x] Links navigate to correct destinations (docs.atria.gg, GitHub repo)