### PR TITLE
feat: filter streaming platforms based on org credentials (#365)

### DIFF
--- a/backend/atria/api/schemas/event.py
+++ b/backend/atria/api/schemas/event.py
@@ -44,8 +44,11 @@ class EventDetailSchema(EventSchema):
     sponsors_count = ma.Integer(dump_only=True)  # Number of active sponsors (detail only to avoid N+1)
 
     # Nested relationships - only include necessary fields
+    # Include credential flags so frontend can filter available streaming platforms
     organization = ma.Nested(
-        "OrganizationSchema", only=("id", "name"), dump_only=True
+        "OrganizationSchema",
+        only=("id", "name", "has_mux_credentials", "has_mux_signing_credentials", "has_jaas_credentials"),
+        dump_only=True,
     )
 
     sessions = ma.Nested(

--- a/backend/atria/api/schemas/organization.py
+++ b/backend/atria/api/schemas/organization.py
@@ -32,6 +32,12 @@ class OrganizationSchema(ma.SQLAlchemyAutoSchema):
         include_fk = True
         name = "OrganizationBase"
 
+    # Credential status flags (computed properties from model)
+    # Boolean indicators only - no sensitive data exposed
+    has_mux_credentials = ma.Boolean(dump_only=True)
+    has_mux_signing_credentials = ma.Boolean(dump_only=True)
+    has_jaas_credentials = ma.Boolean(dump_only=True)
+
     users = ma.Nested(
         "api.schemas.organization_user.OrganizationUserNestedSchema",  # Full path
         many=True,
@@ -51,16 +57,7 @@ class OrganizationDetailSchema(OrganizationSchema):
     user_is_admin_or_owner = ma.Boolean(dump_only=True)
     current_user_role = ma.Method("get_current_user_role", dump_only=True)
 
-    # Mux credential status (OPTIONAL - visible to all org members)
-    # Just boolean flags indicating if credentials are configured
-    # has_mux_credentials: API credentials (future analytics/management)
-    # has_mux_signing_credentials: Signing credentials (for SIGNED playback)
-    has_mux_credentials = ma.Boolean(dump_only=True)
-    has_mux_signing_credentials = ma.Boolean(dump_only=True)
-
-    # JaaS credential status (OPTIONAL - visible to all org members)
-    # Boolean flag indicating if JaaS credentials are configured
-    has_jaas_credentials = ma.Boolean(dump_only=True)
+    # Credential flags inherited from OrganizationSchema
 
     users = ma.Nested(
         "api.schemas.organization_user.OrganizationUserNestedSchema",

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCard/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   TextInput,
   Textarea,
@@ -25,6 +25,7 @@ import {
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
 import { useSessionStreaming } from '../hooks';
+import type { AvailablePlatforms } from '../SessionList';
 import type { Session, StreamingPlatform, SessionSpeaker } from '@/types';
 import type { SessionType, SessionChatMode, SessionStatus } from '@/types/enums';
 import styles from '../styles/index.module.css';
@@ -103,11 +104,12 @@ const SWITCH_STYLES_REGULAR = {
 type SessionCardProps = {
   session: Session;
   hasConflict: boolean;
+  availablePlatforms: AvailablePlatforms;
 };
 
 type FieldErrors = Partial<Record<SessionFieldName | 'time_order', string>>;
 
-export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
+export const SessionCard = ({ session, hasConflict, availablePlatforms }: SessionCardProps) => {
   const [updateSession] = useUpdateSessionMutation();
   const [deleteSession] = useDeleteSessionMutation();
 
@@ -174,6 +176,29 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
 
   // Use the streaming hook for all streaming-related state and validation
   const streaming = useSessionStreaming({ session, onUpdate: handleUpdate });
+
+  // Filter platform options based on organization credentials
+  const filteredLivePlatforms = useMemo(() => {
+    return LIVE_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      if (p.value === 'JITSI' && !availablePlatforms.hasJitsi) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
+
+  const filteredVodPlatforms = useMemo(() => {
+    return VOD_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
+
+  const filteredRecordingPlatforms = useMemo(() => {
+    return RECORDING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
 
   // Merge streaming errors with component errors for display
   const allErrors = { ...errors, ...streaming.streamingErrors };
@@ -424,7 +449,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
               data={[...STREAM_MODES]}
               size='sm'
               allowDeselect={false}
-              style={{ width: 140 }}
+              style={{ width: 165 }}
               classNames={{ input: cn(styles.formSelect) }}
             />
 
@@ -433,11 +458,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
               <Select
                 value={streaming.streamingPlatform}
                 onChange={streaming.handlePlatformChange}
-                data={
-                  streaming.streamMode === 'VOD' ?
-                    [...VOD_STREAMING_PLATFORMS]
-                  : [...LIVE_STREAMING_PLATFORMS]
-                }
+                data={streaming.streamMode === 'VOD' ? filteredVodPlatforms : filteredLivePlatforms}
                 placeholder='Platform'
                 size='sm'
                 allowDeselect={false}
@@ -446,6 +467,12 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
               />
             )}
           </Group>
+          {/* Hint when some platforms are unavailable */}
+          {(!availablePlatforms.hasMux || !availablePlatforms.hasJitsi) && (
+            <Text size='xs' c='dimmed' mt={4}>
+              More platforms available via Organization settings
+            </Text>
+          )}
 
           {/* Platform-specific fields for LIVE/VOD */}
           {streaming.streamMode !== 'NONE' && streaming.streamingPlatform && (
@@ -566,7 +593,7 @@ export const SessionCard = ({ session, hasConflict }: SessionCardProps) => {
                       <Select
                         value={streaming.vodPlatform}
                         onChange={streaming.handleVodPlatformChange}
-                        data={[...RECORDING_PLATFORMS]}
+                        data={filteredRecordingPlatforms}
                         size='sm'
                         allowDeselect={false}
                         style={{ width: 120 }}

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionCardMobile/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   TextInput,
   Textarea,
@@ -33,6 +33,7 @@ import {
   type SessionFieldName,
   type SessionTypeValue,
 } from '../schemas/sessionCardSchema';
+import type { AvailablePlatforms } from '../SessionList';
 import { useSessionStreaming } from '../hooks';
 import { formatTime } from '@/shared/utils/formatting';
 import type { Session, StreamingPlatform, SessionSpeaker } from '@/types';
@@ -113,11 +114,16 @@ const SWITCH_STYLES_REGULAR = {
 type SessionCardMobileProps = {
   session: Session;
   hasConflict: boolean;
+  availablePlatforms: AvailablePlatforms;
 };
 
 type FieldErrors = Partial<Record<SessionFieldName | 'time_order', string>>;
 
-export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobileProps) => {
+export const SessionCardMobile = ({
+  session,
+  hasConflict,
+  availablePlatforms,
+}: SessionCardMobileProps) => {
   const [updateSession] = useUpdateSessionMutation();
   const [deleteSession] = useDeleteSessionMutation();
   const [detailsExpanded, setDetailsExpanded] = useState(false);
@@ -185,6 +191,29 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
 
   // Use the streaming hook for all streaming-related state and validation
   const streaming = useSessionStreaming({ session, onUpdate: handleUpdate });
+
+  // Filter platform lists based on organization credentials
+  const filteredLivePlatforms = useMemo(() => {
+    return LIVE_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      if (p.value === 'JITSI' && !availablePlatforms.hasJitsi) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
+
+  const filteredVodPlatforms = useMemo(() => {
+    return VOD_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
+
+  const filteredRecordingPlatforms = useMemo(() => {
+    return RECORDING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !availablePlatforms.hasMux) return false;
+      return true;
+    });
+  }, [availablePlatforms]);
 
   // Merge streaming errors with component errors for display
   const allErrors = { ...errors, ...streaming.streamingErrors };
@@ -482,15 +511,20 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                   value={streaming.streamingPlatform}
                   onChange={streaming.handlePlatformChange}
                   data={
-                    streaming.streamMode === 'VOD' ?
-                      [...VOD_STREAMING_PLATFORMS]
-                    : [...LIVE_STREAMING_PLATFORMS]
+                    streaming.streamMode === 'VOD' ? filteredVodPlatforms : filteredLivePlatforms
                   }
                   size='sm'
                   mt='xs'
                   allowDeselect={false}
                   classNames={{ input: cn(styles.formSelect) }}
                 />
+              )}
+
+              {/* Hint when some platforms are unavailable */}
+              {(!availablePlatforms.hasMux || !availablePlatforms.hasJitsi) && (
+                <Text size='xs' c='dimmed' mt='xs'>
+                  More platforms available via Organization settings
+                </Text>
               )}
 
               {/* Platform-specific fields for LIVE/VOD */}
@@ -620,7 +654,7 @@ export const SessionCardMobile = ({ session, hasConflict }: SessionCardMobilePro
                           label='Recording Platform'
                           value={streaming.vodPlatform}
                           onChange={streaming.handleVodPlatformChange}
-                          data={[...RECORDING_PLATFORMS]}
+                          data={filteredRecordingPlatforms}
                           size='sm'
                           mt='xs'
                           allowDeselect={false}

--- a/frontend/src/pages/EventAdmin/SessionManager/SessionList/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/SessionList/index.tsx
@@ -5,15 +5,21 @@ import { SessionCardMobile } from '../SessionCardMobile';
 import type { Session } from '@/types';
 import styles from './styles/index.module.css';
 
+export type AvailablePlatforms = {
+  hasMux: boolean;
+  hasJitsi: boolean;
+};
+
 type SessionListProps = {
   sessions: Session[];
   currentDay: number;
   eventId: number;
+  availablePlatforms: AvailablePlatforms;
 };
 
 type SessionWithConflict = Session & { hasConflict: boolean };
 
-export const SessionList = ({ sessions, currentDay }: SessionListProps) => {
+export const SessionList = ({ sessions, currentDay, availablePlatforms }: SessionListProps) => {
   const isMobile = useMediaQuery('(max-width: 768px)');
 
   if (!sessions || sessions.length === 0) {
@@ -66,7 +72,12 @@ export const SessionList = ({ sessions, currentDay }: SessionListProps) => {
   return (
     <div className={styles.sessionsList}>
       {sessionsWithConflicts.map((session) => (
-        <CardComponent key={session.id} session={session} hasConflict={session.hasConflict} />
+        <CardComponent
+          key={session.id}
+          session={session}
+          hasConflict={session.hasConflict}
+          availablePlatforms={availablePlatforms}
+        />
       ))}
     </div>
   );

--- a/frontend/src/pages/EventAdmin/SessionManager/index.tsx
+++ b/frontend/src/pages/EventAdmin/SessionManager/index.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { LoadingOverlay } from '@/shared/components/loading';
 import { useParams } from 'react-router-dom';
 import { useGetEventQuery } from '@/app/features/events/api';
 import { useGetSessionsQuery } from '@/app/features/sessions/api';
 import { DateNavigation } from '@/pages/Agenda/DateNavigation';
 import { EditSessionModal } from '@/shared/components/modals/session/EditSessionModal';
-import { SessionList } from './SessionList';
+import { SessionList, type AvailablePlatforms } from './SessionList';
 import { SessionManagerHeader } from './SessionManagerHeader';
 import { SessionErrorState } from './SessionErrorState';
 import { SessionEmptyState } from './SessionEmptyState';
-import type { Session } from '@/types';
+import type { Session, EventDetail } from '@/types';
 import styles from './styles/index.module.css';
 
 type SessionStats = {
@@ -95,6 +95,15 @@ export const SessionManager = () => {
     { total: 0, overlapping: 0, speakers: 0 },
   );
 
+  // Compute available platforms based on org credentials
+  const availablePlatforms: AvailablePlatforms = useMemo(() => {
+    const eventDetail = event as EventDetail | undefined;
+    return {
+      hasMux: eventDetail?.organization?.has_mux_credentials ?? false,
+      hasJitsi: eventDetail?.organization?.has_jaas_credentials ?? false,
+    };
+  }, [event]);
+
   if (eventError) {
     return <SessionErrorState onRetry={refetchEvent} />;
   }
@@ -129,6 +138,7 @@ export const SessionManager = () => {
             sessions={sessions as Session[]}
             currentDay={currentDay}
             eventId={numericEventId}
+            availablePlatforms={availablePlatforms}
           />
         </section>
 

--- a/frontend/src/types/events.ts
+++ b/frontend/src/types/events.ts
@@ -121,6 +121,10 @@ export type EventDetail = Event & {
   organization: {
     id: number;
     name: string;
+    // Credential flags for filtering available streaming platforms
+    has_mux_credentials: boolean;
+    has_mux_signing_credentials: boolean;
+    has_jaas_credentials: boolean;
   };
   sessions: SessionSummary[];
   organizers: UserWithRole[];


### PR DESCRIPTION
## Summary
- Filter Mux and Jitsi streaming platform options based on whether the organization has configured credentials
- Widen the stream mode dropdown to properly display "Pre-recorded (VOD)"
- Show helper text when some platforms are unavailable, directing users to Organization settings

## Changes
- **Backend**: Added credential flags (`has_mux_credentials`, `has_mux_signing_credentials`, `has_jaas_credentials`) to base `OrganizationSchema` so they're available in nested EventDetail responses
- **Frontend**: Pass `availablePlatforms` through component hierarchy and filter platform dropdowns using `useMemo`
- **UX**: Added hint text "More platforms available via Organization settings" when Mux or Jitsi credentials are missing

## Test plan
- [ ] Verify platform dropdowns only show available platforms based on org credentials
- [ ] Verify "Pre-recorded (VOD)" displays fully in the dropdown
- [ ] Verify helper text appears when Mux or Jitsi credentials are missing
- [ ] Verify helper text does not appear when all credentials are configured