### PR TITLE
fix: add platform filtering to EditSessionModal + fix auto-save bug

### DIFF
--- a/frontend/src/pages/EventAdmin/SessionManager/hooks/useSessionStreaming.ts
+++ b/frontend/src/pages/EventAdmin/SessionManager/hooks/useSessionStreaming.ts
@@ -142,18 +142,37 @@ export const useSessionStreaming = ({
           if (!validation.success) {
             const zodError = validation.error as { errors: { message: string }[] };
             setFieldError('stream_url', zodError.errors[0]?.message ?? 'URL required');
+          } else if (streamUrl) {
+            // If URL is valid and non-empty, save platform + URL together
+            // This ensures platform change isn't lost when URL matches session value
+            onUpdate({
+              streaming_platform: value as StreamingPlatform,
+              stream_url: streamUrl,
+            });
           }
         } else if (value === 'ZOOM') {
           const validation = validateZoomMeetingId(zoomMeetingId, true, value);
           if (!validation.success) {
             const zodError = validation.error as { errors: { message: string }[] };
             setFieldError('zoom_meeting_id', zodError.errors[0]?.message ?? 'Meeting ID required');
+          } else if (zoomMeetingId) {
+            // Save platform + meeting ID together
+            onUpdate({
+              streaming_platform: value as StreamingPlatform,
+              zoom_meeting_id: zoomMeetingId,
+            });
           }
         } else if (value === 'JITSI') {
           const validation = validateJitsiRoomName(jitsiRoomName, true, value);
           if (!validation.success) {
             const zodError = validation.error as { errors: { message: string }[] };
             setFieldError('jitsi_room_name', zodError.errors[0]?.message ?? 'Room name required');
+          } else if (jitsiRoomName) {
+            // Save platform + room name together
+            onUpdate({
+              streaming_platform: value as StreamingPlatform,
+              jitsi_room_name: jitsiRoomName,
+            });
           }
         }
       }

