### PR TITLE
chore: prepare for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to Atria will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-10-25
+
+### Added
+- Scrollable sections for organizations and news on dashboard with custom purple-themed scrollbars
+- v0.1.0 release announcements in dashboard news with clickable documentation links
+- Documentation and GitHub icon links in landing page navigation (desktop only)
+- Comprehensive `.env.example` with 113 lines of detailed configuration guidance
+- Script organization with dedicated `scripts/dev/`, `scripts/testing/`, and `scripts/database/` directories
+- Script documentation in `scripts/README.md`
+
+### Fixed
+- **Critical**: Connection request privacy settings now properly enforced on backend
+- **Critical**: Privacy preferences now validated server-side for all three levels (Event Attendees Only, Speakers & Organizers Only, No One)
+- "Manage Sessions" navigation route in speakers manager (no more 404 errors)
+- Plausible analytics double-counting on landing page
+- OpenAPI documentation references for pagination endpoints
+- Frontend linting errors throughout codebase
+- React prop naming conventions (fetchpriority → fetchPriority)
+- Double serialization errors in pagination endpoints
+
+### Changed
+- Flattened `api/api/` nested directory structure for cleaner project organization
+- Updated README with accurate installation instructions and setup options
+- Improved CONTRIBUTING.md with correct local development setup
+- Simplified PR template from 57 to 23 lines for better adoption
+- Optimized privacy checks to prevent N+1 query issues
+
+### Documentation
+- Complete rewrite of README with accurate prerequisites and installation steps
+- Added reference to documentation repository (github.com/thesubtleties/atria-docs)
+- All documentation now points to docs.atria.gg
+- Removed references to non-existent documentation pages
+
+### Developer Experience
+- Organized root-level scripts into logical categories
+- Improved code quality with resolved linting errors
+- Better error handling in pagination endpoints
+- Proper schema registration for Flask-SMOREST OpenAPI generation
+
+[0.1.0]: https://github.com/thesubtleties/atria/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build meaningful connections that last beyond your events.**
 
-[![Live Demo](https://img.shields.io/badge/demo-atria.gg-6366f1)](https://atria.gg) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](LICENSE) [![Documentation](https://img.shields.io/badge/docs-docs.atria.gg-34d399)](https://docs.atria.gg)
+![Version](https://img.shields.io/github/v/release/thesubtleties/atria) [![Live Demo](https://img.shields.io/badge/demo-atria.gg-6366f1)](https://atria.gg) [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](LICENSE) [![Documentation](https://img.shields.io/badge/docs-docs.atria.gg-34d399)](https://docs.atria.gg)
 
 > ⭐ **If you find Atria interesting, please consider starring this repository** — it helps us grow and reach more people who could benefit from the platform.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Preparing Atria for v0.1.0 release with changelog, version badge, and version bump.

## Changes

**CHANGELOG.md**
- ✅ Complete changelog in Keep a Changelog format
- ✅ Documents all 10 PRs merged since last main release
- ✅ Categorized into Added, Fixed, Changed, Documentation, Developer Experience

**README.md**
- ✅ Added version badge at top (auto-updates from GitHub releases)

**package.json**
- ✅ Bumped version from 0.0.0 → 0.1.0

## Test Plan

- [x] CHANGELOG.md formatted correctly
- [x] Version badge added to README
- [x] package.json version updated to 0.1.0