### PR TITLE
Frontend QoL improvements: labels, date picker, streaming validation

### DIFF
--- a/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/index.tsx
+++ b/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/index.tsx
@@ -1,13 +1,12 @@
 import { useState, useEffect } from 'react';
 import { TextInput, Textarea, Select, Stack, Group, Text } from '@mantine/core';
 import { useForm, zodResolver } from '@mantine/form';
-import { DateInput } from '@mantine/dates';
 import { notifications } from '@mantine/notifications';
 import { IconCheck, IconX } from '@tabler/icons-react';
 import { useUpdateEventMutation } from '@/app/features/events/api';
 import { useGetSessionsQuery } from '@/app/features/sessions/api';
 import { useEventStatusStyle } from '@/shared/hooks/useEventStatusStyle';
-import { parseDateOnly, formatDateOnly } from '@/shared/hooks/formatDate';
+// Dates are stored as YYYY-MM-DD strings, used directly with native date input
 import { eventUpdateSchema } from '../schemas/eventSettingsSchemas';
 import { Button } from '@/shared/components/buttons';
 import { COMMON_TIMEZONES } from '@/shared/constants/timezones';
@@ -26,8 +25,8 @@ type FormValues = {
   title: string;
   description: string;
   event_type: string;
-  start_date: Date | null;
-  end_date: Date | null;
+  start_date: string;
+  end_date: string;
   timezone: string;
   company_name: string;
   status: string;
@@ -59,8 +58,8 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
       title: event?.title || '',
       description: event?.description || '',
       event_type: event?.event_type || 'CONFERENCE',
-      start_date: parseDateOnly(event?.start_date),
-      end_date: parseDateOnly(event?.end_date),
+      start_date: event?.start_date || '',
+      end_date: event?.end_date || '',
       timezone: event?.timezone || 'UTC',
       company_name: event?.company_name || '',
       status: event?.status || 'DRAFT',
@@ -79,11 +78,8 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
       const changed = Object.keys(form.values).some((key) => {
         const formKey = key as keyof FormValues;
         if (formKey === 'start_date' || formKey === 'end_date') {
-          // Compare dates as YYYY-MM-DD strings to avoid timezone issues
-          const eventKey = formKey as 'start_date' | 'end_date';
-          const eventDate = event?.[eventKey] || null;
-          const formDate = formatDateOnly(form.values[formKey] as Date | null);
-          return eventDate !== formDate;
+          // Compare as strings directly (both are YYYY-MM-DD)
+          return form.values[formKey] !== (event?.[formKey] || '');
         }
         if (formKey === 'main_session_id') {
           return form.values[formKey] !== (event?.main_session_id?.toString() || null);
@@ -117,8 +113,8 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
         title: values.title,
         description: values.description || null,
         event_type: values.event_type as Event['event_type'],
-        start_date: formatDateOnly(values.start_date) || '',
-        end_date: formatDateOnly(values.end_date) || '',
+        start_date: values.start_date,
+        end_date: values.end_date,
         timezone: values.timezone,
         company_name: values.company_name,
         status: values.status as Event['status'],
@@ -150,8 +146,8 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
       title: event?.title || '',
       description: event?.description || '',
       event_type: event?.event_type || 'CONFERENCE',
-      start_date: parseDateOnly(event?.start_date),
-      end_date: parseDateOnly(event?.end_date),
+      start_date: event?.start_date || '',
+      end_date: event?.end_date || '',
       timezone: event?.timezone || 'UTC',
       company_name: event?.company_name || '',
       status: event?.status || 'DRAFT',
@@ -234,9 +230,9 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
           </Group>
 
           <Group grow>
-            <DateInput
+            <TextInput
+              type='date'
               label='Start Date'
-              placeholder='Select start date'
               required
               classNames={{
                 input: styles.formInput ?? '',
@@ -245,10 +241,11 @@ const BasicInfoSection = ({ event, eventId }: BasicInfoSectionProps) => {
               {...form.getInputProps('start_date')}
             />
 
-            <DateInput
+            <TextInput
+              type='date'
               label='End Date'
-              placeholder='Select end date'
               required
+              min={form.values.start_date}
               classNames={{
                 input: styles.formInput ?? '',
                 label: styles.formLabel ?? '',

--- a/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/styles.module.css
+++ b/frontend/src/pages/EventAdmin/EventSettings/BasicInfoSection/styles.module.css
@@ -30,9 +30,21 @@
   cursor: pointer;
 }
 
-/* Date Input Calendar Icon */
-.formInput[type='button'] {
+/* Date Input Styling */
+.formInput[type='date'] {
   cursor: pointer;
+  color-scheme: light; /* Ensures light theme for date picker */
+}
+
+/* Style the calendar icon (WebKit browsers) */
+.formInput[type='date']::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  filter: opacity(0.6);
+  transition: filter 0.2s ease;
+}
+
+.formInput[type='date']::-webkit-calendar-picker-indicator:hover {
+  filter: opacity(1);
 }
 
 /* Status-specific styling */

--- a/frontend/src/pages/EventAdmin/EventSettings/schemas/eventSettingsSchemas.ts
+++ b/frontend/src/pages/EventAdmin/EventSettings/schemas/eventSettingsSchemas.ts
@@ -5,16 +5,19 @@ export const eventUpdateSchema = z
     title: z.string().min(3, 'Title must be at least 3 characters'),
     description: z.string().optional(),
     event_type: z.enum(['CONFERENCE', 'SINGLE_SESSION']),
-    start_date: z.date({
-      required_error: 'Start date is required',
-    }),
-    end_date: z.date({
-      required_error: 'End date is required',
-    }),
+    start_date: z
+      .string()
+      .min(1, 'Start date is required')
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
+    end_date: z
+      .string()
+      .min(1, 'End date is required')
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
     timezone: z.string().min(1, 'Timezone is required'),
     company_name: z.string().min(1, 'Company name is required'),
     status: z.enum(['DRAFT', 'PUBLISHED', 'ARCHIVED']),
     main_session_id: z.string().nullable().optional(),
+    session_visibility_minutes: z.string().optional(),
   })
   .refine((data) => data.end_date >= data.start_date, {
     message: 'End date must be after start date',

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
@@ -443,8 +443,10 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
       </div>
 
       <div className={styles.content}>
-        <Group className={cn(styles.infoBar)}>
-          <Group gap='xs' align='center'>
+        {/* Type & Chat Row */}
+        <div>
+          <Text className={cn(styles.sectionLabel)}>Type & Chat</Text>
+          <Group gap='xs'>
             <Select
               value={sessionType}
               onChange={(value) => {
@@ -460,130 +462,158 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
               style={{ width: 140 }}
               classNames={{ input: cn(styles.formSelect) }}
             />
-          </Group>
-          <Select
-            value={chatMode}
-            onChange={(value) => {
-              if (value) {
-                setChatMode(value as SessionChatMode);
-                handleUpdate({ chat_mode: value as SessionChatMode });
-              }
-            }}
-            data={[...CHAT_MODES]}
-            size='sm'
-            allowDeselect={false}
-            style={{ width: 160 }}
-            classNames={{ input: cn(styles.formSelect) }}
-          />
-          <Select
-            placeholder='Streaming Platform'
-            value={streamingPlatform}
-            onChange={handlePlatformChange}
-            data={[...STREAMING_PLATFORMS]}
-            size='sm'
-            allowDeselect={false}
-            style={{ width: 180 }}
-            classNames={{ input: cn(styles.formSelect) }}
-          />
-        </Group>
-
-        {streamingPlatform === 'VIMEO' && (
-          <Group gap='xs' style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder='Vimeo URL or video ID'
-              size='sm'
-              style={{ flex: 1 }}
-              value={streamUrl}
-              onChange={(e) => setStreamUrl(e.target.value)}
-              error={errors.stream_url}
-              classNames={{ input: cn(styles.formInput) }}
-            />
-          </Group>
-        )}
-
-        {streamingPlatform === 'MUX' && (
-          <Group gap='xs' style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder='Mux Playback ID or stream URL'
-              size='sm'
-              style={{ flex: 1 }}
-              value={streamUrl}
-              onChange={(e) => setStreamUrl(e.target.value)}
-              error={errors.stream_url}
-              classNames={{ input: cn(styles.formInput) }}
-            />
             <Select
-              placeholder='Policy'
-              value={muxPlaybackPolicy}
+              value={chatMode}
               onChange={(value) => {
-                if (value === 'PUBLIC' || value === 'SIGNED') {
-                  setMuxPlaybackPolicy(value);
-                  handleUpdate({ mux_playback_policy: value });
+                if (value) {
+                  setChatMode(value as SessionChatMode);
+                  handleUpdate({ chat_mode: value as SessionChatMode });
                 }
               }}
-              data={[...MUX_PLAYBACK_POLICIES]}
+              data={[...CHAT_MODES]}
               size='sm'
               allowDeselect={false}
-              style={{ width: 120 }}
+              style={{ width: 160 }}
               classNames={{ input: cn(styles.formSelect) }}
             />
           </Group>
-        )}
+        </div>
 
-        {streamingPlatform === 'ZOOM' && (
-          <Group gap='xs' style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder='Zoom meeting URL or ID'
+        {/* Streaming Row */}
+        <div style={{ marginTop: 12 }}>
+          <Text className={cn(styles.sectionLabel)}>Streaming & Recording</Text>
+          <Group gap='xs' wrap='wrap'>
+            <Select
+              value={streamingPlatform}
+              onChange={handlePlatformChange}
+              data={[...STREAMING_PLATFORMS]}
               size='sm'
-              style={{ flex: 1 }}
-              value={zoomMeetingId}
-              onChange={(e) => setZoomMeetingId(e.target.value)}
-              error={errors.zoom_meeting_id}
-              classNames={{ input: cn(styles.formInput) }}
-            />
-            <TextInput
-              placeholder='Passcode (optional)'
-              size='sm'
+              allowDeselect={false}
               style={{ width: 150 }}
-              value={zoomPasscode}
-              onChange={(e) => setZoomPasscode(e.target.value)}
-              classNames={{ input: cn(styles.formInput) }}
+              classNames={{ input: cn(styles.formSelect) }}
             />
+            {streamingPlatform === 'VIMEO' && (
+              <TextInput
+                placeholder='Vimeo URL or video ID'
+                size='sm'
+                style={{ flex: 1, minWidth: 200 }}
+                value={streamUrl}
+                onChange={(e) => setStreamUrl(e.target.value)}
+                error={errors.stream_url}
+                classNames={{ input: cn(styles.formInput) }}
+              />
+            )}
+            {streamingPlatform === 'MUX' && (
+              <>
+                <TextInput
+                  placeholder='Mux Playback ID'
+                  size='sm'
+                  style={{ flex: 1, minWidth: 180 }}
+                  value={streamUrl}
+                  onChange={(e) => setStreamUrl(e.target.value)}
+                  error={errors.stream_url}
+                  classNames={{ input: cn(styles.formInput) }}
+                />
+                <Select
+                  value={muxPlaybackPolicy}
+                  onChange={(value) => {
+                    if (value === 'PUBLIC' || value === 'SIGNED') {
+                      setMuxPlaybackPolicy(value);
+                      handleUpdate({ mux_playback_policy: value });
+                    }
+                  }}
+                  data={[...MUX_PLAYBACK_POLICIES]}
+                  size='sm'
+                  allowDeselect={false}
+                  style={{ width: 100 }}
+                  classNames={{ input: cn(styles.formSelect) }}
+                />
+              </>
+            )}
+            {streamingPlatform === 'ZOOM' && (
+              <>
+                <TextInput
+                  placeholder='Zoom meeting URL or ID'
+                  size='sm'
+                  style={{ flex: 1, minWidth: 180 }}
+                  value={zoomMeetingId}
+                  onChange={(e) => setZoomMeetingId(e.target.value)}
+                  error={errors.zoom_meeting_id}
+                  classNames={{ input: cn(styles.formInput) }}
+                />
+                <TextInput
+                  placeholder='Passcode'
+                  size='sm'
+                  style={{ width: 120 }}
+                  value={zoomPasscode}
+                  onChange={(e) => setZoomPasscode(e.target.value)}
+                  classNames={{ input: cn(styles.formInput) }}
+                />
+              </>
+            )}
+            {streamingPlatform === 'JITSI' && (
+              <TextInput
+                placeholder='Jitsi room name or URL'
+                size='sm'
+                style={{ flex: 1, minWidth: 200 }}
+                value={jitsiRoomName}
+                onChange={(e) => setJitsiRoomName(e.target.value)}
+                error={errors.jitsi_room_name}
+                classNames={{ input: cn(styles.formInput) }}
+              />
+            )}
+            {streamingPlatform === 'OTHER' && (
+              <TextInput
+                placeholder='External stream URL'
+                size='sm'
+                style={{ flex: 1, minWidth: 200 }}
+                value={streamUrl}
+                onChange={(e) => setStreamUrl(e.target.value)}
+                error={errors.stream_url}
+                classNames={{ input: cn(styles.formInput) }}
+              />
+            )}
           </Group>
-        )}
-
-        {streamingPlatform === 'JITSI' && (
-          <Group gap='xs' style={{ marginTop: 8 }}>
+          {/* Recording URL - Optional, Vimeo/Mux auto-detect from stream */}
+          <Group gap='xs' mt={8} wrap='wrap' align='flex-end'>
             <TextInput
-              placeholder='Jitsi room name or URL'
+              placeholder='Recording URL (optional)'
               size='sm'
-              style={{ flex: 1 }}
-              value={jitsiRoomName}
-              onChange={(e) => setJitsiRoomName(e.target.value)}
-              error={errors.jitsi_room_name}
+              style={{ flex: 1, minWidth: 200 }}
+              value={vodUrl}
+              onChange={(e) => setVodUrl(e.target.value)}
               classNames={{ input: cn(styles.formInput) }}
             />
+            {vodUrl && (
+              <Select
+                value={vodPlatform}
+                onChange={(value) => {
+                  const newValue = (value ?? '') as StreamingPlatform | '';
+                  setVodPlatform(newValue);
+                  handleUpdate({ vod_platform: newValue || null });
+                }}
+                data={[...VOD_PLATFORMS]}
+                size='sm'
+                allowDeselect={false}
+                style={{ width: 120 }}
+                classNames={{ input: cn(styles.formSelect) }}
+              />
+            )}
           </Group>
-        )}
+          {(streamingPlatform === 'VIMEO' || streamingPlatform === 'MUX') && !vodUrl && (
+            <Text size='xs' c='dimmed' mt={4}>
+              Vimeo/Mux will use stream URL for recording if left blank
+            </Text>
+          )}
+        </div>
 
-        {streamingPlatform === 'OTHER' && (
-          <Group gap='xs' style={{ marginTop: 8 }}>
-            <TextInput
-              placeholder='External stream URL (https://...)'
-              size='sm'
-              style={{ flex: 1 }}
-              value={streamUrl}
-              onChange={(e) => setStreamUrl(e.target.value)}
-              error={errors.stream_url}
-              classNames={{ input: cn(styles.formInput) }}
-            />
-          </Group>
-        )}
-
-        {/* Visibility Window and VOD */}
-        <Group gap='xs' style={{ marginTop: 8 }}>
+        {/* Visibility Window */}
+        <div style={{ marginTop: 12 }}>
+          <Text className={cn(styles.sectionLabel)}>Access Window</Text>
+          <Text size='xs' c='dimmed' mb={6}>
+            Buffer time before and after session when stream and chat are accessible
+          </Text>
           <Select
-            placeholder='Visibility'
             value={visibilityMinutesOverride}
             onChange={(value) => {
               const newValue = value ?? '';
@@ -595,34 +625,10 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
             data={[...VISIBILITY_WINDOW_OPTIONS]}
             size='sm'
             allowDeselect={false}
-            style={{ width: 130 }}
+            style={{ width: 160 }}
             classNames={{ input: cn(styles.formSelect) }}
           />
-          <TextInput
-            placeholder='Recording URL (optional)'
-            size='sm'
-            style={{ flex: 1 }}
-            value={vodUrl}
-            onChange={(e) => setVodUrl(e.target.value)}
-            classNames={{ input: cn(styles.formInput) }}
-          />
-          {vodUrl && (
-            <Select
-              placeholder='VOD Platform'
-              value={vodPlatform}
-              onChange={(value) => {
-                const newValue = (value ?? '') as StreamingPlatform | '';
-                setVodPlatform(newValue);
-                handleUpdate({ vod_platform: newValue || null });
-              }}
-              data={[...VOD_PLATFORMS]}
-              size='sm'
-              allowDeselect={false}
-              style={{ width: 120 }}
-              classNames={{ input: cn(styles.formSelect) }}
-            />
-          )}
-        </Group>
+        </div>
 
         <div className={styles.speakersSection}>
           {(() => {
@@ -685,29 +691,36 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
           })()}
         </div>
 
-        <Textarea
-          value={shortDescription}
-          onChange={(e) => setShortDescription(e.target.value)}
-          placeholder='Short description for agenda (max 200 characters)'
-          maxLength={200}
-          autosize
-          minRows={1}
-          maxRows={3}
-          size='sm'
-          error={errors.short_description}
-          classNames={{ input: cn(styles.formTextarea) }}
-        />
+        {/* Descriptions */}
+        <div style={{ marginTop: 12 }}>
+          <Text className={cn(styles.sectionLabel)}>Short Description (Agenda)</Text>
+          <Textarea
+            value={shortDescription}
+            onChange={(e) => setShortDescription(e.target.value)}
+            placeholder='Brief summary shown in the schedule (max 200 characters)'
+            maxLength={200}
+            autosize
+            minRows={1}
+            maxRows={3}
+            size='sm'
+            error={errors.short_description}
+            classNames={{ input: cn(styles.formTextarea) }}
+          />
+        </div>
 
-        <Textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder='Full session description'
-          autosize
-          minRows={2}
-          maxRows={6}
-          classNames={{ input: cn(styles.formTextarea) }}
-          className={cn(styles.descriptionTextarea)}
-        />
+        <div style={{ marginTop: 12 }}>
+          <Text className={cn(styles.sectionLabel)}>Full Description</Text>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder='Detailed description shown on the session page'
+            autosize
+            minRows={2}
+            maxRows={6}
+            classNames={{ input: cn(styles.formTextarea) }}
+            className={cn(styles.descriptionTextarea)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
@@ -227,7 +227,10 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({ ...prev, stream_url: zodError.errors[0]?.message ?? 'Invalid value' }));
+      setErrors((prev) => ({
+        ...prev,
+        stream_url: zodError.errors[0]?.message ?? 'Invalid value',
+      }));
       return;
     }
 
@@ -268,7 +271,10 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     const validation = validateZoomMeetingId(debouncedZoomMeetingId);
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({ ...prev, zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value' }));
+      setErrors((prev) => ({
+        ...prev,
+        zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value',
+      }));
       return;
     }
 
@@ -317,7 +323,10 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     const validation = validateJitsiRoomName(debouncedJitsiRoomName);
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({ ...prev, jitsi_room_name: zodError.errors[0]?.message ?? 'Invalid value' }));
+      setErrors((prev) => ({
+        ...prev,
+        jitsi_room_name: zodError.errors[0]?.message ?? 'Invalid value',
+      }));
       return;
     }
 

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { TextInput, Textarea, Select, Group, Text, ActionIcon, Menu, Badge } from '@mantine/core';
 import { TimeSelect } from '@/shared/components/forms/TimeSelect';
 import { IconDots, IconTrash, IconAlertCircle } from '@tabler/icons-react';
@@ -11,6 +11,9 @@ import { cn } from '@/lib/cn';
 import {
   validateField,
   validateTimeOrder,
+  validateStreamUrl,
+  validateZoomMeetingId,
+  validateJitsiRoomName,
   type SessionFieldName,
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
@@ -107,7 +110,6 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   );
 
   const [errors, setErrors] = useState<FieldErrors>({});
-  const pendingPlatformChangeRef = useRef(false);
 
   const [debouncedTitle] = useDebouncedValue(title, 500);
   const [debouncedDescription] = useDebouncedValue(description, 500);
@@ -182,14 +184,18 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   }, [debouncedTitle, session.title, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    if (debouncedDescription !== session.description) {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionDesc = session.description ?? '';
+    if (debouncedDescription !== normalizedSessionDesc) {
       handleUpdate({ description: debouncedDescription || null });
     }
   }, [debouncedDescription, session.description, handleUpdate]);
 
   useEffect(() => {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionShort = session.short_description ?? '';
     if (
-      debouncedShortDescription !== session.short_description &&
+      debouncedShortDescription !== normalizedSessionShort &&
       validateAndUpdate('short_description', debouncedShortDescription)
     ) {
       handleUpdate({ short_description: debouncedShortDescription || null });
@@ -197,79 +203,141 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   }, [debouncedShortDescription, session.short_description, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    if (
-      debouncedStreamUrl !== session.stream_url &&
-      (debouncedStreamUrl === '' || validateAndUpdate('stream_url', debouncedStreamUrl))
-    ) {
-      if (pendingPlatformChangeRef.current) {
-        handleUpdate({
-          streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-          stream_url: debouncedStreamUrl || null,
-        });
-        pendingPlatformChangeRef.current = false;
-      } else {
-        handleUpdate({ stream_url: debouncedStreamUrl || null });
-      }
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionUrl = session.stream_url ?? '';
+    const hasActualChange = debouncedStreamUrl !== normalizedSessionUrl;
+
+    if (!hasActualChange) return;
+
+    // Empty value is valid (clearing the field)
+    if (debouncedStreamUrl === '') {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors.stream_url;
+        return newErrors;
+      });
+      handleUpdate({
+        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+        stream_url: null,
+      });
+      return;
     }
-  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate, validateAndUpdate]);
+
+    // Validate with platform-aware schema
+    const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
+    if (!validation.success) {
+      const zodError = validation.error as { errors: { message: string }[] };
+      setErrors((prev) => ({ ...prev, stream_url: zodError.errors[0]?.message ?? 'Invalid value' }));
+      return;
+    }
+
+    // Clear error and send update
+    setErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors.stream_url;
+      return newErrors;
+    });
+    handleUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      stream_url: debouncedStreamUrl,
+    });
+  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate]);
 
   useEffect(() => {
-    if (
-      debouncedZoomMeetingId !== session.zoom_meeting_id &&
-      (debouncedZoomMeetingId === '' ||
-        validateAndUpdate('zoom_meeting_id', debouncedZoomMeetingId))
-    ) {
-      if (pendingPlatformChangeRef.current) {
-        handleUpdate({
-          streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-          zoom_meeting_id: debouncedZoomMeetingId || null,
-        });
-        pendingPlatformChangeRef.current = false;
-      } else {
-        handleUpdate({ zoom_meeting_id: debouncedZoomMeetingId || null });
-      }
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionZoom = session.zoom_meeting_id ?? '';
+    const hasActualChange = debouncedZoomMeetingId !== normalizedSessionZoom;
+
+    if (!hasActualChange) return;
+
+    // Empty value is valid (clearing the field)
+    if (debouncedZoomMeetingId === '') {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors.zoom_meeting_id;
+        return newErrors;
+      });
+      handleUpdate({
+        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+        zoom_meeting_id: null,
+      });
+      return;
     }
-  }, [
-    debouncedZoomMeetingId,
-    session.zoom_meeting_id,
-    streamingPlatform,
-    handleUpdate,
-    validateAndUpdate,
-  ]);
+
+    // Validate with Zoom-specific schema
+    const validation = validateZoomMeetingId(debouncedZoomMeetingId);
+    if (!validation.success) {
+      const zodError = validation.error as { errors: { message: string }[] };
+      setErrors((prev) => ({ ...prev, zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value' }));
+      return;
+    }
+
+    // Clear error and send update
+    setErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors.zoom_meeting_id;
+      return newErrors;
+    });
+    handleUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      zoom_meeting_id: debouncedZoomMeetingId,
+    });
+  }, [debouncedZoomMeetingId, session.zoom_meeting_id, streamingPlatform, handleUpdate]);
 
   useEffect(() => {
-    if (debouncedZoomPasscode !== session.zoom_passcode) {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionPasscode = session.zoom_passcode ?? '';
+    if (debouncedZoomPasscode !== normalizedSessionPasscode) {
       handleUpdate({ zoom_passcode: debouncedZoomPasscode || null });
     }
   }, [debouncedZoomPasscode, session.zoom_passcode, handleUpdate]);
 
   useEffect(() => {
-    if (
-      debouncedJitsiRoomName !== session.jitsi_room_name &&
-      (debouncedJitsiRoomName === '' ||
-        validateAndUpdate('jitsi_room_name', debouncedJitsiRoomName))
-    ) {
-      if (pendingPlatformChangeRef.current) {
-        handleUpdate({
-          streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-          jitsi_room_name: debouncedJitsiRoomName || null,
-        });
-        pendingPlatformChangeRef.current = false;
-      } else {
-        handleUpdate({ jitsi_room_name: debouncedJitsiRoomName || null });
-      }
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionJitsi = session.jitsi_room_name ?? '';
+    const hasActualChange = debouncedJitsiRoomName !== normalizedSessionJitsi;
+
+    if (!hasActualChange) return;
+
+    // Empty value is valid (clearing the field)
+    if (debouncedJitsiRoomName === '') {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors.jitsi_room_name;
+        return newErrors;
+      });
+      handleUpdate({
+        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+        jitsi_room_name: null,
+      });
+      return;
     }
-  }, [
-    debouncedJitsiRoomName,
-    session.jitsi_room_name,
-    streamingPlatform,
-    handleUpdate,
-    validateAndUpdate,
-  ]);
+
+    // Validate with Jitsi-specific schema
+    const validation = validateJitsiRoomName(debouncedJitsiRoomName);
+    if (!validation.success) {
+      const zodError = validation.error as { errors: { message: string }[] };
+      setErrors((prev) => ({ ...prev, jitsi_room_name: zodError.errors[0]?.message ?? 'Invalid value' }));
+      return;
+    }
+
+    // Clear error and send update
+    setErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors.jitsi_room_name;
+      return newErrors;
+    });
+    handleUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      jitsi_room_name: debouncedJitsiRoomName,
+    });
+  }, [debouncedJitsiRoomName, session.jitsi_room_name, streamingPlatform, handleUpdate]);
 
   // Auto-save VOD URL (debounced)
   useEffect(() => {
-    if (debouncedVodUrl !== session.vod_url) {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionVod = session.vod_url ?? '';
+    if (debouncedVodUrl !== normalizedSessionVod) {
       handleUpdate({ vod_url: debouncedVodUrl || null });
     }
   }, [debouncedVodUrl, session.vod_url, handleUpdate]);
@@ -358,6 +426,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     setStreamingPlatform(platformValue);
 
     if (!value || value === '') {
+      // Clearing platform - reset all streaming fields and update immediately
       setStreamUrl('');
       setZoomMeetingId('');
       setZoomPasscode('');
@@ -371,10 +440,9 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
         mux_playback_policy: null,
         jitsi_room_name: null,
       });
