### PR TITLE
feat: add v0.1.0 news items, docs links, and scrollable dashboard sections

### DIFF
--- a/backend/atria/api/schemas/dashboard.py
+++ b/backend/atria/api/schemas/dashboard.py
@@ -57,6 +57,7 @@ class DashboardNewsSchema(Schema):
     date = fields.DateTime(format="iso", dump_only=True)
     type = fields.Str(dump_only=True)  # 'platform_update', 'product_launch', 'feature_release', 'security'
     is_new = fields.Bool(dump_only=True)
+    link = fields.Str(dump_only=True, allow_none=True)
 
 
 class DashboardUserSchema(Schema):

--- a/backend/atria/api/services/dashboard.py
+++ b/backend/atria/api/services/dashboard.py
@@ -280,6 +280,24 @@ class DashboardService:
                 'date': datetime(2025, 10, 5, tzinfo=timezone.utc),
                 'type': 'feature_release',
                 'is_new': True
+            },
+            {
+                'id': 4,
+                'title': 'v0.1.0 Release',
+                'description': 'New features, bug fixes, and improvements are now live! Check out the full changelog at docs.atria.gg/blog',
+                'date': datetime(2025, 10, 25, tzinfo=timezone.utc),
+                'type': 'platform_update',
+                'is_new': True,
+                'link': 'https://docs.atria.gg/blog'
+            },
+            {
+                'id': 5,
+                'title': 'Documentation Hub Now Available',
+                'description': 'Need help getting started? Our comprehensive documentation is now live with guides, tutorials, and API references. Visit docs.atria.gg',
+                'date': datetime(2025, 10, 25, tzinfo=timezone.utc),
+                'type': 'platform_update',
+                'is_new': True,
+                'link': 'https://docs.atria.gg'
             }
         ]
 

--- a/frontend/src/pages/Dashboard/NewsSection/index.jsx
+++ b/frontend/src/pages/Dashboard/NewsSection/index.jsx
@@ -69,6 +69,32 @@ export const NewsSection = ({ news }) => {
     }
   };
 
