### PR TITLE
fix: wire up DM functionality in Speakers Manager

### DIFF
--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerCard/index.tsx
@@ -23,11 +23,14 @@ import {
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
 import { useUpdateEventUserMutation } from '@/app/features/events/api';
+import { useCreateDirectMessageThreadMutation } from '@/app/features/networking/api';
+import { openThread } from '@/app/store/chatSlice';
 import { formatTime, capitalizeWords, truncateBio } from '@/shared/utils/formatting';
-import type { EventUser, EventUserRole } from '@/types';
+import type { EventUser, EventUserRole, ApiError } from '@/types';
 import styles from './styles.module.css';
 
 type SpeakerCardProps = {
@@ -38,8 +41,34 @@ type SpeakerCardProps = {
 
 const SpeakerCard = ({ speaker, onEditSpeaker, currentUserRole }: SpeakerCardProps) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [updateUser] = useUpdateEventUserMutation();
+  const [createThread] = useCreateDirectMessageThreadMutation();
   const [sessionsExpanded, setSessionsExpanded] = useState(false);
+
+  const handleMessage = async () => {
+    try {
+      const result = await createThread({
+        userId: speaker.user_id,
+        eventId: speaker.event_id,
+      }).unwrap();
+
+      dispatch(openThread(result.id));
+
+      notifications.show({
+        title: 'Success',
+        message: 'Message thread opened',
+        color: 'green',
+      });
+    } catch (error) {
+      const apiError = error as ApiError;
+      notifications.show({
+        title: 'Error',
+        message: apiError?.data?.message || 'Failed to open message thread',
+        color: 'red',
+      });
+    }
+  };
 
   const handleRemoveSpeaker = () => {
     openConfirmationModal({
@@ -147,16 +176,7 @@ const SpeakerCard = ({ speaker, onEditSpeaker, currentUserRole }: SpeakerCardPro
                 Remove Speaker Role
               </Menu.Item>
 
-              <Menu.Item
-                leftSection={<IconMessage size={16} />}
-                onClick={() => {
-                  notifications.show({
-                    title: 'Coming Soon',
-                    message: 'Direct messaging will be available soon',
-                    color: 'blue',
-                  });
-                }}
-              >
+              <Menu.Item leftSection={<IconMessage size={16} />} onClick={handleMessage}>
                 Send Message
               </Menu.Item>
             </Menu.Dropdown>

--- a/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.tsx
+++ b/frontend/src/pages/EventAdmin/SpeakersManager/SpeakerRow/index.tsx
@@ -20,11 +20,14 @@ import {
   IconAlertCircle,
 } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { notifications } from '@mantine/notifications';
 import { openConfirmationModal } from '@/shared/components/modals/ConfirmationModal';
 import { useUpdateEventUserMutation } from '@/app/features/events/api';
+import { useCreateDirectMessageThreadMutation } from '@/app/features/networking/api';
+import { openThread } from '@/app/store/chatSlice';
 import { formatTime, capitalizeWords, truncateText } from '@/shared/utils/formatting';
-import type { EventUser, EventUserRole } from '@/types';
+import type { EventUser, EventUserRole, ApiError } from '@/types';
 import styles from './styles.module.css';
 
 type SpeakerRowProps = {
@@ -35,7 +38,33 @@ type SpeakerRowProps = {
 
 const SpeakerRow = ({ speaker, onEditSpeaker, currentUserRole }: SpeakerRowProps) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const [updateUser] = useUpdateEventUserMutation();
+  const [createThread] = useCreateDirectMessageThreadMutation();
+
+  const handleMessage = async () => {
+    try {
+      const result = await createThread({
+        userId: speaker.user_id,
+        eventId: speaker.event_id,
+      }).unwrap();
+
+      dispatch(openThread(result.id));
+
+      notifications.show({
+        title: 'Success',
+        message: 'Message thread opened',
+        color: 'green',
+      });
+    } catch (error) {
+      const apiError = error as ApiError;
+      notifications.show({
+        title: 'Error',
+        message: apiError?.data?.message || 'Failed to open message thread',
+        color: 'red',
+      });
+    }
+  };
 
   const handleRemoveSpeaker = () => {
     openConfirmationModal({
@@ -260,16 +289,7 @@ const SpeakerRow = ({ speaker, onEditSpeaker, currentUserRole }: SpeakerRowProps
               </>
             )}
 
-            <Menu.Item
-              leftSection={<IconMessage size={16} />}
-              onClick={() => {
-                notifications.show({
-                  title: 'Coming Soon',
-                  message: 'Direct messaging will be available soon',
-                  color: 'blue',
-                });
-              }}
-            >
+            <Menu.Item leftSection={<IconMessage size={16} />} onClick={handleMessage}>
               Send Message
             </Menu.Item>
           </Menu.Dropdown>


### PR DESCRIPTION
## Problem
Clicking "Send Message" in Speakers Manager showed a "Coming Soon" toast, but DM functionality is already implemented and working in Attendees Manager.

Closes #346

## Solution
Wire up the same DM thread creation pattern used in AttendeeCard.

## Changes
- `SpeakersManager/SpeakerRow/index.tsx`: Add `handleMessage` using `createDirectMessageThread` and `openThread`
- `SpeakersManager/SpeakerCard/index.tsx`: Same implementation for mobile view

## Testing
1. Go to Speakers Manager
2. Click menu on any speaker
3. Click "Send Message"
4. DM thread opens in chat sidebar

## Breaking Changes
None

---
**Type:** [x] Bug Fix [ ] Feature [ ] Breaking [ ] Refactor [ ] Docs [ ] Performance

**CLA:** [x] I agree to the [Contributor License Agreement](../CLA.md)...