### PR TITLE
chore: sync package-lock.json version to 0.2.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@dnd-kit/helpers": "^0.1.20",
         "@dnd-kit/react": "^0.1.20",


### PR DESCRIPTION
## Summary
Syncs package-lock.json version to match package.json (0.2.1).

## Issue
During the v0.2.1 release prep, package.json was updated to 0.2.1 but package-lock.json was missed and still showed 0.2.0.

## Fix
Updates the version field in package-lock.json to match package.json.

## Files Changed
- frontend/package-lock.json: version 0.2.0 → 0.2.1 (2 lines)