-      pendingPlatformChangeRef.current = false;
-    } else {
-      pendingPlatformChangeRef.current = true;
     }
+    // When selecting a platform, just set local state - the URL effect will
+    // send platform+URL together when user enters the URL
   };
 
   return (

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
   TextInput,
   Textarea,
@@ -29,6 +29,8 @@ import { cn } from '@/lib/cn';
 import {
   validateField,
   validateTimeOrder,
+  validateStreamUrl,
+  validateZoomMeetingId,
   type SessionFieldName,
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
@@ -97,7 +99,6 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   );
 
   const [errors, setErrors] = useState<FieldErrors>({});
-  const pendingPlatformChangeRef = useRef(false);
 
   const [debouncedTitle] = useDebouncedValue(title, 500);
   const [debouncedDescription] = useDebouncedValue(description, 500);
@@ -162,14 +163,18 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   }, [debouncedTitle, session.title, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    if (debouncedDescription !== session.description) {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionDesc = session.description ?? '';
+    if (debouncedDescription !== normalizedSessionDesc) {
       handleUpdate({ description: debouncedDescription || null });
     }
   }, [debouncedDescription, session.description, handleUpdate]);
 
   useEffect(() => {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionShort = session.short_description ?? '';
     if (
-      debouncedShortDescription !== session.short_description &&
+      debouncedShortDescription !== normalizedSessionShort &&
       validateAndUpdate('short_description', debouncedShortDescription)
     ) {
       handleUpdate({ short_description: debouncedShortDescription || null });
@@ -177,48 +182,91 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   }, [debouncedShortDescription, session.short_description, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    if (
-      debouncedStreamUrl !== session.stream_url &&
-      (debouncedStreamUrl === '' || validateAndUpdate('stream_url', debouncedStreamUrl))
-    ) {
-      if (pendingPlatformChangeRef.current) {
-        handleUpdate({
-          streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-          stream_url: debouncedStreamUrl || null,
-        });
-        pendingPlatformChangeRef.current = false;
-      } else {
-        handleUpdate({ stream_url: debouncedStreamUrl || null });
-      }
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionUrl = session.stream_url ?? '';
+    const hasActualChange = debouncedStreamUrl !== normalizedSessionUrl;
+
+    if (!hasActualChange) return;
+
+    // Empty value is valid (clearing the field)
+    if (debouncedStreamUrl === '') {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors.stream_url;
+        return newErrors;
+      });
+      handleUpdate({
+        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+        stream_url: null,
+      });
+      return;
     }
-  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate, validateAndUpdate]);
+
+    // Validate with platform-aware schema
+    const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
+    if (!validation.success) {
+      const zodError = validation.error as { errors: { message: string }[] };
+      setErrors((prev) => ({ ...prev, stream_url: zodError.errors[0]?.message ?? 'Invalid value' }));
+      return;
+    }
+
+    // Clear error and send update - always send platform with URL
+    setErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors.stream_url;
+      return newErrors;
+    });
+    handleUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      stream_url: debouncedStreamUrl,
+    });
+  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate]);
 
   useEffect(() => {
-    if (
-      debouncedZoomMeetingId !== session.zoom_meeting_id &&
-      (debouncedZoomMeetingId === '' ||
-        validateAndUpdate('zoom_meeting_id', debouncedZoomMeetingId))
-    ) {
-      if (pendingPlatformChangeRef.current) {
-        handleUpdate({
-          streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-          zoom_meeting_id: debouncedZoomMeetingId || null,
-        });
-        pendingPlatformChangeRef.current = false;
-      } else {
-        handleUpdate({ zoom_meeting_id: debouncedZoomMeetingId || null });
-      }
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionZoom = session.zoom_meeting_id ?? '';
+    const hasActualChange = debouncedZoomMeetingId !== normalizedSessionZoom;
+
+    if (!hasActualChange) return;
+
+    // Empty value is valid (clearing the field)
+    if (debouncedZoomMeetingId === '') {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors.zoom_meeting_id;
+        return newErrors;
+      });
+      handleUpdate({
+        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+        zoom_meeting_id: null,
+      });
+      return;
     }
-  }, [
-    debouncedZoomMeetingId,
-    session.zoom_meeting_id,
-    streamingPlatform,
-    handleUpdate,
-    validateAndUpdate,
-  ]);
+
+    // Validate with Zoom-specific schema
+    const validation = validateZoomMeetingId(debouncedZoomMeetingId);
+    if (!validation.success) {
+      const zodError = validation.error as { errors: { message: string }[] };
+      setErrors((prev) => ({ ...prev, zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value' }));
+      return;
+    }
+
+    // Clear error and send update - always send platform with zoom_meeting_id
+    setErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors.zoom_meeting_id;
+      return newErrors;
+    });
+    handleUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      zoom_meeting_id: debouncedZoomMeetingId,
+    });
+  }, [debouncedZoomMeetingId, session.zoom_meeting_id, streamingPlatform, handleUpdate]);
 
   useEffect(() => {
-    if (debouncedZoomPasscode !== session.zoom_passcode) {
+    // Normalize comparison: treat null, undefined, '' as equivalent
+    const normalizedSessionPasscode = session.zoom_passcode ?? '';
+    if (debouncedZoomPasscode !== normalizedSessionPasscode) {
       handleUpdate({ zoom_passcode: debouncedZoomPasscode || null });
     }
   }, [debouncedZoomPasscode, session.zoom_passcode, handleUpdate]);
@@ -447,6 +495,7 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                 const platformValue = value as StreamingPlatform | '';
                 setStreamingPlatform(platformValue);
                 if (!value || value === '') {
+                  // Clearing platform - reset all streaming fields and update immediately
                   setStreamUrl('');
                   setZoomMeetingId('');
                   setZoomPasscode('');
@@ -458,10 +507,9 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                     zoom_passcode: null,
                     mux_playback_policy: null,
                   });
