### PR TITLE
docs: add v0.1.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Atria will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-10-31
+
+### Fixed
+- Documentation links in README (added missing `/docs` path segment to installation guide and API reference)
+
+### Changed
+- Version bumps across frontend and backend packages to 0.1.1
+
+[0.1.1]: https://github.com/thesubtleties/atria/releases/tag/v0.1.1
+
 ## [0.1.0] - 2025-10-25
 
 ### Added


### PR DESCRIPTION
## Summary
Add changelog entry for v0.1.1 patch release.

## Changes
- Add v0.1.1 section to CHANGELOG.md documenting documentation link fixes and version bumps

## Test Plan
- [x] Verify changelog formatting is correct
- [x] Verify date is accurate (2025-10-31)
- [x] CI tests pass