### PR TITLE
refactor: streaming validation hook and cache improvements

### DIFF
--- a/frontend/src/app/features/sessions/api.ts
+++ b/frontend/src/app/features/sessions/api.ts
@@ -135,7 +135,16 @@ export const sessionsApi = baseApi.injectEndpoints({
         url: `/events/${eventId}/sessions`,
         params: { day_number: dayNumber, page, per_page },
       }),
-      providesTags: ['Sessions'],
+      // Provide tags for each session + a LIST tag
+      // This allows updateSession to invalidate just the specific session in the cache
+      // without refetching the entire list
+      providesTags: (result) =>
+        result ?
+          [
+            ...result.sessions.map(({ id }) => ({ type: 'Sessions' as const, id })),
+            { type: 'Sessions' as const, id: 'LIST' },
+          ]
+        : [{ type: 'Sessions' as const, id: 'LIST' }],
     }),
     getSession: builder.query<Session, GetSessionParams>({
       query: ({ id }) => ({
@@ -152,7 +161,7 @@ export const sessionsApi = baseApi.injectEndpoints({
       invalidatesTags: (_result, _error, { eventId }) => [
         { type: 'Events' as const, id: eventId },
         'Events',
-        'Sessions',
+        { type: 'Sessions' as const, id: 'LIST' },
       ],
     }),
     updateSession: builder.mutation<Session, UpdateSessionParams>({
@@ -195,7 +204,11 @@ export const sessionsApi = baseApi.injectEndpoints({
         method: 'POST',
         body: speakerData,
       }),
-      invalidatesTags: ['SessionSpeakers', 'Sessions', 'EventUsers'],
+      invalidatesTags: (_result, _error, { sessionId }) => [
+        'SessionSpeakers',
+        { type: 'Sessions' as const, id: sessionId },
+        'EventUsers',
+      ],
     }),
     updateSessionSpeaker: builder.mutation<void, UpdateSessionSpeakerParams>({
       query: ({ sessionId, userId, ...updates }) => ({
@@ -203,7 +216,10 @@ export const sessionsApi = baseApi.injectEndpoints({
         method: 'PUT',
         body: updates,
       }),
-      invalidatesTags: ['SessionSpeakers', 'Sessions'],
+      invalidatesTags: (_result, _error, { sessionId }) => [
+        'SessionSpeakers',
+        { type: 'Sessions' as const, id: sessionId },
+      ],
     }),
     reorderSessionSpeaker: builder.mutation<void, ReorderSessionSpeakerParams>({
       query: ({ sessionId, userId, order }) => ({
@@ -211,21 +227,31 @@ export const sessionsApi = baseApi.injectEndpoints({
         method: 'PUT',
         body: { order },
       }),
-      invalidatesTags: ['SessionSpeakers', 'Sessions'],
+      invalidatesTags: (_result, _error, { sessionId }) => [
+        'SessionSpeakers',
+        { type: 'Sessions' as const, id: sessionId },
+      ],
     }),
     removeSessionSpeaker: builder.mutation<void, RemoveSessionSpeakerParams>({
       query: ({ sessionId, userId }) => ({
         url: `/sessions/${sessionId}/speakers/${userId}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['SessionSpeakers', 'Sessions', 'EventUsers'],
+      invalidatesTags: (_result, _error, { sessionId }) => [
+        'SessionSpeakers',
+        { type: 'Sessions' as const, id: sessionId },
+        'EventUsers',
+      ],
     }),
     deleteSession: builder.mutation<void, DeleteSessionParams>({
       query: ({ id }) => ({
         url: `/sessions/${id}`,
         method: 'DELETE',
       }),
-      invalidatesTags: ['Sessions'],
+      invalidatesTags: (_result, _error, { id }) => [
+        { type: 'Sessions' as const, id },
+        { type: 'Sessions' as const, id: 'LIST' },
+      ],
     }),
   }),
 });

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
@@ -21,12 +21,10 @@ import { cn } from '@/lib/cn';
 import {
   validateField,
   validateTimeOrder,
-  validateStreamUrl,
-  validateZoomMeetingId,
-  validateJitsiRoomName,
   type SessionFieldName,
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
+import { useSessionStreaming } from '../hooks';
 import type { Session, StreamingPlatform, SessionSpeaker } from '@/types';
 import type { SessionType, SessionChatMode, SessionStatus } from '@/types/enums';
 import styles from '../styles/index.module.css';
@@ -113,6 +111,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   const [updateSession] = useUpdateSessionMutation();
   const [deleteSession] = useDeleteSessionMutation();
 
+  // Non-streaming state
   const [title, setTitle] = useState(session.title);
   const [description, setDescription] = useState(session.description ?? '');
   const [shortDescription, setShortDescription] = useState(session.short_description ?? '');
@@ -122,44 +121,17 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   const [startTime, setStartTime] = useState(session.start_time);
   const [endTime, setEndTime] = useState(session.end_time);
   const [chatMode, setChatMode] = useState<SessionChatMode>(session.chat_mode ?? 'ENABLED');
-
-  const [streamingPlatform, setStreamingPlatform] = useState<StreamingPlatform | ''>(
-    session.streaming_platform ?? '',
-  );
-  const [streamUrl, setStreamUrl] = useState(session.stream_url ?? '');
-  const [zoomMeetingId, setZoomMeetingId] = useState(session.zoom_meeting_id ?? '');
-  const [zoomPasscode, setZoomPasscode] = useState(session.zoom_passcode ?? '');
-  const [muxPlaybackPolicy, setMuxPlaybackPolicy] = useState(
-    session.mux_playback_policy ?? 'PUBLIC',
-  );
-  const [jitsiRoomName, setJitsiRoomName] = useState(session.jitsi_room_name ?? '');
-
-  // Visibility window and VOD fields
   const [visibilityMinutesOverride, setVisibilityMinutesOverride] = useState<string>(
     session.visibility_minutes_override != null ?
       session.visibility_minutes_override.toString()
     : '',
   );
-  const [vodUrl, setVodUrl] = useState(session.vod_url ?? '');
-  const [vodPlatform, setVodPlatform] = useState<StreamingPlatform | ''>(
-    session.vod_platform ?? '',
-  );
-
-  // Stream mode and visibility toggles
-  const [streamMode, setStreamMode] = useState<'NONE' | 'LIVE' | 'VOD'>(session.stream_mode);
-  const [showVideo, setShowVideo] = useState(session.show_video);
-  const [showRecording, setShowRecording] = useState(session.show_recording);
 
   const [errors, setErrors] = useState<FieldErrors>({});
 
   const [debouncedTitle] = useDebouncedValue(title, 500);
   const [debouncedDescription] = useDebouncedValue(description, 500);
   const [debouncedShortDescription] = useDebouncedValue(shortDescription, 500);
-  const [debouncedStreamUrl] = useDebouncedValue(streamUrl, 500);
-  const [debouncedZoomMeetingId] = useDebouncedValue(zoomMeetingId, 500);
-  const [debouncedZoomPasscode] = useDebouncedValue(zoomPasscode, 500);
-  const [debouncedJitsiRoomName] = useDebouncedValue(jitsiRoomName, 500);
-  const [debouncedVodUrl] = useDebouncedValue(vodUrl, 500);
 
   const handleUpdate = useCallback(
     async (updates: Partial<Session>) => {
@@ -200,6 +172,12 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     [session.id, updateSession],
   );
 
+  // Use the streaming hook for all streaming-related state and validation
+  const streaming = useSessionStreaming({ session, onUpdate: handleUpdate });
+
+  // Merge streaming errors with component errors for display
+  const allErrors = { ...errors, ...streaming.streamingErrors };
+
   const validateAndUpdate = useCallback((field: SessionFieldName, value: unknown): boolean => {
     const validation = validateField(field, value);
 
@@ -225,7 +203,6 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   }, [debouncedTitle, session.title, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
     const normalizedSessionDesc = session.description ?? '';
     if (debouncedDescription !== normalizedSessionDesc) {
       handleUpdate({ description: debouncedDescription || null });
@@ -233,7 +210,6 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
   }, [debouncedDescription, session.description, handleUpdate]);
 
   useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
     const normalizedSessionShort = session.short_description ?? '';
     if (
       debouncedShortDescription !== normalizedSessionShort &&
@@ -242,155 +218,6 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
       handleUpdate({ short_description: debouncedShortDescription || null });
     }
   }, [debouncedShortDescription, session.short_description, handleUpdate, validateAndUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionUrl = session.stream_url ?? '';
-    const hasActualChange = debouncedStreamUrl !== normalizedSessionUrl;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedStreamUrl === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.stream_url;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        stream_url: null,
-      });
-      return;
-    }
-
-    // Validate with platform-aware schema
-    const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        stream_url: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.stream_url;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      stream_url: debouncedStreamUrl,
-    });
-  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionZoom = session.zoom_meeting_id ?? '';
-    const hasActualChange = debouncedZoomMeetingId !== normalizedSessionZoom;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedZoomMeetingId === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.zoom_meeting_id;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        zoom_meeting_id: null,
-      });
-      return;
-    }
-
-    // Validate with Zoom-specific schema
-    const validation = validateZoomMeetingId(debouncedZoomMeetingId);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.zoom_meeting_id;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      zoom_meeting_id: debouncedZoomMeetingId,
-    });
-  }, [debouncedZoomMeetingId, session.zoom_meeting_id, streamingPlatform, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionPasscode = session.zoom_passcode ?? '';
-    if (debouncedZoomPasscode !== normalizedSessionPasscode) {
-      handleUpdate({ zoom_passcode: debouncedZoomPasscode || null });
-    }
-  }, [debouncedZoomPasscode, session.zoom_passcode, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionJitsi = session.jitsi_room_name ?? '';
-    const hasActualChange = debouncedJitsiRoomName !== normalizedSessionJitsi;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedJitsiRoomName === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.jitsi_room_name;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        jitsi_room_name: null,
-      });
-      return;
-    }
-
-    // Validate with Jitsi-specific schema
-    const validation = validateJitsiRoomName(debouncedJitsiRoomName);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        jitsi_room_name: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.jitsi_room_name;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      jitsi_room_name: debouncedJitsiRoomName,
-    });
-  }, [debouncedJitsiRoomName, session.jitsi_room_name, streamingPlatform, handleUpdate]);
-
-  // Auto-save VOD URL (debounced)
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionVod = session.vod_url ?? '';
-    if (debouncedVodUrl !== normalizedSessionVod) {
-      handleUpdate({ vod_url: debouncedVodUrl || null });
-    }
-  }, [debouncedVodUrl, session.vod_url, handleUpdate]);
 
   const calculateDuration = (start: string, end: string): string => {
     const startParts = start.split(':').map(Number);
@@ -471,40 +298,17 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
     });
   };
 
-  const handlePlatformChange = (value: string | null) => {
-    const platformValue = value as StreamingPlatform | '';
-    setStreamingPlatform(platformValue);
-
-    if (!value || value === '') {
-      // Clearing platform - reset all streaming fields and update immediately
-      setStreamUrl('');
-      setZoomMeetingId('');
-      setZoomPasscode('');
-      setMuxPlaybackPolicy('PUBLIC');
-      setJitsiRoomName('');
-      handleUpdate({
-        streaming_platform: null,
-        stream_url: null,
-        zoom_meeting_id: null,
-        zoom_passcode: null,
-        mux_playback_policy: null,
-        jitsi_room_name: null,
-      });
-    }
-    // When selecting a platform, just set local state - the URL effect will
-    // send platform+URL together when user enters the URL
-  };
-
   return (
     <div className={cn(styles.sessionCard, hasConflict && styles.hasConflict)}>
       <div className={styles.header}>
         <TextInput
+          name={`session_${session.id}_title`}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           variant='unstyled'
           className={cn(styles.titleInput)}
           placeholder='Session Title'
-          error={errors.title}
+          error={allErrors.title}
         />
         <Menu position='bottom-end' withinPortal>
           <Menu.Target>
@@ -527,7 +331,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
             onChange={(value) => handleTimeChange('start_time', value)}
             placeholder='Start time'
             classNames={{ input: cn(styles.formTimeInput) }}
-            error={errors.start_time}
+            error={allErrors.start_time}
           />
           <Text size='sm' c='dimmed'>
             to
@@ -537,7 +341,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
             onChange={(value) => handleTimeChange('end_time', value)}
             placeholder='End time'
             classNames={{ input: cn(styles.formTimeInput) }}
-            error={errors.end_time ?? errors.time_order}
+            error={allErrors.end_time ?? allErrors.time_order}
           />
         </Group>
 
@@ -601,15 +405,12 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
         <div style={{ marginTop: 12 }}>
           <Group gap='xs' justify='space-between' align='center'>
             <Text className={cn(styles.sectionLabel)}>Video</Text>
-            {streamMode !== 'NONE' && (
+            {streaming.streamMode !== 'NONE' && (
               <Switch
                 size='xs'
                 label='Enabled'
-                checked={showVideo}
-                onChange={(e) => {
-                  setShowVideo(e.currentTarget.checked);
-                  handleUpdate({ show_video: e.currentTarget.checked });
-                }}
+                checked={streaming.showVideo}
+                onChange={(e) => streaming.handleShowVideoChange(e.currentTarget.checked)}
                 color='var(--color-primary)'
                 styles={SWITCH_STYLES_COMPACT}
               />
@@ -618,17 +419,8 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
           <Group gap='xs' wrap='wrap' mt={4}>
             {/* Stream Mode - Primary selector */}
             <Select
-              value={streamMode}
-              onChange={(value) => {
-                if (value === 'NONE' || value === 'LIVE' || value === 'VOD') {
-                  setStreamMode(value);
-                  handleUpdate({ stream_mode: value });
-                  // Clear platform when switching to NONE
-                  if (value === 'NONE') {
-                    handlePlatformChange('');
-                  }
-                }
-              }}
+              value={streaming.streamMode}
+              onChange={streaming.handleStreamModeChange}
               data={[...STREAM_MODES]}
               size='sm'
               allowDeselect={false}
@@ -637,12 +429,12 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
             />
 
             {/* Platform - Only for LIVE and VOD modes */}
-            {streamMode !== 'NONE' && (
+            {streaming.streamMode !== 'NONE' && (
               <Select
-                value={streamingPlatform}
-                onChange={handlePlatformChange}
+                value={streaming.streamingPlatform}
+                onChange={streaming.handlePlatformChange}
                 data={
-                  streamMode === 'VOD' ?
+                  streaming.streamMode === 'VOD' ?
                     [...VOD_STREAMING_PLATFORMS]
                   : [...LIVE_STREAMING_PLATFORMS]
                 }
@@ -656,40 +448,39 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
           </Group>
 
           {/* Platform-specific fields for LIVE/VOD */}
-          {streamMode !== 'NONE' && streamingPlatform && (
+          {streaming.streamMode !== 'NONE' && streaming.streamingPlatform && (
             <Group gap='xs' mt={8} wrap='wrap'>
-              {streamingPlatform === 'VIMEO' && (
+              {streaming.streamingPlatform === 'VIMEO' && (
                 <TextInput
+                  name={`session_${session.id}_vimeo_url`}
                   placeholder={
-                    streamMode === 'VOD' ? 'Vimeo video URL or ID' : 'Vimeo stream URL or ID'
+                    streaming.streamMode === 'VOD' ?
+                      'Vimeo video URL or ID'
+                    : 'Vimeo stream URL or ID'
                   }
                   size='sm'
                   style={{ flex: 1, minWidth: 200 }}
-                  value={streamUrl}
-                  onChange={(e) => setStreamUrl(e.target.value)}
-                  error={errors.stream_url}
+                  value={streaming.streamUrl}
+                  onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                  error={allErrors.stream_url}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
-              {streamingPlatform === 'MUX' && (
+              {streaming.streamingPlatform === 'MUX' && (
                 <>
                   <TextInput
+                    name={`session_${session.id}_mux_playback_id`}
                     placeholder='Mux Playback ID'
                     size='sm'
                     style={{ flex: 1, minWidth: 180 }}
-                    value={streamUrl}
-                    onChange={(e) => setStreamUrl(e.target.value)}
-                    error={errors.stream_url}
+                    value={streaming.streamUrl}
+                    onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                    error={allErrors.stream_url}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                   <Select
-                    value={muxPlaybackPolicy}
-                    onChange={(value) => {
-                      if (value === 'PUBLIC' || value === 'SIGNED') {
-                        setMuxPlaybackPolicy(value);
-                        handleUpdate({ mux_playback_policy: value });
-                      }
-                    }}
+                    value={streaming.muxPlaybackPolicy}
+                    onChange={streaming.handleMuxPolicyChange}
                     data={[...MUX_PLAYBACK_POLICIES]}
                     size='sm'
                     allowDeselect={false}
@@ -698,46 +489,50 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
                   />
                 </>
               )}
-              {streamingPlatform === 'ZOOM' && (
+              {streaming.streamingPlatform === 'ZOOM' && (
                 <>
                   <TextInput
+                    name={`session_${session.id}_zoom_meeting_id`}
                     placeholder='Zoom meeting URL or ID'
                     size='sm'
                     style={{ flex: 1, minWidth: 180 }}
-                    value={zoomMeetingId}
-                    onChange={(e) => setZoomMeetingId(e.target.value)}
-                    error={errors.zoom_meeting_id}
+                    value={streaming.zoomMeetingId}
+                    onChange={(e) => streaming.setZoomMeetingId(e.target.value)}
+                    error={allErrors.zoom_meeting_id}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                   <TextInput
+                    name={`session_${session.id}_zoom_passcode`}
                     placeholder='Passcode'
                     size='sm'
                     style={{ width: 120 }}
-                    value={zoomPasscode}
-                    onChange={(e) => setZoomPasscode(e.target.value)}
+                    value={streaming.zoomPasscode}
+                    onChange={(e) => streaming.setZoomPasscode(e.target.value)}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                 </>
               )}
-              {streamingPlatform === 'JITSI' && (
+              {streaming.streamingPlatform === 'JITSI' && (
                 <TextInput
+                  name={`session_${session.id}_jitsi_room`}
                   placeholder='Jitsi room name or URL'
                   size='sm'
                   style={{ flex: 1, minWidth: 200 }}
-                  value={jitsiRoomName}
-                  onChange={(e) => setJitsiRoomName(e.target.value)}
-                  error={errors.jitsi_room_name}
+                  value={streaming.jitsiRoomName}
+                  onChange={(e) => streaming.setJitsiRoomName(e.target.value)}
+                  error={allErrors.jitsi_room_name}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
-              {streamingPlatform === 'OTHER' && (
+              {streaming.streamingPlatform === 'OTHER' && (
                 <TextInput
+                  name={`session_${session.id}_external_url`}
                   placeholder='External stream/video URL'
                   size='sm'
                   style={{ flex: 1, minWidth: 200 }}
-                  value={streamUrl}
-                  onChange={(e) => setStreamUrl(e.target.value)}
-                  error={errors.stream_url}
+                  value={streaming.streamUrl}
+                  onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                  error={allErrors.stream_url}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
@@ -745,38 +540,32 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
           )}
 
           {/* Recording options - Only for LIVE mode */}
-          {streamMode === 'LIVE' && streamingPlatform && (
+          {streaming.streamMode === 'LIVE' && streaming.streamingPlatform && (
             <div style={{ marginTop: 8 }}>
               <Switch
                 size='sm'
                 label='Show recording after session'
-                checked={showRecording}
-                onChange={(e) => {
-                  setShowRecording(e.currentTarget.checked);
-                  handleUpdate({ show_recording: e.currentTarget.checked });
-                }}
+                checked={streaming.showRecording}
+                onChange={(e) => streaming.handleShowRecordingChange(e.currentTarget.checked)}
                 color='var(--color-primary)'
                 styles={SWITCH_STYLES_REGULAR}
               />
-              {showRecording && (
+              {streaming.showRecording && (
                 <>
                   <Group gap='xs' mt={8} wrap='wrap' align='flex-end'>
                     <TextInput
+                      name={`session_${session.id}_vod_url`}
                       placeholder='Recording URL (optional)'
                       size='sm'
                       style={{ flex: 1, minWidth: 200 }}
-                      value={vodUrl}
-                      onChange={(e) => setVodUrl(e.target.value)}
+                      value={streaming.vodUrl}
+                      onChange={(e) => streaming.setVodUrl(e.target.value)}
                       classNames={{ input: cn(styles.formInput) }}
                     />
-                    {vodUrl && (
+                    {streaming.vodUrl && (
                       <Select
-                        value={vodPlatform}
-                        onChange={(value) => {
-                          const newValue = (value ?? '') as StreamingPlatform | '';
-                          setVodPlatform(newValue);
-                          handleUpdate({ vod_platform: newValue || null });
-                        }}
+                        value={streaming.vodPlatform}
+                        onChange={streaming.handleVodPlatformChange}
                         data={[...RECORDING_PLATFORMS]}
                         size='sm'
                         allowDeselect={false}
@@ -785,11 +574,13 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
                       />
                     )}
                   </Group>
-                  {(streamingPlatform === 'VIMEO' || streamingPlatform === 'MUX') && !vodUrl && (
-                    <Text size='xs' c='dimmed' mt={4}>
-                      Leave blank to use stream URL for recording
-                    </Text>
-                  )}
+                  {(streaming.streamingPlatform === 'VIMEO' ||
+                    streaming.streamingPlatform === 'MUX') &&
+                    !streaming.vodUrl && (
+                      <Text size='xs' c='dimmed' mt={4}>
+                        Leave blank to use stream URL for recording
+                      </Text>
+                    )}
                 </>
               )}
             </div>
@@ -884,6 +675,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
         <div style={{ marginTop: 12 }}>
           <Text className={cn(styles.sectionLabel)}>Short Description (Agenda)</Text>
           <Textarea
+            name={`session_${session.id}_short_desc`}
             value={shortDescription}
             onChange={(e) => setShortDescription(e.target.value)}
             placeholder='Brief summary shown in the schedule (max 200 characters)'
@@ -892,7 +684,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
             minRows={1}
             maxRows={3}
             size='sm'
-            error={errors.short_description}
+            error={allErrors.short_description}
             classNames={{ input: cn(styles.formTextarea) }}
           />
         </div>
@@ -900,6 +692,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
         <div style={{ marginTop: 12 }}>
           <Text className={cn(styles.sectionLabel)}>Full Description</Text>
           <Textarea
+            name={`session_${session.id}_description`}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder='Detailed description shown on the session page'

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
@@ -30,12 +30,10 @@ import { cn } from '@/lib/cn';
 import {
   validateField,
   validateTimeOrder,
-  validateStreamUrl,
-  validateZoomMeetingId,
-  validateJitsiRoomName,
   type SessionFieldName,
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
+import { useSessionStreaming } from '../hooks';
 import { formatTime } from '@/shared/utils/formatting';
 import type { Session, StreamingPlatform, SessionSpeaker } from '@/types';
 import type { SessionType, SessionChatMode, SessionStatus } from '@/types/enums';
@@ -124,6 +122,7 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   const [deleteSession] = useDeleteSessionMutation();
   const [detailsExpanded, setDetailsExpanded] = useState(false);
 
+  // Non-streaming state
   const [title, setTitle] = useState(session.title);
   const [description, setDescription] = useState(session.description ?? '');
   const [shortDescription, setShortDescription] = useState(session.short_description ?? '');
@@ -133,44 +132,17 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   const [startTime, setStartTime] = useState(session.start_time);
   const [endTime, setEndTime] = useState(session.end_time);
   const [chatMode, setChatMode] = useState<SessionChatMode>(session.chat_mode ?? 'ENABLED');
-
-  const [streamingPlatform, setStreamingPlatform] = useState<StreamingPlatform | ''>(
-    session.streaming_platform ?? '',
-  );
-  const [streamUrl, setStreamUrl] = useState(session.stream_url ?? '');
-  const [zoomMeetingId, setZoomMeetingId] = useState(session.zoom_meeting_id ?? '');
-  const [zoomPasscode, setZoomPasscode] = useState(session.zoom_passcode ?? '');
-  const [muxPlaybackPolicy, setMuxPlaybackPolicy] = useState(
-    session.mux_playback_policy ?? 'PUBLIC',
-  );
-  const [jitsiRoomName, setJitsiRoomName] = useState(session.jitsi_room_name ?? '');
-
-  // Visibility window and VOD fields
   const [visibilityMinutesOverride, setVisibilityMinutesOverride] = useState<string>(
     session.visibility_minutes_override != null ?
       session.visibility_minutes_override.toString()
     : '',
   );
-  const [vodUrl, setVodUrl] = useState(session.vod_url ?? '');
-  const [vodPlatform, setVodPlatform] = useState<StreamingPlatform | ''>(
-    session.vod_platform ?? '',
-  );
-
-  // Stream mode and visibility toggles
-  const [streamMode, setStreamMode] = useState<'NONE' | 'LIVE' | 'VOD'>(session.stream_mode);
-  const [showVideo, setShowVideo] = useState(session.show_video);
-  const [showRecording, setShowRecording] = useState(session.show_recording);
 
   const [errors, setErrors] = useState<FieldErrors>({});
 
   const [debouncedTitle] = useDebouncedValue(title, 500);
   const [debouncedDescription] = useDebouncedValue(description, 500);
   const [debouncedShortDescription] = useDebouncedValue(shortDescription, 500);
-  const [debouncedStreamUrl] = useDebouncedValue(streamUrl, 500);
-  const [debouncedZoomMeetingId] = useDebouncedValue(zoomMeetingId, 500);
-  const [debouncedZoomPasscode] = useDebouncedValue(zoomPasscode, 500);
-  const [debouncedJitsiRoomName] = useDebouncedValue(jitsiRoomName, 500);
-  const [debouncedVodUrl] = useDebouncedValue(vodUrl, 500);
 
   const handleUpdate = useCallback(
     async (updates: Partial<Session>) => {
@@ -194,9 +166,6 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
           visibility_minutes_override?: number | null;
           vod_url?: string | null;
           vod_platform?: StreamingPlatform | null;
-          stream_mode?: 'NONE' | 'LIVE' | 'VOD';
-          show_video?: boolean;
-          show_recording?: boolean;
         } = {
           id: session.id,
           ...Object.fromEntries(
@@ -214,18 +183,27 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
     [session.id, updateSession],
   );
 
+  // Use the streaming hook for all streaming-related state and validation
+  const streaming = useSessionStreaming({ session, onUpdate: handleUpdate });
+
+  // Merge streaming errors with component errors for display
+  const allErrors = { ...errors, ...streaming.streamingErrors };
+
   const validateAndUpdate = useCallback((field: SessionFieldName, value: unknown): boolean => {
     const validation = validateField(field, value);
+
     if (!validation.success) {
       const zodError = validation.error as { errors: { message: string }[] };
       setErrors((prev) => ({ ...prev, [field]: zodError.errors[0]?.message }));
       return false;
     }
+
     setErrors((prev) => {
       const newErrors = { ...prev };
       delete newErrors[field];
       return newErrors;
     });
+
     return true;
   }, []);
 
@@ -236,7 +214,6 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   }, [debouncedTitle, session.title, handleUpdate, validateAndUpdate]);
 
   useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
     const normalizedSessionDesc = session.description ?? '';
     if (debouncedDescription !== normalizedSessionDesc) {
       handleUpdate({ description: debouncedDescription || null });
@@ -244,7 +221,6 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
   }, [debouncedDescription, session.description, handleUpdate]);
 
   useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
     const normalizedSessionShort = session.short_description ?? '';
     if (
       debouncedShortDescription !== normalizedSessionShort &&
@@ -253,155 +229,6 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
       handleUpdate({ short_description: debouncedShortDescription || null });
     }
   }, [debouncedShortDescription, session.short_description, handleUpdate, validateAndUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionUrl = session.stream_url ?? '';
-    const hasActualChange = debouncedStreamUrl !== normalizedSessionUrl;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedStreamUrl === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.stream_url;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        stream_url: null,
-      });
-      return;
-    }
-
-    // Validate with platform-aware schema
-    const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        stream_url: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update - always send platform with URL
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.stream_url;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      stream_url: debouncedStreamUrl,
-    });
-  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionZoom = session.zoom_meeting_id ?? '';
-    const hasActualChange = debouncedZoomMeetingId !== normalizedSessionZoom;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedZoomMeetingId === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.zoom_meeting_id;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        zoom_meeting_id: null,
-      });
-      return;
-    }
-
-    // Validate with Zoom-specific schema
-    const validation = validateZoomMeetingId(debouncedZoomMeetingId);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        zoom_meeting_id: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update - always send platform with zoom_meeting_id
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.zoom_meeting_id;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      zoom_meeting_id: debouncedZoomMeetingId,
-    });
-  }, [debouncedZoomMeetingId, session.zoom_meeting_id, streamingPlatform, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionPasscode = session.zoom_passcode ?? '';
-    if (debouncedZoomPasscode !== normalizedSessionPasscode) {
-      handleUpdate({ zoom_passcode: debouncedZoomPasscode || null });
-    }
-  }, [debouncedZoomPasscode, session.zoom_passcode, handleUpdate]);
-
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionJitsi = session.jitsi_room_name ?? '';
-    const hasActualChange = debouncedJitsiRoomName !== normalizedSessionJitsi;
-
-    if (!hasActualChange) return;
-
-    // Empty value is valid (clearing the field)
-    if (debouncedJitsiRoomName === '') {
-      setErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.jitsi_room_name;
-        return newErrors;
-      });
-      handleUpdate({
-        streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-        jitsi_room_name: null,
-      });
-      return;
-    }
-
-    // Validate with Jitsi-specific schema
-    const validation = validateJitsiRoomName(debouncedJitsiRoomName);
-    if (!validation.success) {
-      const zodError = validation.error as { errors: { message: string }[] };
-      setErrors((prev) => ({
-        ...prev,
-        jitsi_room_name: zodError.errors[0]?.message ?? 'Invalid value',
-      }));
-      return;
-    }
-
-    // Clear error and send update
-    setErrors((prev) => {
-      const newErrors = { ...prev };
-      delete newErrors.jitsi_room_name;
-      return newErrors;
-    });
-    handleUpdate({
-      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
-      jitsi_room_name: debouncedJitsiRoomName,
-    });
-  }, [debouncedJitsiRoomName, session.jitsi_room_name, streamingPlatform, handleUpdate]);
-
-  // Auto-save VOD URL (debounced)
-  useEffect(() => {
-    // Normalize comparison: treat null, undefined, '' as equivalent
-    const normalizedSessionVod = session.vod_url ?? '';
-    if (debouncedVodUrl !== normalizedSessionVod) {
-      handleUpdate({ vod_url: debouncedVodUrl || null });
-    }
-  }, [debouncedVodUrl, session.vod_url, handleUpdate]);
 
   const calculateDuration = (start: string, end: string): string => {
     const startParts = start.split(':').map(Number);
@@ -417,7 +244,9 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
 
   const handleTimeChange = (field: 'start_time' | 'end_time', value: string | null) => {
     if (!value) return;
+
     if (!validateAndUpdate(field, value)) return;
+
     if (field === 'start_time') setStartTime(value);
     else setEndTime(value);
 
@@ -439,6 +268,22 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
     const updates =
       errors.time_order ? { start_time: newStartTime, end_time: newEndTime } : { [field]: value };
     handleUpdate(updates);
+  };
+
+  const getSessionTypeBadgeClass = (type: string): string => {
+    const typeClassMap: Record<string, string | undefined> = {
+      KEYNOTE: styles.badgeKeynote,
+      WORKSHOP: styles.badgeWorkshop,
+      PANEL: styles.badgePanel,
+      PRESENTATION: styles.badgePresentation,
+      NETWORKING: styles.badgeNetworking,
+      QA: styles.badgeQa,
+    };
+    return typeClassMap[type] ?? styles.sessionTypeBadge ?? '';
+  };
+
+  const getSessionTypeLabel = (type: string): string => {
+    return SESSION_TYPES.find((t) => t.value === type)?.label ?? type;
   };
 
   const handleDelete = () => {
@@ -464,36 +309,15 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
     });
   };
 
-  const getSessionTypeLabel = (type: string): string =>
-    SESSION_TYPES.find((t) => t.value === type)?.label ?? type;
-
-  const getSessionTypeBadgeClass = (type: string): string => {
-    const typeClassMap: Record<string, string | undefined> = {
-      KEYNOTE: styles.badgeKeynote,
-      WORKSHOP: styles.badgeWorkshop,
-      PANEL: styles.badgePanel,
-      PRESENTATION: styles.badgePresentation,
-      NETWORKING: styles.badgeNetworking,
-      QA: styles.badgeQa,
-    };
-    return typeClassMap[type] ?? styles.sessionTypeBadge ?? '';
-  };
-
   return (
-    <div className={cn(styles.sessionCard, hasConflict && styles.hasConflict)}>
+    <div className={cn(styles.sessionCardMobile, hasConflict && styles.hasConflict)}>
       <Menu position='bottom-end' withinPortal>
         <Menu.Target>
           <ActionIcon
             variant='subtle'
             color='gray'
-            className={cn(styles.mobileActionButton)}
-            style={{
-              position: 'absolute',
-              top: '0.75rem',
-              right: '0.75rem',
-              opacity: 1,
-              visibility: 'visible',
-            }}
+            className={cn(styles.actionButton)}
+            style={{ position: 'absolute', right: 8, top: 8, zIndex: 10 }}
           >
             <IconDots size={16} />
           </ActionIcon>
@@ -507,199 +331,158 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
 
       <Stack gap='xs'>
         <TextInput
+          name={`session_${session.id}_title`}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           variant='unstyled'
           className={cn(styles.titleInput)}
           placeholder='Session Title'
-          error={errors.title}
+          error={allErrors.title}
           style={{ paddingRight: '2.5rem' }}
         />
 
         <Group justify='space-between' wrap='nowrap'>
           <div className={styles.mobileTimeDisplay}>
             <IconClock size={16} />
-            <Text size='sm'>
+            <Text size='sm' fw={500}>
               {formatTime(startTime)} - {formatTime(endTime)}
             </Text>
-            <Badge size='sm' className={cn(styles.durationPill)}>
+          </div>
+          <Group gap='xs'>
+            <Badge className={cn(getSessionTypeBadgeClass(sessionType))} size='sm'>
+              {getSessionTypeLabel(sessionType)}
+            </Badge>
+            <Badge className={cn(styles.durationPill)} size='sm'>
               {calculateDuration(startTime, endTime)}
             </Badge>
-          </div>
-        </Group>
-
-        <Group gap='xs'>
-          <Badge className={cn(getSessionTypeBadgeClass(sessionType))} size='sm'>
-            {getSessionTypeLabel(sessionType)}
-          </Badge>
-          {hasConflict && (
-            <Badge
-              className={cn(styles.conflictPill)}
-              size='sm'
-              leftSection={<IconAlertCircle size={12} />}
-            >
-              Overlaps
-            </Badge>
-          )}
+            {hasConflict && (
+              <Badge
+                className={cn(styles.conflictPill)}
+                size='sm'
+                leftSection={<IconAlertCircle size={12} />}
+              >
+                Overlaps
+              </Badge>
+            )}
+          </Group>
         </Group>
 
         <div
-          className={styles.expandableSection}
+          className={styles.expandToggle}
           onClick={() => setDetailsExpanded(!detailsExpanded)}
+          role='button'
+          tabIndex={0}
+          onKeyDown={(e) => e.key === 'Enter' && setDetailsExpanded(!detailsExpanded)}
         >
-          <Group justify='space-between' wrap='nowrap'>
-            <Text size='sm' fw={500}>
-              Session Details
-            </Text>
-            <ActionIcon
-              size='xs'
-              variant='transparent'
-              style={{ color: 'var(--color-text-muted)' }}
-            >
-              {detailsExpanded ?
-                <IconChevronUp size={14} />
-              : <IconChevronDown size={14} />}
-            </ActionIcon>
-          </Group>
+          <Text size='sm' c='dimmed'>
+            {detailsExpanded ? 'Hide details' : 'Show details'}
+          </Text>
+          {detailsExpanded ?
+            <IconChevronUp size={16} />
+          : <IconChevronDown size={16} />}
         </div>
       </Stack>
 
       <Collapse in={detailsExpanded}>
-        <div className={styles.collapsedContent}>
-          <Stack gap='md' mt='md'>
-            <Group grow>
-              <TimeSelect
-                value={startTime}
-                onChange={(value) => handleTimeChange('start_time', value)}
-                placeholder='Start time'
-                label='Start Time'
-                error={errors.start_time}
-                size='sm'
-                classNames={{ input: cn(styles.formTimeInput) }}
-              />
-              <TimeSelect
-                value={endTime}
-                onChange={(value) => handleTimeChange('end_time', value)}
-                placeholder='End time'
-                label='End Time'
-                error={errors.end_time ?? errors.time_order}
-                size='sm'
-                classNames={{ input: cn(styles.formTimeInput) }}
-              />
-            </Group>
+        <div className={styles.mobileDetailsContent}>
+          <Stack gap='md'>
+            {/* Time Selection */}
+            <div>
+              <Text className={cn(styles.sectionLabel)}>Time</Text>
+              <Group gap='xs'>
+                <TimeSelect
+                  value={startTime}
+                  onChange={(value) => handleTimeChange('start_time', value)}
+                  placeholder='Start'
+                  classNames={{ input: cn(styles.formTimeInput) }}
+                  error={allErrors.start_time}
+                />
+                <Text size='sm' c='dimmed'>
+                  to
+                </Text>
+                <TimeSelect
+                  value={endTime}
+                  onChange={(value) => handleTimeChange('end_time', value)}
+                  placeholder='End'
+                  classNames={{ input: cn(styles.formTimeInput) }}
+                  error={allErrors.end_time ?? allErrors.time_order}
+                />
+              </Group>
+            </div>
 
-            <Select
-              label='Session Type'
-              value={sessionType}
-              onChange={(value) => {
-                if (value) {
-                  const typedValue = value as SessionTypeValue;
-                  setSessionType(typedValue);
-                  handleUpdate({ session_type: typedValue as SessionType });
-                }
-              }}
-              data={[...SESSION_TYPES]}
-              size='sm'
-              allowDeselect={false}
-              classNames={{ input: cn(styles.formSelect) }}
-            />
-
-            <Select
-              label='Chat Mode'
-              value={chatMode}
-              onChange={(value) => {
-                if (value) {
-                  setChatMode(value as SessionChatMode);
-                  handleUpdate({ chat_mode: value as SessionChatMode });
-                }
-              }}
-              data={[...CHAT_MODES]}
-              size='sm'
-              allowDeselect={false}
-              classNames={{ input: cn(styles.formSelect) }}
-            />
+            {/* Type & Chat */}
+            <div>
+              <Text className={cn(styles.sectionLabel)}>Type & Chat</Text>
+              <Stack gap='xs'>
+                <Select
+                  label='Session Type'
+                  value={sessionType}
+                  onChange={(value) => {
+                    if (value) {
+                      const typedValue = value as SessionTypeValue;
+                      setSessionType(typedValue);
+                      handleUpdate({ session_type: typedValue as SessionType });
+                    }
+                  }}
+                  data={[...SESSION_TYPES]}
+                  size='sm'
+                  allowDeselect={false}
+                  classNames={{ input: cn(styles.formSelect) }}
+                />
+                <Select
+                  label='Chat Mode'
+                  value={chatMode}
+                  onChange={(value) => {
+                    if (value) {
+                      setChatMode(value as SessionChatMode);
+                      handleUpdate({ chat_mode: value as SessionChatMode });
+                    }
+                  }}
+                  data={[...CHAT_MODES]}
+                  size='sm'
+                  allowDeselect={false}
+                  classNames={{ input: cn(styles.formSelect) }}
+                />
+              </Stack>
+            </div>
 
             {/* Video Section */}
             <div>
-              <Group gap='xs' justify='space-between' align='center' mb={4}>
-                <Text size='sm' fw={500}>
-                  Video
-                </Text>
-                {streamMode !== 'NONE' && (
+              <Group gap='xs' justify='space-between' align='center'>
+                <Text className={cn(styles.sectionLabel)}>Video</Text>
+                {streaming.streamMode !== 'NONE' && (
                   <Switch
                     size='xs'
                     label='Enabled'
-                    checked={showVideo}
-                    onChange={(e) => {
-                      setShowVideo(e.currentTarget.checked);
-                      handleUpdate({ show_video: e.currentTarget.checked });
-                    }}
+                    checked={streaming.showVideo}
+                    onChange={(e) => streaming.handleShowVideoChange(e.currentTarget.checked)}
                     color='var(--color-primary)'
                     styles={SWITCH_STYLES_COMPACT}
                   />
                 )}
               </Group>
+
+              {/* Stream Mode - Primary selector */}
               <Select
-                label='Stream Mode'
-                value={streamMode}
-                onChange={(value) => {
-                  if (value === 'NONE' || value === 'LIVE' || value === 'VOD') {
-                    setStreamMode(value);
-                    handleUpdate({ stream_mode: value });
-                    // Clear platform when switching to NONE
-                    if (value === 'NONE') {
-                      setStreamingPlatform('');
-                      setStreamUrl('');
-                      setZoomMeetingId('');
-                      setZoomPasscode('');
-                      setMuxPlaybackPolicy('PUBLIC');
-                      setJitsiRoomName('');
-                      handleUpdate({
-                        stream_mode: value,
-                        streaming_platform: null,
-                        stream_url: null,
-                        zoom_meeting_id: null,
-                        zoom_passcode: null,
-                        mux_playback_policy: null,
-                        jitsi_room_name: null,
-                      });
-                    }
-                  }
-                }}
+                label='Mode'
+                value={streaming.streamMode}
+                onChange={streaming.handleStreamModeChange}
                 data={[...STREAM_MODES]}
                 size='sm'
+                mt='xs'
                 allowDeselect={false}
                 classNames={{ input: cn(styles.formSelect) }}
               />
 
               {/* Platform - Only for LIVE and VOD modes */}
-              {streamMode !== 'NONE' && (
+              {streaming.streamMode !== 'NONE' && (
                 <Select
                   label='Platform'
                   placeholder='Select platform'
-                  value={streamingPlatform}
-                  onChange={(value) => {
-                    const platformValue = value as StreamingPlatform | '';
-                    setStreamingPlatform(platformValue);
-                    if (!value || value === '') {
-                      // Clearing platform - reset all streaming fields
-                      setStreamUrl('');
-                      setZoomMeetingId('');
-                      setZoomPasscode('');
-                      setMuxPlaybackPolicy('PUBLIC');
-                      setJitsiRoomName('');
-                      handleUpdate({
-                        streaming_platform: null,
-                        stream_url: null,
-                        zoom_meeting_id: null,
-                        zoom_passcode: null,
-                        mux_playback_policy: null,
-                        jitsi_room_name: null,
-                      });
-                    }
-                  }}
+                  value={streaming.streamingPlatform}
+                  onChange={streaming.handlePlatformChange}
                   data={
-                    streamMode === 'VOD' ?
+                    streaming.streamMode === 'VOD' ?
                       [...VOD_STREAMING_PLATFORMS]
                     : [...LIVE_STREAMING_PLATFORMS]
                   }
@@ -711,40 +494,41 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
               )}
 
               {/* Platform-specific fields for LIVE/VOD */}
-              {streamMode !== 'NONE' && streamingPlatform === 'VIMEO' && (
+              {streaming.streamMode !== 'NONE' && streaming.streamingPlatform === 'VIMEO' && (
                 <TextInput
-                  label={streamMode === 'VOD' ? 'Vimeo Video URL or ID' : 'Vimeo Stream URL or ID'}
+                  name={`session_${session.id}_vimeo_url`}
+                  label={
+                    streaming.streamMode === 'VOD' ?
+                      'Vimeo Video URL or ID'
+                    : 'Vimeo Stream URL or ID'
+                  }
                   placeholder='https://vimeo.com/123... or ID'
                   size='sm'
                   mt='xs'
-                  value={streamUrl}
-                  onChange={(e) => setStreamUrl(e.target.value)}
-                  error={errors.stream_url}
+                  value={streaming.streamUrl}
+                  onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                  error={allErrors.stream_url}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
 
-              {streamMode !== 'NONE' && streamingPlatform === 'MUX' && (
+              {streaming.streamMode !== 'NONE' && streaming.streamingPlatform === 'MUX' && (
                 <>
                   <TextInput
+                    name={`session_${session.id}_mux_playback_id`}
                     label='Mux Playback ID'
                     placeholder='DS00Spx1CV902...'
                     size='sm'
                     mt='xs'
-                    value={streamUrl}
-                    onChange={(e) => setStreamUrl(e.target.value)}
-                    error={errors.stream_url}
+                    value={streaming.streamUrl}
+                    onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                    error={allErrors.stream_url}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                   <Select
                     label='Playback Policy'
-                    value={muxPlaybackPolicy}
-                    onChange={(value) => {
-                      if (value === 'PUBLIC' || value === 'SIGNED') {
-                        setMuxPlaybackPolicy(value);
-                        handleUpdate({ mux_playback_policy: value });
-                      }
-                    }}
+                    value={streaming.muxPlaybackPolicy}
+                    onChange={streaming.handleMuxPolicyChange}
                     data={[...MUX_PLAYBACK_POLICIES]}
                     size='sm'
                     mt='xs'
@@ -754,90 +538,88 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                 </>
               )}
 
-              {streamMode !== 'NONE' && streamingPlatform === 'ZOOM' && (
+              {streaming.streamMode !== 'NONE' && streaming.streamingPlatform === 'ZOOM' && (
                 <>
                   <TextInput
+                    name={`session_${session.id}_zoom_meeting_id`}
                     label='Zoom Meeting URL or ID'
                     placeholder='https://zoom.us/j/123... or ID'
                     size='sm'
                     mt='xs'
-                    value={zoomMeetingId}
-                    onChange={(e) => setZoomMeetingId(e.target.value)}
-                    error={errors.zoom_meeting_id}
+                    value={streaming.zoomMeetingId}
+                    onChange={(e) => streaming.setZoomMeetingId(e.target.value)}
+                    error={allErrors.zoom_meeting_id}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                   <TextInput
+                    name={`session_${session.id}_zoom_passcode`}
                     label='Passcode (Optional)'
                     placeholder='Meeting passcode'
                     size='sm'
                     mt='xs'
-                    value={zoomPasscode}
-                    onChange={(e) => setZoomPasscode(e.target.value)}
+                    value={streaming.zoomPasscode}
+                    onChange={(e) => streaming.setZoomPasscode(e.target.value)}
                     classNames={{ input: cn(styles.formInput) }}
                   />
                 </>
               )}
 
-              {streamMode !== 'NONE' && streamingPlatform === 'JITSI' && (
+              {streaming.streamMode !== 'NONE' && streaming.streamingPlatform === 'JITSI' && (
                 <TextInput
+                  name={`session_${session.id}_jitsi_room`}
                   label='Jitsi Room Name or URL'
                   placeholder='my-room-name or URL'
                   size='sm'
                   mt='xs'
-                  value={jitsiRoomName}
-                  onChange={(e) => setJitsiRoomName(e.target.value)}
-                  error={errors.jitsi_room_name}
+                  value={streaming.jitsiRoomName}
+                  onChange={(e) => streaming.setJitsiRoomName(e.target.value)}
+                  error={allErrors.jitsi_room_name}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
 
-              {streamMode !== 'NONE' && streamingPlatform === 'OTHER' && (
+              {streaming.streamMode !== 'NONE' && streaming.streamingPlatform === 'OTHER' && (
                 <TextInput
+                  name={`session_${session.id}_external_url`}
                   label='External Stream/Video URL'
                   placeholder='https://...'
                   size='sm'
                   mt='xs'
-                  value={streamUrl}
-                  onChange={(e) => setStreamUrl(e.target.value)}
-                  error={errors.stream_url}
+                  value={streaming.streamUrl}
+                  onChange={(e) => streaming.setStreamUrl(e.target.value)}
+                  error={allErrors.stream_url}
                   classNames={{ input: cn(styles.formInput) }}
                 />
               )}
 
               {/* Recording options - Only for LIVE mode with a platform selected */}
-              {streamMode === 'LIVE' && streamingPlatform && (
+              {streaming.streamMode === 'LIVE' && streaming.streamingPlatform && (
                 <div style={{ marginTop: 12 }}>
                   <Switch
                     size='sm'
                     label='Show recording after session'
-                    checked={showRecording}
-                    onChange={(e) => {
-                      setShowRecording(e.currentTarget.checked);
-                      handleUpdate({ show_recording: e.currentTarget.checked });
-                    }}
+                    checked={streaming.showRecording}
+                    onChange={(e) => streaming.handleShowRecordingChange(e.currentTarget.checked)}
                     color='var(--color-primary)'
                     styles={SWITCH_STYLES_REGULAR}
                   />
-                  {showRecording && (
+                  {streaming.showRecording && (
                     <>
                       <TextInput
+                        name={`session_${session.id}_vod_url`}
                         label='Recording URL (optional)'
                         placeholder='Leave blank to use stream URL'
                         size='sm'
                         mt='xs'
-                        value={vodUrl}
-                        onChange={(e) => setVodUrl(e.target.value)}
+                        value={streaming.vodUrl}
+                        onChange={(e) => streaming.setVodUrl(e.target.value)}
                         classNames={{ input: cn(styles.formInput) }}
                       />
-                      {vodUrl && (
+                      {streaming.vodUrl && (
                         <Select
                           label='Recording Platform'
-                          value={vodPlatform}
-                          onChange={(value) => {
-                            const newValue = (value ?? '') as StreamingPlatform | '';
-                            setVodPlatform(newValue);
-                            handleUpdate({ vod_platform: newValue || null });
-                          }}
+                          value={streaming.vodPlatform}
+                          onChange={streaming.handleVodPlatformChange}
                           data={[...RECORDING_PLATFORMS]}
                           size='sm'
                           mt='xs'
@@ -845,19 +627,24 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                           classNames={{ input: cn(styles.formSelect) }}
                         />
                       )}
+                      {(streaming.streamingPlatform === 'VIMEO' ||
+                        streaming.streamingPlatform === 'MUX') &&
+                        !streaming.vodUrl && (
+                          <Text size='xs' c='dimmed' mt={4}>
+                            Leave blank to use stream URL for recording
+                          </Text>
+                        )}
                     </>
                   )}
                 </div>
               )}
             </div>
 
-            {/* Access Window */}
+            {/* Visibility Window */}
             <div>
-              <Text size='sm' fw={500} mb={4}>
-                Access Window
-              </Text>
+              <Text className={cn(styles.sectionLabel)}>Access Window</Text>
               <Text size='xs' c='dimmed' mb={6}>
-                Buffer time before and after session when stream and chat are accessible
+                Buffer time before and after session
               </Text>
               <Select
                 value={visibilityMinutesOverride}
@@ -875,23 +662,20 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
               />
             </div>
 
+            {/* Speakers */}
             <div className={styles.speakersSection}>
-              <Text size='sm' fw={500} mb='xs'>
-                Speakers
-              </Text>
               {(() => {
-                const speakers = (session as { session_speakers?: SessionSpeaker[] })
-                  .session_speakers;
+                const speakers = (session as { speakers?: SessionSpeaker[] }).speakers;
                 if (!speakers) {
                   return (
                     <SessionSpeakers
                       sessionId={session.id}
                       eventId={session.event_id}
                       canEdit={true}
+                      variant='flow'
                     />
                   );
                 }
-                // Convert API SessionSpeaker type to component's expected format
                 const convertedSpeakers = speakers.map((speaker) => {
                   const converted: {
                     user_id: number;
@@ -932,6 +716,7 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                     sessionId={session.id}
                     eventId={session.event_id}
                     canEdit={true}
+                    variant='flow'
                     preloadedSpeakers={convertedSpeakers}
                   />
                 );
@@ -939,6 +724,7 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
             </div>
 
             <Textarea
+              name={`session_${session.id}_short_desc`}
               label='Short Description'
               value={shortDescription}
               onChange={(e) => setShortDescription(e.target.value)}
@@ -948,11 +734,12 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
               minRows={2}
               maxRows={3}
               size='sm'
-              error={errors.short_description}
+              error={allErrors.short_description}
               classNames={{ input: cn(styles.formTextarea) }}
             />
 
             <Textarea
+              name={`session_${session.id}_description`}
               label='Full Description'
               value={description}
               onChange={(e) => setDescription(e.target.value)}

--- a/frontend/src/pages/EventAdmin/SessionManager/hooks/index.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSessionStreaming } from './useSessionStreaming';

--- a/frontend/src/pages/EventAdmin/SessionManager/hooks/useSessionStreaming.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/hooks/useSessionStreaming.ts
@@ -1,0 +1,416 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+  validateStreamUrl,
+  validateZoomMeetingId,
+  validateJitsiRoomName,
+} from '../schemas/sessionCardSchema';
+import type { Session, StreamingPlatform } from '@/types';
+
+type StreamingErrors = {
+  stream_url?: string;
+  zoom_meeting_id?: string;
+  jitsi_room_name?: string;
+};
+
+type StreamMode = 'NONE' | 'LIVE' | 'VOD';
+
+type UseSessionStreamingProps = {
+  session: Session;
+  onUpdate: (updates: Partial<Session>) => Promise<void>;
+};
+
+type UseSessionStreamingReturn = {
+  // State values
+  streamingPlatform: StreamingPlatform | '';
+  streamUrl: string;
+  zoomMeetingId: string;
+  zoomPasscode: string;
+  muxPlaybackPolicy: string;
+  jitsiRoomName: string;
+  vodUrl: string;
+  vodPlatform: StreamingPlatform | '';
+  streamMode: StreamMode;
+  showVideo: boolean;
+  showRecording: boolean;
+  streamingErrors: StreamingErrors;
+
+  // Setters for controlled inputs
+  setStreamUrl: (value: string) => void;
+  setZoomMeetingId: (value: string) => void;
+  setZoomPasscode: (value: string) => void;
+  setJitsiRoomName: (value: string) => void;
+  setVodUrl: (value: string) => void;
+
+  // Handlers
+  handlePlatformChange: (value: string | null) => void;
+  handleStreamModeChange: (value: string | null) => void;
+  handleMuxPolicyChange: (value: string | null) => void;
+  handleVodPlatformChange: (value: string | null) => void;
+  handleShowVideoChange: (checked: boolean) => void;
+  handleShowRecordingChange: (checked: boolean) => void;
+};
+
+/**
+ * Hook to manage session streaming state, validation, and auto-save logic.
+ * Shared between SessionCard and SessionCardMobile to eliminate duplication.
+ */
+export const useSessionStreaming = ({
+  session,
+  onUpdate,
+}: UseSessionStreamingProps): UseSessionStreamingReturn => {
+  // Streaming platform state
+  const [streamingPlatform, setStreamingPlatform] = useState<StreamingPlatform | ''>(
+    session.streaming_platform ?? '',
+  );
+  const [streamUrl, setStreamUrl] = useState(session.stream_url ?? '');
+  const [zoomMeetingId, setZoomMeetingId] = useState(session.zoom_meeting_id ?? '');
+  const [zoomPasscode, setZoomPasscode] = useState(session.zoom_passcode ?? '');
+  const [muxPlaybackPolicy, setMuxPlaybackPolicy] = useState(
+    session.mux_playback_policy ?? 'PUBLIC',
+  );
+  const [jitsiRoomName, setJitsiRoomName] = useState(session.jitsi_room_name ?? '');
+
+  // VOD fields
+  const [vodUrl, setVodUrl] = useState(session.vod_url ?? '');
+  const [vodPlatform, setVodPlatform] = useState<StreamingPlatform | ''>(
+    session.vod_platform ?? '',
+  );
+
+  // Stream mode and visibility
+  const [streamMode, setStreamMode] = useState<StreamMode>(session.stream_mode);
+  const [showVideo, setShowVideo] = useState(session.show_video);
+  const [showRecording, setShowRecording] = useState(session.show_recording);
+
+  // Streaming-related errors
+  const [streamingErrors, setStreamingErrors] = useState<StreamingErrors>({});
+
+  // Debounced values for auto-save
+  const [debouncedStreamUrl] = useDebouncedValue(streamUrl, 500);
+  const [debouncedZoomMeetingId] = useDebouncedValue(zoomMeetingId, 500);
+  const [debouncedZoomPasscode] = useDebouncedValue(zoomPasscode, 500);
+  const [debouncedJitsiRoomName] = useDebouncedValue(jitsiRoomName, 500);
+  const [debouncedVodUrl] = useDebouncedValue(vodUrl, 500);
+
+  // Helper to clear all URL-related errors
+  const clearUrlErrors = useCallback(() => {
+    setStreamingErrors({});
+  }, []);
+
+  // Helper to set a specific error
+  const setFieldError = useCallback((field: keyof StreamingErrors, message: string) => {
+    setStreamingErrors((prev) => ({ ...prev, [field]: message }));
+  }, []);
+
+  // Helper to clear a specific error
+  const clearFieldError = useCallback((field: keyof StreamingErrors) => {
+    setStreamingErrors((prev) => {
+      const newErrors = { ...prev };
+      delete newErrors[field];
+      return newErrors;
+    });
+  }, []);
+
+  // Platform change handler
+  const handlePlatformChange = useCallback(
+    (value: string | null) => {
+      const platformValue = (value ?? '') as StreamingPlatform | '';
+      setStreamingPlatform(platformValue);
+
+      if (!value || value === '') {
+        // Clearing platform - reset all streaming fields
+        setStreamUrl('');
+        setZoomMeetingId('');
+        setZoomPasscode('');
+        setMuxPlaybackPolicy('PUBLIC');
+        setJitsiRoomName('');
+        clearUrlErrors();
+        onUpdate({
+          streaming_platform: null,
+          stream_url: null,
+          zoom_meeting_id: null,
+          zoom_passcode: null,
+          mux_playback_policy: null,
+          jitsi_room_name: null,
+        });
+      } else {
+        // Clear old errors first, then re-validate against new platform
+        clearUrlErrors();
+
+        if (value === 'VIMEO' || value === 'MUX' || value === 'OTHER') {
+          const validation = validateStreamUrl(value, streamUrl, true);
+          if (!validation.success) {
+            const zodError = validation.error as { errors: { message: string }[] };
+            setFieldError('stream_url', zodError.errors[0]?.message ?? 'URL required');
+          }
+        } else if (value === 'ZOOM') {
+          const validation = validateZoomMeetingId(zoomMeetingId, true, value);
+          if (!validation.success) {
+            const zodError = validation.error as { errors: { message: string }[] };
+            setFieldError('zoom_meeting_id', zodError.errors[0]?.message ?? 'Meeting ID required');
+          }
+        } else if (value === 'JITSI') {
+          const validation = validateJitsiRoomName(jitsiRoomName, true, value);
+          if (!validation.success) {
+            const zodError = validation.error as { errors: { message: string }[] };
+            setFieldError('jitsi_room_name', zodError.errors[0]?.message ?? 'Room name required');
+          }
+        }
+      }
+    },
+    [streamUrl, zoomMeetingId, jitsiRoomName, onUpdate, clearUrlErrors, setFieldError],
+  );
+
+  // Stream mode change handler
+  const handleStreamModeChange = useCallback(
+    (value: string | null) => {
+      if (value === 'NONE' || value === 'LIVE' || value === 'VOD') {
+        setStreamMode(value);
+        onUpdate({ stream_mode: value });
+
+        // Clear platform when switching to NONE
+        if (value === 'NONE') {
+          handlePlatformChange('');
+        }
+      }
+    },
+    [onUpdate, handlePlatformChange],
+  );
+
+  // Mux policy change handler
+  const handleMuxPolicyChange = useCallback(
+    (value: string | null) => {
+      if (value === 'PUBLIC' || value === 'SIGNED') {
+        setMuxPlaybackPolicy(value);
+        onUpdate({ mux_playback_policy: value });
+      }
+    },
+    [onUpdate],
+  );
+
+  // VOD platform change handler
+  const handleVodPlatformChange = useCallback(
+    (value: string | null) => {
+      const newValue = (value ?? '') as StreamingPlatform | '';
+      setVodPlatform(newValue);
+      onUpdate({ vod_platform: newValue || null });
+    },
+    [onUpdate],
+  );
+
+  // Show video toggle handler
+  const handleShowVideoChange = useCallback(
+    (checked: boolean) => {
+      setShowVideo(checked);
+      onUpdate({ show_video: checked });
+    },
+    [onUpdate],
+  );
+
+  // Show recording toggle handler
+  const handleShowRecordingChange = useCallback(
+    (checked: boolean) => {
+      setShowRecording(checked);
+      onUpdate({ show_recording: checked });
+    },
+    [onUpdate],
+  );
+
+  // Effect: Immediate validation for error display (no debounce)
+  // This clears errors as soon as user types a valid URL, without waiting for debounce
+  useEffect(() => {
+    // Only validate if platform requires a URL
+    const platformRequiresUrl =
+      streamingPlatform === 'VIMEO' || streamingPlatform === 'MUX' || streamingPlatform === 'OTHER';
+
+    if (!platformRequiresUrl) return;
+
+    // If URL is non-empty, validate immediately for error display
+    if (streamUrl) {
+      const validation = validateStreamUrl(streamingPlatform, streamUrl);
+      if (validation.success) {
+        clearFieldError('stream_url');
+      } else {
+        const zodError = validation.error as { errors: { message: string }[] };
+        setFieldError('stream_url', zodError.errors[0]?.message ?? 'Invalid URL');
+      }
+    }
+    // Note: We don't set error when empty here - that's handled by handlePlatformChange
+  }, [streamUrl, streamingPlatform, setFieldError, clearFieldError]);
+
+  // Effect: Auto-save stream URL (for VIMEO, MUX, OTHER only) - debounced for backend
+  useEffect(() => {
+    // Only save stream_url for platforms that use it (not ZOOM/JITSI)
+    const platformUsesStreamUrl =
+      streamingPlatform === 'VIMEO' || streamingPlatform === 'MUX' || streamingPlatform === 'OTHER';
+
+    if (!platformUsesStreamUrl) return;
+
+    const normalizedSessionUrl = session.stream_url ?? '';
+    const hasActualChange = debouncedStreamUrl !== normalizedSessionUrl;
+
+    if (!hasActualChange) return;
+
+    // When clearing URL: show error, don't send to backend
+    if (debouncedStreamUrl === '') {
+      // Don't send to backend, error is already shown by immediate validation effect
+      return;
+    }
+
+    // Validate with platform-aware schema
+    const validation = validateStreamUrl(streamingPlatform, debouncedStreamUrl);
+    if (!validation.success) {
+      // Error already shown by immediate validation effect
+      return;
+    }
+
+    clearFieldError('stream_url');
+    onUpdate({
+      streaming_platform: (streamingPlatform || null) as StreamingPlatform | null,
+      stream_url: debouncedStreamUrl,
+    });
+  }, [debouncedStreamUrl, session.stream_url, streamingPlatform, onUpdate, clearFieldError]);
+
+  // Effect: Immediate validation for Zoom meeting ID (no debounce)
+  useEffect(() => {
+    if (streamingPlatform !== 'ZOOM') return;
+
+    if (zoomMeetingId) {
+      const validation = validateZoomMeetingId(zoomMeetingId);
+      if (validation.success) {
+        clearFieldError('zoom_meeting_id');
+      } else {
+        const zodError = validation.error as { errors: { message: string }[] };
+        setFieldError('zoom_meeting_id', zodError.errors[0]?.message ?? 'Invalid meeting ID');
+      }
+    }
+  }, [zoomMeetingId, streamingPlatform, setFieldError, clearFieldError]);
+
+  // Effect: Auto-save Zoom meeting ID - debounced for backend (ZOOM only)
+  useEffect(() => {
+    // Only save zoom_meeting_id when platform is ZOOM
+    if (streamingPlatform !== 'ZOOM') return;
+
+    const normalizedSessionZoom = session.zoom_meeting_id ?? '';
+    const hasActualChange = debouncedZoomMeetingId !== normalizedSessionZoom;
+
+    if (!hasActualChange) return;
+
+    // When clearing: don't send to backend, error shown by handlePlatformChange
+    if (debouncedZoomMeetingId === '') return;
+
+    const validation = validateZoomMeetingId(debouncedZoomMeetingId);
+    if (!validation.success) {
+      // Error already shown by immediate validation
+      return;
+    }
+
+    clearFieldError('zoom_meeting_id');
+    onUpdate({
+      streaming_platform: 'ZOOM' as StreamingPlatform,
+      zoom_meeting_id: debouncedZoomMeetingId,
+    });
+  }, [
+    debouncedZoomMeetingId,
+    session.zoom_meeting_id,
+    streamingPlatform,
+    onUpdate,
+    clearFieldError,
+  ]);
+
+  // Effect: Auto-save Zoom passcode (ZOOM only)
+  useEffect(() => {
+    if (streamingPlatform !== 'ZOOM') return;
+
+    const normalizedSessionPasscode = session.zoom_passcode ?? '';
+    if (debouncedZoomPasscode !== normalizedSessionPasscode) {
+      onUpdate({ zoom_passcode: debouncedZoomPasscode || null });
+    }
+  }, [debouncedZoomPasscode, session.zoom_passcode, streamingPlatform, onUpdate]);
+
+  // Effect: Immediate validation for Jitsi room name (no debounce)
+  useEffect(() => {
+    if (streamingPlatform !== 'JITSI') return;
+
+    if (jitsiRoomName) {
+      const validation = validateJitsiRoomName(jitsiRoomName);
+      if (validation.success) {
+        clearFieldError('jitsi_room_name');
+      } else {
+        const zodError = validation.error as { errors: { message: string }[] };
+        setFieldError('jitsi_room_name', zodError.errors[0]?.message ?? 'Invalid room name');
+      }
+    }
+  }, [jitsiRoomName, streamingPlatform, setFieldError, clearFieldError]);
+
+  // Effect: Auto-save Jitsi room name - debounced for backend (JITSI only)
+  useEffect(() => {
+    // Only save jitsi_room_name when platform is JITSI
+    if (streamingPlatform !== 'JITSI') return;
+
+    const normalizedSessionJitsi = session.jitsi_room_name ?? '';
+    const hasActualChange = debouncedJitsiRoomName !== normalizedSessionJitsi;
+
+    if (!hasActualChange) return;
+
+    // When clearing: don't send to backend, error shown by handlePlatformChange
+    if (debouncedJitsiRoomName === '') return;
+
+    const validation = validateJitsiRoomName(debouncedJitsiRoomName);
+    if (!validation.success) {
+      // Error already shown by immediate validation
+      return;
+    }
+
+    clearFieldError('jitsi_room_name');
+    onUpdate({
+      streaming_platform: 'JITSI' as StreamingPlatform,
+      jitsi_room_name: debouncedJitsiRoomName,
+    });
+  }, [
+    debouncedJitsiRoomName,
+    session.jitsi_room_name,
+    streamingPlatform,
+    onUpdate,
+    clearFieldError,
+  ]);
+
+  // Effect: Auto-save VOD URL
+  useEffect(() => {
+    const normalizedSessionVod = session.vod_url ?? '';
+    if (debouncedVodUrl !== normalizedSessionVod) {
+      onUpdate({ vod_url: debouncedVodUrl || null });
+    }
+  }, [debouncedVodUrl, session.vod_url, onUpdate]);
+
+  return {
+    // State values
+    streamingPlatform,
+    streamUrl,
+    zoomMeetingId,
+    zoomPasscode,
+    muxPlaybackPolicy,
+    jitsiRoomName,
+    vodUrl,
+    vodPlatform,
+    streamMode,
+    showVideo,
+    showRecording,
+    streamingErrors,
+
+    // Setters
+    setStreamUrl,
+    setZoomMeetingId,
+    setZoomPasscode,
+    setJitsiRoomName,
+    setVodUrl,
+
+    // Handlers
+    handlePlatformChange,
+    handleStreamModeChange,
+    handleMuxPolicyChange,
+    handleVodPlatformChange,
+    handleShowVideoChange,
+    handleShowRecordingChange,
+  };
+};

--- a/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/schemas/sessionCardSchema.ts
@@ -124,11 +124,30 @@ export type StreamingPlatformValue = z.infer<typeof StreamingPlatform>;
 export type MuxPlaybackPolicyValue = z.infer<typeof MuxPlaybackPolicy>;
 
 // Platform-aware validation for stream URL (used by Vimeo, Mux, Other)
+// Set requireIfPlatformSet=true to require URL when platform is selected
 export const validateStreamUrl = (
   platform: string | null | undefined,
   value: string,
+  requireIfPlatformSet = false,
 ): z.SafeParseReturnType<string, string> => {
-  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  // Check if URL is required but missing
+  if (!value) {
+    if (
+      requireIfPlatformSet &&
+      (platform === 'VIMEO' || platform === 'MUX' || platform === 'OTHER')
+    ) {
+      // Build user-friendly error message
+      const errorMessage =
+        platform === 'MUX' ? 'Mux Playback ID required'
+        : platform === 'VIMEO' ? 'Vimeo video URL or ID required'
+        : 'URL required';
+      return {
+        success: false,
+        error: { errors: [{ message: errorMessage }] },
+      } as z.SafeParseReturnType<string, string>;
+    }
+    return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  }
 
   switch (platform) {
     case 'VIMEO':
@@ -143,13 +162,39 @@ export const validateStreamUrl = (
 };
 
 // Platform-aware validation for Zoom meeting ID
-export const validateZoomMeetingId = (value: string): z.SafeParseReturnType<string, string> => {
-  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+// Set requireIfPlatformSet=true to require meeting ID when platform is ZOOM
+export const validateZoomMeetingId = (
+  value: string,
+  requireIfPlatformSet = false,
+  platform?: string | null,
+): z.SafeParseReturnType<string, string> => {
+  if (!value) {
+    if (requireIfPlatformSet && platform === 'ZOOM') {
+      return {
+        success: false,
+        error: { errors: [{ message: 'Zoom meeting URL or ID required' }] },
+      } as z.SafeParseReturnType<string, string>;
+    }
+    return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  }
   return zoomSchema.safeParse(value);
 };
 
 // Platform-aware validation for Jitsi room name
-export const validateJitsiRoomName = (value: string): z.SafeParseReturnType<string, string> => {
-  if (!value) return { success: true, data: '' } as z.SafeParseSuccess<string>;
+// Set requireIfPlatformSet=true to require room name when platform is JITSI
+export const validateJitsiRoomName = (
+  value: string,
+  requireIfPlatformSet = false,
+  platform?: string | null,
+): z.SafeParseReturnType<string, string> => {
+  if (!value) {
+    if (requireIfPlatformSet && platform === 'JITSI') {
+      return {
+        success: false,
+        error: { errors: [{ message: 'Jitsi room name required' }] },
+      } as z.SafeParseReturnType<string, string>;
+    }
+    return { success: true, data: '' } as z.SafeParseSuccess<string>;
+  }
   return jitsiSchema.safeParse(value);
 };


### PR DESCRIPTION
## Summary
- Extract streaming validation logic to shared `useSessionStreaming` hook
- Fix RTK Query cache invalidation for better UX when navigating

## Changes

### Streaming Validation Hook
- New `useSessionStreaming` hook handles all streaming-related state, validation, and auto-save
- Immediate validation for error display (clears errors as you type valid URLs)
- Platform-scoped effects prevent backend errors when switching platforms
- Improved error messages ("URL required" instead of "OTHER URL required")
- Reduces ~600 lines of duplicated code between SessionCard and SessionCardMobile
- Added name attributes to form fields for browser autofill

### RTK Query Cache Fix  
- `getSessions` now provides per-session tags + LIST tag
- `updateSession` invalidates specific session, surgically updating the cached list
- Fixes stale data issue when navigating away and back to session manager
- Speaker mutations now invalidate specific session instead of entire list

## Testing
- Tested platform switching (OTHER → ZOOM → VIMEO) without backend errors
- Tested validation error display clears immediately when typing valid URL
- Tested navigation away and back shows updated session data
- Tested create/delete still properly refreshes the list

## Breaking Changes
None