-                  pendingPlatformChangeRef.current = false;
-                } else {
-                  pendingPlatformChangeRef.current = true;
                 }
+                // When selecting a platform, just set local state - the URL effect will
+                // send platform+URL together when user enters the URL
               }}
               data={[...STREAMING_PLATFORMS]}
               size='sm'

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
@@ -206,7 +206,10 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
     const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({ ...prev, stream_url: zodError.errors[0]?.message ?? 'Invalid value' }));
+      setErrors((prev) => ({
+        ...prev,
+        stream_url: zodError.errors[0]?.message ?? 'Invalid value',
+      }));
       return;
     }
 
@@ -247,7 +250,10 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
     const validation = validateZoomMeetingId(debouncedZoomMeetingId);
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({ ...prev, zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value' }));
+      setErrors((prev) => ({
+        ...prev,
+        zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value',
+      }));
       return;
     }
 

--- a/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
@@ -21,9 +21,7 @@ const muxSchema = z
     'Enter Mux Playback ID (10+ alphanumeric chars) or stream URL',
   );
 
-const otherUrlSchema = z
-  .string()
-  .regex(/^https:\/\/.+/, 'Must be a valid HTTPS URL');
+const otherUrlSchema = z.string().regex(/^https:\/\/.+/, 'Must be a valid HTTPS URL');
 
 const zoomSchema = z
   .string()
