### PR TITLE
chore: prepare for v0.1.1 patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The development environment includes:
 - PostgreSQL database with sample data
 - Automatic dependency installation
 
-**Need more detailed setup instructions?** → [Full installation guide](https://docs.atria.gg/getting-started/installation)
+**Need more detailed setup instructions?** → [Full installation guide](https://docs.atria.gg/docs/getting-started/installation)
 
 ---
 
@@ -197,7 +197,7 @@ The development environment includes:
 ## Documentation & Resources
 
 - **Complete Documentation**: [docs.atria.gg](https://docs.atria.gg)
-- **API Reference**: [docs.atria.gg/api/atria-api](https://docs.atria.gg/api/atria-api)
+- **API Reference**: [docs.atria.gg/docs/api/atria-api](https://docs.atria.gg/docs/api/atria-api)
 - **Community Support**: [GitHub Discussions](https://github.com/thesubtleties/atria/discussions)
 - **Bug Reports**: [GitHub Issues](https://github.com/thesubtleties/atria/issues)
 - **Commercial Support**: [steven@sbtl.dev](mailto:steven@sbtl.dev)

--- a/backend/atria/setup.py
+++ b/backend/atria/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = "0.1"
+__version__ = "0.1.1"
 
 # requirements.txt to stay up to date
 with open("requirements.txt") as f:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "dependencies": {
         "@dnd-kit/helpers": "^0.1.20",
         "@dnd-kit/react": "^0.1.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Prepare for v0.1.1 patch release with version bumps and documentation link fixes.

## Changes
- Bump frontend package.json and package-lock.json to 0.1.1
- Bump backend setup.py to 0.1.1
- Fix broken documentation links in README (added `/docs` path segment to installation guide and API reference)

## Test Plan
- [ ] Verify version numbers are correct in all package files
- [ ] Verify documentation links work correctly
- [ ] CI tests pass