### PR TITLE
chore: prepare for v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Atria will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-11-15
+
+### Fixed
+- Dev environment setup reliability - tmux helper scripts now detect project root dynamically
+- Scripts can be executed from any directory location (previously required project root)
+- Environment file configuration verified for consistency across example files
+
+### Changed
+- All dev helper scripts updated with dynamic project root detection
+- Scripts now change to project root before running docker compose commands
+
+[0.2.1]: https://github.com/thesubtleties/atria/releases/tag/v0.2.1
+
 ## [0.2.0] - 2025-11-08
 
 ### Added

--- a/backend/atria/api/services/dashboard.py
+++ b/backend/atria/api/services/dashboard.py
@@ -298,6 +298,15 @@ class DashboardService:
                 'type': 'platform_update',
                 'is_new': True,
                 'link': 'https://docs.atria.gg'
+            },
+            {
+                'id': 6,
+                'title': 'v0.2.0 - Multi-Platform Streaming Release',
+                'description': 'Multi-platform video streaming support with Vimeo, Mux, and Zoom integration. Read the full announcement at docs.atria.gg/blog/v0.2.0-release',
+                'date': datetime(2025, 11, 8, tzinfo=timezone.utc),
+                'type': 'feature_release',
+                'is_new': True,
+                'link': 'https://docs.atria.gg/blog/v0.2.0-release'
             }
         ]
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release Preparation for v0.2.1

This PR prepares the codebase for the v0.2.1 patch release.

## Changes

### Version Updates
- Updated `frontend/package.json` version to 0.2.1
- Updated `CHANGELOG.md` with v0.2.1 release notes

### Documentation
- Added v0.2.0 release announcement to dashboard news section
- Linked to full blog post at docs.atria.gg/blog/v0.2.0-release

## v0.2.1 Changelog Summary

### Fixed
- Dev environment setup reliability - tmux helper scripts now detect project root dynamically
- Scripts can be executed from any directory location (previously required project root)
- Environment file configuration verified for consistency across example files

### Changed
- All dev helper scripts updated with dynamic project root detection
- Scripts now change to project root before running docker compose commands

## Next Steps
1. Merge this PR to dev
2. Create release PR from dev to main
3. Tag and create GitHub release v0.2.1