@@ -131,17 +129,13 @@ export const validateStreamUrl = (
 };
 
 // Platform-aware validation for Zoom meeting ID
-export const validateZoomMeetingId = (
-  value: string,
-): z.SafeParseReturnType<string, string> => {
+export const validateZoomMeetingId = (value: string): z.SafeParseReturnType<string, string> => {
   if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
   return zoomSchema.safeParse(value);
 };
 
 // Platform-aware validation for Jitsi room name
-export const validateJitsiRoomName = (
-  value: string,
-): z.SafeParseReturnType<string, string> => {
+export const validateJitsiRoomName = (value: string): z.SafeParseReturnType<string, string> => {
   if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
   return jitsiSchema.safeParse(value);
 };

--- a/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
@@ -6,6 +6,39 @@ const StreamingPlatform = z.enum(['VIMEO', 'MUX', 'ZOOM', 'JITSI', 'OTHER']);
 
 const MuxPlaybackPolicy = z.enum(['PUBLIC', 'SIGNED']);
 
+// Platform-specific URL/ID validation patterns
+const vimeoSchema = z
+  .string()
+  .regex(
+    /^(\d+|https?:\/\/(player\.)?vimeo\.com\/(video\/)?\d+.*)$/,
+    'Enter Vimeo video ID (numbers only) or full URL (https://vimeo.com/123456789)',
+  );
+
+const muxSchema = z
+  .string()
+  .regex(
+    /^([a-zA-Z0-9]{10,}|https?:\/\/stream\.mux\.com\/.+)$/,
+    'Enter Mux Playback ID (10+ alphanumeric chars) or stream URL',
+  );
+
+const otherUrlSchema = z
+  .string()
+  .regex(/^https:\/\/.+/, 'Must be a valid HTTPS URL');
+
+const zoomSchema = z
+  .string()
+  .regex(
+    /^(https?:\/\/([\w-]+\.)?zoom\.us\/j\/\d+.*|\d[\d\s-]{8,14}\d)$/,
+    'Enter Zoom meeting URL or ID (9-11 digits, spaces/dashes OK)',
+  );
+
+const jitsiSchema = z
+  .string()
+  .regex(
+    /^(https?:\/\/.+|[a-zA-Z0-9][a-zA-Z0-9\s_-]{1,198}[a-zA-Z0-9])$/,
+    'Enter Jitsi room name (3+ chars) or full URL',
+  );
+
 // Schema for individual field validation
 export const sessionFieldSchemas = {
   title: z.string().min(1, 'Title is required').max(255, 'Title too long'),
@@ -77,3 +110,38 @@ export const validateTimeOrder = (startTime: string, endTime: string): TimeValid
 export type SessionTypeValue = z.infer<typeof SessionType>;
 export type StreamingPlatformValue = z.infer<typeof StreamingPlatform>;
 export type MuxPlaybackPolicyValue = z.infer<typeof MuxPlaybackPolicy>;
+
+// Platform-aware validation for stream URL (used by Vimeo, Mux, Other)
+export const validateStreamUrl = (
+  platform: string | null | undefined,
+  value: string,
+): z.SafeParseReturnType<string, string> => {
+  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+
+  switch (platform) {
+    case 'VIMEO':
+      return vimeoSchema.safeParse(value);
+    case 'MUX':
+      return muxSchema.safeParse(value);
+    case 'OTHER':
+      return otherUrlSchema.safeParse(value);
+    default:
+      return { success: true, data: value } as z.SafeParseSuccess<string>;
+  }
+};
+
+// Platform-aware validation for Zoom meeting ID
+export const validateZoomMeetingId = (
+  value: string,
+): z.SafeParseReturnType<string, string> => {
+  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  return zoomSchema.safeParse(value);
+};
+
+// Platform-aware validation for Jitsi room name
+export const validateJitsiRoomName = (
+  value: string,
+): z.SafeParseReturnType<string, string> => {
+  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  return jitsiSchema.safeParse(value);
+};

--- a/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
+++ b/frontend/src/pages/EventAdmin/SessionManager/styles/index.module.css
@@ -331,6 +331,16 @@
   min-height: 60px;
 }
 
+/* Section labels for inline form groups */
+.sectionLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.35rem;
+}
+
 /* Form inputs within modals - Subtle and clean */
 .formInput,
 .formSelect,


### PR DESCRIPTION
## Summary
- **Section labels for SessionCard**: Added labeled sections (Type & Chat, Streaming & Recording, Access Window, Short/Full Description) to desktop inline editor for better UX
- **Native date picker**: Switched Event Settings to native HTML5 date input for better mobile support and consistency with EventModal
- **Platform-aware streaming validation**: Added Zod validators for Vimeo, Mux, Zoom, Jitsi, and Other platforms with immediate inline error feedback
- **Fixed streaming platform updates**: Always send platform+URL together, fixing 422 errors when switching platforms

## Changes
- `SessionCard/index.tsx`: Section labels, platform-aware validation, simplified update logic
- `SessionCardMobile/index.tsx`: Same validation fixes applied to mobile
- `sessionCardSchema.ts`: Added platform-specific Zod validators (Vimeo numeric ID, Mux playback ID, Zoom meeting ID, Jitsi room name, HTTPS URLs)
- `BasicInfoSection/index.tsx`: Native date picker with updated Zod schema

## Test plan
- [x] Test date picker in Event Settings on desktop and mobile
- [x] Verify section labels display correctly in SessionCard
- [x] Test switching streaming platforms (Vimeo → Mux → Zoom)
- [x] Test entering invalid formats (letters for Vimeo ID, non-HTTPS for Other)
- [x] Verify inline error messages appear before backend validation