+  const renderDescription = (description, link) => {
+    if (!link) return description;
+
+    // Match URLs like "docs.atria.gg" or "docs.atria.gg/blog"
+    const urlPattern = /(docs\.atria\.gg[^\s]*)/g;
+    const parts = description.split(urlPattern);
+
+    return parts.map((part, index) => {
+      if (part.match(urlPattern)) {
+        return (
+          <a
+            key={index}
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.inlineLink}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {part}
+          </a>
+        );
+      }
+      return part;
+    });
+  };
+
   return (
     <section className={styles.dashboardSection}>
       <div className={styles.sectionHeader}>
@@ -82,7 +108,9 @@ export const NewsSection = ({ news }) => {
               <div className={`${styles.newsDot} ${getDotClass(item.date, item.is_new)}`} />
               <div className={styles.newsContent}>
                 <div className={styles.newsTitle}>{item.title}</div>
-                <div className={styles.newsDescription}>{item.description}</div>
+                <div className={styles.newsDescription}>
+                  {renderDescription(item.description, item.link)}
+                </div>
                 <div className={styles.newsMeta}>
                   <span>{getTimeDifference(item.date)}</span>
                   <Badge

--- a/frontend/src/pages/Dashboard/NewsSection/styles/index.module.css
+++ b/frontend/src/pages/Dashboard/NewsSection/styles/index.module.css
@@ -17,6 +17,36 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-height: 400px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 4px; /* Space for scrollbar */
+}
+
+/* Custom scrollbar styling for news list */
+.newsList::-webkit-scrollbar {
+  width: 8px;
+}
+
+.newsList::-webkit-scrollbar-track {
+  background: rgba(139, 92, 246, 0.02);
+  border-radius: 4px;
+}
+
+.newsList::-webkit-scrollbar-thumb {
+  background: rgba(139, 92, 246, 0.15);
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.newsList::-webkit-scrollbar-thumb:hover {
+  background: rgba(139, 92, 246, 0.25);
+}
+
+/* Firefox scrollbar styling */
+.newsList {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139, 92, 246, 0.15) rgba(139, 92, 246, 0.02);
 }
 
 .newsItem {
@@ -35,40 +65,53 @@
   margin-bottom: 0;
 }
 
+/* Inline links in descriptions */
+.inlineLink {
+  color: #8b5cf6;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.inlineLink:hover {
+  color: #7c3aed;
+  text-decoration: underline;
+}
+
 .platformUpdateItem {
-  background: #FAFAFF;
-  border: 1px solid #F1F0FF;
+  background: #fafaff;
+  border: 1px solid #f1f0ff;
 }
 
 .platformUpdateItem:hover {
-  background: #F5F4FF;
+  background: #f5f4ff;
 }
 
 .productLaunchItem {
-  background: #FAFFFA;
-  border: 1px solid #F0FFF0;
+  background: #fafffa;
+  border: 1px solid #f0fff0;
 }
 
 .productLaunchItem:hover {
-  background: #F4FFF4;
+  background: #f4fff4;
 }
 
 .featureReleaseItem {
-  background: #FFFEFA;
-  border: 1px solid #FFF8F0;
+  background: #fffefa;
+  border: 1px solid #fff8f0;
 }
 
 .featureReleaseItem:hover {
-  background: #FFFCF4;
+  background: #fffcf4;
 }
 
 .securityItem {
-  background: #FFFAFA;
-  border: 1px solid #FFF0F0;
+  background: #fffafa;
+  border: 1px solid #fff0f0;
 }
 
 .securityItem:hover {
-  background: #FFF4F4;
+  background: #fff4f4;
 }
 
 .newsDot {
@@ -80,15 +123,15 @@
 }
 
 .newsDot.new {
-  background: #10B981;
+  background: #10b981;
 }
 
 .newsDot.recent {
-  background: #F59E0B;
+  background: #f59e0b;
 }
 
 .newsDot.older {
-  background: #94A3B8;
+  background: #94a3b8;
 }
 
 .newsContent {
@@ -97,14 +140,14 @@
 
 .newsTitle {
   font-weight: 600;
-  color: #1E293B;
+  color: #1e293b;
   font-size: clamp(0.9rem, 2vw, 0.95rem);
   margin-bottom: clamp(0.1rem, 1vw, 0.25rem);
   line-height: 1.3;
 }
 
 .newsDescription {
-  color: #64748B;
+  color: #64748b;
   font-size: clamp(0.75rem, 1.8vw, 0.85rem);
   line-height: 1.4;
   margin-bottom: clamp(0.4rem, 1vw, 0.5rem);
@@ -115,7 +158,7 @@
   align-items: center;
   gap: 0.75rem;
   font-size: 0.8rem;
-  color: #94A3B8;
+  color: #94a3b8;
 }
 
 /* Badge composition from design tokens */
@@ -140,6 +183,15 @@
 }
 
 /* Responsive Design */
+/* Disable max-height on mobile/tablet - allow natural page scrolling */
+@media (max-width: 1023px) {
+  .newsList {
+    max-height: none;
+    overflow-y: visible;
+    padding-right: 0;
+  }
+}
+
 @media (max-width: 429px) {
   /* iPhone SE and smaller */
   .sectionHeader {

--- a/frontend/src/pages/Dashboard/OrganizationsSection/styles/index.module.css
+++ b/frontend/src/pages/Dashboard/OrganizationsSection/styles/index.module.css
@@ -15,7 +15,7 @@
 
 /* Card System Classes */
 .cardList {
-  composes: card-list-scrollable from '../../../../styles/design-tokens.css';
+  composes: card-list-scrollable from '../../../../styles/design-tokens.css' !important;
 }
 
 .card {

--- a/frontend/src/styles/design-tokens.css
+++ b/frontend/src/styles/design-tokens.css
@@ -245,7 +245,7 @@
 /* Scrollable Card List - For sections with many cards (5+ items) */
 .card-list-scrollable {
   composes: card-list;
-  max-height: 550px !important;
+  max-height: 800px !important;
   overflow-y: auto !important;
   overflow-x: hidden !important;
   padding-right: 4px; /* Space for scrollbar */


### PR DESCRIPTION
## Summary

- Added v0.1.0 release and documentation hub announcements to dashboard news
- Made news URLs clickable with inline link styling
- Added scrollable sections for organizations and news on dashboard

## News Updates

**New News Items:**
- ✅ v0.1.0 Release announcement with link to docs.atria.gg/blog for full changelog
- ✅ Documentation Hub announcement with link to docs.atria.gg

**Clickable Links:**
- URLs like "docs.atria.gg" and "docs.atria.gg/blog" in news descriptions are now clickable
- Purple link styling with hover effects
- Opens in new tab with security attributes

**Backend Changes:**
- Added `link` field to news items in dashboard service
- Added `link` field to `DashboardNewsSchema` for proper serialization

## Scrollable Sections

**Organizations Section:**
- Max-height: 800px (desktop only)
- Custom purple-themed scrollbar
- Mobile/tablet: natural page scrolling

**News Section:**
- Max-height: 400px (desktop only)
- Custom purple-themed scrollbar
- Mobile/tablet: natural page scrolling

## Test Plan

- [x] News items display correctly
- [x] URLs in news descriptions are clickable and styled
- [x] Links open to correct destinations in new tab
- [x] Organizations section scrolls properly with 800px limit
- [x] News section scrolls properly with 400px limit
- [x] Scrollbars styled consistently with purple theme
- [x] Mobile view disables scrolling for natural page flow