### PR TITLE
chore: prepare for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to Atria will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-01-05
+
+### Added
+
+- **Session Visibility Window** - Configure when sessions become accessible to attendees (always visible, or X minutes before/after session time)
+- **Stream Mode UI** - New video state management with NONE/LIVE/VOD modes, show/hide video toggle, and post-session recording option
+- **Platform Credential Filtering** - Streaming platform options (Mux, Jitsi) now filtered based on organization credentials configuration
+- Helper text in session forms when additional platforms are available via Organization settings
+
+### Changed
+
+- Session modal sections reordered: Chat Settings now appears before Video & Streaming for better UX
+- Streaming validation refactored into shared `useSessionStreaming` hook for consistency between SessionCard and modal
+- RTK Query cache invalidation optimized for session updates
+- Stream mode dropdown widened to properly display "Pre-recorded (VOD)" option
+
+### Fixed
+
+- Platform change with existing URL now saves correctly (was being skipped when URL matched session value)
+- Date picker accessibility improved with proper labels
+- Streaming field validation consolidated and improved
+
+[0.5.0]: https://github.com/thesubtleties/atria/releases/tag/v0.5.0
+
 ## [0.4.1] - 2025-12-27
 
 ### Fixed

--- a/backend/atria/api/services/dashboard.py
+++ b/backend/atria/api/services/dashboard.py
@@ -353,8 +353,17 @@ class DashboardService:
                 'description': 'Complete frontend TypeScript migration with full type safety and standardized enum handling. Read the full announcement at docs.atria.gg/blog/v0.4.0-release',
                 'date': datetime(2025, 12, 24, tzinfo=timezone.utc),
                 'type': 'platform_update',
-                'is_new': True,
+                'is_new': False,
                 'link': 'https://docs.atria.gg/blog/v0.4.0-release'
+            },
+            {
+                'id': 9,
+                'title': 'v0.5.0 - Stream Mode & Visibility Windows',
+                'description': 'New stream mode UI with LIVE/VOD/NONE options, session visibility windows, and platform credential filtering. Read the full announcement at docs.atria.gg/blog/v0.5.0-release',
+                'date': datetime(2026, 1, 5, tzinfo=timezone.utc),
+                'type': 'feature_release',
+                'is_new': True,
+                'link': 'https://docs.atria.gg/blog/v0.5.0-release'
             }
         ]
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Release Preparation for v0.5.0

This PR prepares for the v0.5.0 release by updating version numbers and documentation.

### Changes
- Updated `CHANGELOG.md` with v0.5.0 changes
- Updated `frontend/package.json` version to 0.5.0
- Added dashboard news announcement for v0.5.0

### v0.5.0 Highlights
- **Session Visibility Window** - Configure when sessions become accessible to attendees
- **Stream Mode UI** - New video state management with NONE/LIVE/VOD modes
- **Platform Credential Filtering** - Platform options filtered based on org credentials
- Auto-save bug fix for platform changes
- Modal section reordering for better UX

### Next Steps (after merge)
1. Create PR from dev → main
2. After merge, tag as v0.5.0
3. Create GitHub release