--- a/frontend/src/shared/components/modals/session/EditSessionModal/index.tsx
+++ b/frontend/src/shared/components/modals/session/EditSessionModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { TextInput, Stack, Modal, Textarea, Select, Group, Text, Switch } from '@mantine/core';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { TimeSelect } from '@/shared/components/forms/TimeSelect';
@@ -43,6 +43,13 @@ interface EventData {
   id: number;
   start_date: string;
   end_date: string;
+  organization?: {
+    id: number;
+    name: string;
+    has_mux_credentials: boolean;
+    has_mux_signing_credentials: boolean;
+    has_jaas_credentials: boolean;
+  };
 }
 
 const SESSION_TYPES = [
@@ -188,6 +195,34 @@ export const EditSessionModal = ({
   const isLoading = isCreating || isUpdating;
 
   const availableDays = getEventDays(event);
+
+  // Filter platform lists based on organization credentials
+  const hasMux = event?.organization?.has_mux_credentials ?? false;
+  const hasJitsi = event?.organization?.has_jaas_credentials ?? false;
+
+  const filteredLivePlatforms = useMemo(() => {
+    return LIVE_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !hasMux) return false;
+      if (p.value === 'JITSI' && !hasJitsi) return false;
+      return true;
+    });
+  }, [hasMux, hasJitsi]);
+
+  const filteredVodPlatforms = useMemo(() => {
+    return VOD_STREAMING_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !hasMux) return false;
+      return true;
+    });
+  }, [hasMux]);
+
+  const filteredVodRecordingPlatforms = useMemo(() => {
+    return VOD_PLATFORMS.filter((p) => {
+      if (p.value === 'MUX' && !hasMux) return false;
+      return true;
+    });
+  }, [hasMux]);
+
+  const hasMissingPlatforms = !hasMux || !hasJitsi;
 
   const getInitialValues = (): SessionFormValues => {
     if (isEditing && session) {
@@ -415,6 +450,28 @@ export const EditSessionModal = ({
             />
           </Group>
 
+          <Text className={styles.sectionTitle || ''}>Chat Settings</Text>
+
+          <Select
+            label='Chat Mode'
+            placeholder='Choose chat availability'
+            data={[...CHAT_MODES]}
+            required
+            allowDeselect={false}
+            classNames={{ input: styles.formSelect || '' }}
+            {...form.getInputProps('chat_mode')}
+          />
+
+          <Select
+            label='Visibility Window'
+            placeholder='When attendees can access this session'
+            description='Controls when video and chat become available relative to session times'
+            data={[...VISIBILITY_WINDOW_OPTIONS]}
+            allowDeselect={false}
+            classNames={{ input: styles.formSelect || '' }}
+            {...form.getInputProps('visibility_minutes_override')}
+          />
+
           <Text className={styles.sectionTitle || ''}>Video & Streaming</Text>
 
           <Select
@@ -447,14 +504,19 @@ export const EditSessionModal = ({
               placeholder='Select streaming platform'
               description='Choose the platform for your video content'
               data={
-                form.values.stream_mode === 'VOD' ?
-                  [...VOD_STREAMING_PLATFORMS]
-                : [...LIVE_STREAMING_PLATFORMS]
+                form.values.stream_mode === 'VOD' ? filteredVodPlatforms : filteredLivePlatforms
               }
               allowDeselect={false}
               classNames={{ input: styles.formSelect || '' }}
               {...form.getInputProps('streaming_platform')}
             />
+          )}
+
+          {/* Hint when some platforms are unavailable */}
+          {hasMissingPlatforms && (
+            <Text size='xs' c='dimmed'>
+              More platforms available via Organization settings
+            </Text>
           )}
 
           {/* Conditional streaming fields based on selected platform */}
@@ -550,28 +612,6 @@ export const EditSessionModal = ({
             />
           )}
 
-          <Text className={styles.sectionTitle || ''}>Chat Settings</Text>
-
-          <Select
-            label='Chat Mode'
-            placeholder='Choose chat availability'
-            data={[...CHAT_MODES]}
-            required
-            allowDeselect={false}
-            classNames={{ input: styles.formSelect || '' }}
-            {...form.getInputProps('chat_mode')}
-          />
-
-          <Select
-            label='Visibility Window'
-            placeholder='When attendees can access this session'
-            description='Controls when video and chat become available relative to session times'
-            data={[...VISIBILITY_WINDOW_OPTIONS]}
-            allowDeselect={false}
-            classNames={{ input: styles.formSelect || '' }}
-            {...form.getInputProps('visibility_minutes_override')}
-          />
-
           {/* Recording section - only show for LIVE mode when show_recording is enabled */}
           {form.values.stream_mode === 'LIVE' &&
             form.values.show_recording &&
@@ -592,7 +632,7 @@ export const EditSessionModal = ({
                     label='Recording Platform'
                     placeholder='Select platform for the recording'
                     description='Leave as auto-detect to use the same platform as the live stream'
-                    data={[...VOD_PLATFORMS]}
+                    data={filteredVodRecordingPlatforms}
                     allowDeselect={false}
                     classNames={{ input: styles.formSelect || '' }}
                     {...form.getInputProps('vod_platform')}


### PR DESCRIPTION
## Summary
Follow-up to #367 - adds platform filtering to the EditSessionModal and fixes an auto-save bug.

## Changes

### Platform Filtering in Modal
- Filter Mux and Jitsi platform options based on organization credentials
- Add helper text "More platforms available via Organization settings" when credentials are missing

### Section Reordering
- Reorder modal sections so **Chat Settings** appears before **Video & Streaming**
- New order: Basic Info → Session Details → Chat Settings → Video & Streaming → Recording

### Auto-Save Bug Fix
- **Bug**: When switching platforms with an existing URL that matched the DB value, the platform change wasn't saved
- **Cause**: Debounced save was checking if URL changed, but skipping when URL matched session value - even though platform changed
- **Fix**: When platform changes with a valid URL, immediately save both values together

## Test plan
- [x] Open EditSessionModal and verify platform filtering works
- [x] Verify helper text shows when Mux/Jitsi credentials are missing
- [x] Verify Chat Settings section now appears before Video & Streaming
- [x] Test platform switching with existing URL - verify it saves correctly